### PR TITLE
Reduce usage of 'as' statements

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/attribute-propagating-span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/attribute-propagating-span-processor.ts
@@ -52,13 +52,14 @@ export class AttributePropagatingSpanProcessor implements SpanProcessor {
     AwsSpanProcessingUtil.setIsLocalRootInformation(span, parentContext);
 
     const parentSpan: APISpan | undefined = trace.getSpan(parentContext);
-    let parentReadableSpan: ReadableSpan | undefined = undefined;
+    let parentReadableSpan: Span | undefined = undefined;
 
-    // `if check` is different than Python and Java. Here we just check if parentSpan is not undefined
-    // Whereas in Python and Java, the check is if parentSpan is and instance of ReadableSpan, which is
-    // not possible in TypeScript because the check is not allowed for interfaces (such as ReadableSpan).
-    if (parentSpan !== undefined) {
-      parentReadableSpan = parentSpan as Span;
+    // In Python and Java, the check is "parentSpan is an instance of ReadableSpan" is not possible
+    // in TypeScript because the check is not allowed for TypeScript interfaces (such as ReadableSpan).
+    // This is because JavaScript doesn't support interfaces, which is what TypeScript will compile to.
+    // `Span` is the only class that implements ReadableSpan, so check for instance of Span.
+    if (parentSpan instanceof Span) {
+      parentReadableSpan = parentSpan;
 
       // Add the AWS_SDK_DESCENDANT attribute to the immediate child spans of AWS SDK span.
       // This attribute helps the backend differentiate between SDK spans and their immediate

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -454,7 +454,7 @@ export class AwsSpanProcessorProvider {
   }
 
   protected _getSpanExporter(name: string): SpanExporter | undefined {
-    return (this.constructor as typeof AwsSpanProcessorProvider)._registeredExporters.get(name)?.();
+    return AwsSpanProcessorProvider._registeredExporters.get(name)?.();
   }
 
   private configureSpanProcessors(exporters: SpanExporter[]): (BatchSpanProcessor | SimpleSpanProcessor)[] {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-metrics-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-metrics-processor.ts
@@ -83,14 +83,14 @@ export class AwsSpanMetricsProcessor implements SpanProcessor {
     let httpStatusCode: AttributeValue | undefined = spanData.attributes[SEMATTRS_HTTP_STATUS_CODE];
     const statusCode: SpanStatusCode = spanData.status.code;
 
-    if (httpStatusCode === undefined) {
+    if (typeof httpStatusCode !== 'number') {
       httpStatusCode = attributes[SEMATTRS_HTTP_STATUS_CODE];
     }
 
     if (
-      httpStatusCode === undefined ||
-      (httpStatusCode as number) < this.ERROR_CODE_LOWER_BOUND ||
-      (httpStatusCode as number) > this.FAULT_CODE_UPPER_BOUND
+      typeof httpStatusCode !== 'number' ||
+      httpStatusCode < this.ERROR_CODE_LOWER_BOUND ||
+      httpStatusCode > this.FAULT_CODE_UPPER_BOUND
     ) {
       if (SpanStatusCode.ERROR === statusCode) {
         this.errorHistogram.record(0, attributes);
@@ -99,16 +99,10 @@ export class AwsSpanMetricsProcessor implements SpanProcessor {
         this.errorHistogram.record(0, attributes);
         this.faultHistogram.record(0, attributes);
       }
-    } else if (
-      (httpStatusCode as number) >= this.ERROR_CODE_LOWER_BOUND &&
-      (httpStatusCode as number) <= this.ERROR_CODE_UPPER_BOUND
-    ) {
+    } else if (httpStatusCode >= this.ERROR_CODE_LOWER_BOUND && httpStatusCode <= this.ERROR_CODE_UPPER_BOUND) {
       this.errorHistogram.record(1, attributes);
       this.faultHistogram.record(0, attributes);
-    } else if (
-      (httpStatusCode as number) >= this.FAULT_CODE_LOWER_BOUND &&
-      (httpStatusCode as number) <= this.FAULT_CODE_UPPER_BOUND
-    ) {
+    } else if (httpStatusCode >= this.FAULT_CODE_LOWER_BOUND && httpStatusCode <= this.FAULT_CODE_UPPER_BOUND) {
       this.errorHistogram.record(0, attributes);
       this.faultHistogram.record(1, attributes);
     }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
@@ -154,12 +154,12 @@ export class AwsSpanProcessingUtil {
     // is started before the other processors (e.g. AwsSpanMetricsProcessor)
     // Thus this function is implemented differently than in Java/Python
     const isLocalRoot: AttributeValue | undefined = spanData.attributes[AWS_ATTRIBUTE_KEYS.AWS_IS_LOCAL_ROOT];
-    if (isLocalRoot === undefined) {
-      // isLocalRoot should be precalculated, this code block should not be entered
+    if (typeof isLocalRoot !== 'boolean') {
+      // isLocalRoot should be a precalculated boolean, this code block should not be entered
       diag.debug('isLocalRoot for span has not been precalculated. Assuming span is Local Root Span.');
       return true;
     }
-    return isLocalRoot as boolean;
+    return isLocalRoot;
   }
 
   // To identify the SQS consumer spans produced by AWS SDK instrumentation
@@ -223,8 +223,8 @@ export class AwsSpanProcessingUtil {
       const httpUrl: AttributeValue | undefined = span.attributes[SEMATTRS_HTTP_URL];
       try {
         let url: URL;
-        if (httpUrl !== undefined) {
-          url = new URL(httpUrl as string);
+        if (typeof httpUrl === 'string') {
+          url = new URL(httpUrl);
           httpPath = url.pathname;
         }
       } catch (e: unknown) {
@@ -235,8 +235,8 @@ export class AwsSpanProcessingUtil {
       }
     }
 
-    if (httpPath !== undefined) {
-      operation = this.extractAPIPathValue(httpPath as string);
+    if (typeof httpPath === 'string') {
+      operation = this.extractAPIPathValue(httpPath);
       if (this.isKeyPresent(span, SEMATTRS_HTTP_METHOD)) {
         const httpMethod: AttributeValue | undefined = span.attributes[SEMATTRS_HTTP_METHOD];
         if (httpMethod !== undefined) {


### PR DESCRIPTION
*Issue #, if available:*

We use the `as` (e.g. `variableName as varableType`) to tell the TypeScript compiler to trust us that we know a certain variable is a certain type. Example:
```
span.attributes[AWS_ATTRIBUTE_KEYS.AWS_KINESIS_STREAM_NAME]
```
We know that this will be a string, but technically any span attribute value can be of type `string | number | boolean | Array<null | undefined | string> | Array<null | undefined | number> | Array<null | undefined | boolean>`

So instead of assuming this is a specific variable type via `as` and ensure it isn't undefined, we should check for the actual type in the above list.

*Description of changes:*
- Reduce `as` statements
  - Resolve TypeScript compiler blockers as a result of reducing usage of `as` statements
- Use correct `parentSpan instanceof Span` check in `attribute-propagating-span-processor.ts`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

