### PR TITLE
Add daily security scan

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -1,0 +1,111 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+# Performs a daily scan of:
+# * The latest released ADOT Javascript image, using Trivy
+# * Project dependencies, using DependencyCheck
+#
+#  Publishes results to CloudWatch Metrics.
+name: Daily scan
+
+on:
+  schedule:
+    - cron: '0 18 * * *' # scheduled to run at 18:00 UTC every day
+  workflow_dispatch: # be able to run the workflow on demand
+
+env:
+  AWS_DEFAULT_REGION: us-east-1
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  scan_and_report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo for dependency scan
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Configure AWS credentials for dependency scan
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Get NVD API key for dependency scan
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        id: nvd_api_key
+        with:
+          secret-ids: ${{ secrets.NVD_API_KEY_SECRET_ARN }}
+          parse-json-secrets: true
+
+      - name: Install dependencies
+        working-directory: aws-distro-opentelemetry-node-autoinstrumentation
+        run: npm install
+
+      # See http://jeremylong.github.io/DependencyCheck/dependency-check-cli/ for installation explanation
+      - name: Install and run dependency scan
+        id: dep_scan
+        if: always()
+        run: |
+          gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 259A55407DD6C00299E6607EFFDE55BE73A2D1ED
+          VERSION=$(curl -s https://jeremylong.github.io/DependencyCheck/current.txt)
+          curl -Ls "https://github.com/jeremylong/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip" --output dependency-check.zip
+          curl -Ls "https://github.com/jeremylong/DependencyCheck/releases/download/v$VERSION/dependency-check-$VERSION-release.zip.asc" --output dependency-check.zip.asc
+          gpg --verify dependency-check.zip.asc
+          unzip dependency-check.zip
+          ./dependency-check/bin/dependency-check.sh  --nvdApiKey ${{ env.NVD_API_KEY_NVD_API_KEY }} -s "aws-distro-opentelemetry-node-autoinstrumentation/"
+
+      - name: Print dependency scan results on failure
+        if: ${{ steps.dep_scan.outcome != 'success' }}
+        run: less dependency-check-report.html
+
+      # TODO: Update image to public once available
+      - name: Perform high image scan
+        if: always()
+        id: high_scan
+        uses: ./.github/actions/image_scan
+        with:
+          image-ref: "637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability/adot-autoinstrumentation-node-staging:latest"
+          severity: 'CRITICAL,HIGH'
+
+      # TODO: Update image to public once available
+      - name: Perform low image scan
+        if: always()
+        id: low_scan
+        uses: ./.github/actions/image_scan
+        with:
+          image-ref: "637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability/adot-autoinstrumentation-node-staging:latest"
+          severity: 'MEDIUM,LOW,UNKNOWN'
+
+      - name: Configure AWS Credentials for emitting metrics
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.MONITORING_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Publish high scan status
+        if: always()
+        run: |
+          value="${{ steps.high_scan.outcome == 'success' && '1.0' || '0.0' }}"
+          aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
+            --metric-name Success \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=daily_scan_high \
+            --value $value
+
+      - name: Publish low scan status
+        if: always()
+        run: |
+          value="${{ steps.low_scan.outcome == 'success' && steps.dep_scan.outcome == 'success' && '1.0' || '0.0'}}"
+          aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
+            --metric-name Success \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=daily_scan_low \
+            --value $value


### PR DESCRIPTION
*Description of changes:*
- Added security scan for dependencies and for ECRs

*Testing:*
- Using `on: push: branches: ...` which was removed for the PR: https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/10480417873
- Verified outgoing metrics with:
  - branch: security-scans
  - repo: aws-observability/aws-otel-js-instrumentation
  - workflow: daily_scan_low and daily_scan_high


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

