### PR TITLE
Fix sampler match not using full regex match, endpoint `=` parsing, and updated test cases

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/.eslintignore
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/.eslintignore
@@ -1,3 +1,4 @@
 build
 node_modules
 .eslintrc.js
+version.ts

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -264,10 +264,11 @@ export function customBuildSamplerFromEnv(resource: Resource): Sampler {
       if (samplerArgumentEnv !== undefined) {
         const args: string[] = samplerArgumentEnv.split(',');
         for (const arg of args) {
-          const keyValue: string[] = arg.split('=', 2);
-          if (keyValue.length !== 2) {
+          const equalIndex: number = arg.indexOf('=');
+          if (equalIndex === -1) {
             continue;
           }
+          const keyValue: string[] = [arg.substring(0, equalIndex), arg.substring(equalIndex + 1)];
           if (keyValue[0] === 'endpoint') {
             endpoint = keyValue[1];
           } else if (keyValue[0] === 'polling_interval') {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/sampler/utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/sampler/utils.ts
@@ -33,7 +33,7 @@ export function wildcardMatch(pattern?: string, text?: AttributeValue): boolean 
   if (pattern === undefined || typeof text !== 'string') return false;
   if (pattern.length === 0) return text.length === 0;
 
-  const match: RegExpMatchArray | null = text.toLowerCase().match(convertPatternToRegExp(pattern.toLowerCase()));
+  const match: RegExpMatchArray | null = text.toLowerCase().match(`^${convertPatternToRegExp(pattern.toLowerCase())}$`);
 
   if (match === null) {
     diag.debug(`WildcardMatch: no match found for ${text} against pattern ${pattern}`);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -173,7 +173,7 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     delete process.env.OTEL_TRACES_SAMPLER_ARG;
 
     process.env.OTEL_TRACES_SAMPLER = 'xray';
-    process.env.OTEL_TRACES_SAMPLER_ARG = 'endpoint=ht-tp:/-/-a-a-:2-2-2,polling_interval=600';
+    process.env.OTEL_TRACES_SAMPLER_ARG = 'endpoint=http://lo=cal=host=:2000,polling_interval=600';
 
     const tmp = (AwsXraySamplingClient.prototype as any).makeSamplingRequest;
     (AwsXraySamplingClient.prototype as any).makeSamplingRequest = (
@@ -183,16 +183,30 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
       callback({});
     };
 
-    const sampler = customBuildSamplerFromEnv(Resource.empty());
+    let sampler = customBuildSamplerFromEnv(Resource.empty());
 
     expect(sampler).toBeInstanceOf(AwsXRayRemoteSampler);
-    expect((sampler as AwsXRayRemoteSampler).getAwsProxyEndpoint()).toEqual('ht-tp:/-/-a-a-:2-2-2');
+    expect((sampler as AwsXRayRemoteSampler).getAwsProxyEndpoint()).toEqual('http://lo=cal=host=:2000');
     expect((sampler as AwsXRayRemoteSampler).getRulePollingIntervalMillis()).toEqual(600000);
     expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).getSamplingRulesEndpoint).toEqual(
-      'ht-tp:/-/-a-a-:2-2-2/GetSamplingRules'
+      'http://lo=cal=host=:2000/GetSamplingRules'
     );
     expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).samplingTargetsEndpoint).toEqual(
-      'ht-tp:/-/-a-a-:2-2-2/SamplingTargets'
+      'http://lo=cal=host=:2000/SamplingTargets'
+    );
+
+    process.env.OTEL_TRACES_SAMPLER_ARG = 'abc,polling_interval=550,123';
+
+    sampler = customBuildSamplerFromEnv(Resource.empty());
+
+    expect(sampler).toBeInstanceOf(AwsXRayRemoteSampler);
+    expect((sampler as AwsXRayRemoteSampler).getAwsProxyEndpoint()).toEqual('http://localhost:2000');
+    expect((sampler as AwsXRayRemoteSampler).getRulePollingIntervalMillis()).toEqual(550000);
+    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).getSamplingRulesEndpoint).toEqual(
+      'http://localhost:2000/GetSamplingRules'
+    );
+    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).samplingTargetsEndpoint).toEqual(
+      'http://localhost:2000/SamplingTargets'
     );
 
     (AwsXraySamplingClient.prototype as any).makeSamplingRequest = tmp;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/sampling-rule-applier.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/sampling-rule-applier.test.ts
@@ -32,7 +32,7 @@ describe('SamplingRuleApplier', () => {
     });
 
     const attr: Attributes = {
-      [SEMATTRS_HTTP_TARGET]: 'target',
+      [SEMATTRS_HTTP_TARGET]: '/target',
       [SEMATTRS_HTTP_METHOD]: 'method',
       [SEMATTRS_HTTP_URL]: 'url',
       [SEMATTRS_HTTP_HOST]: 'host',
@@ -66,7 +66,7 @@ describe('SamplingRuleApplier', () => {
       [SEMATTRS_HTTP_HOST]: 'localhost',
       [SEMATTRS_HTTP_METHOD]: 'GET',
       [SEMATTRS_AWS_LAMBDA_INVOKED_ARN]: 'arn:aws:lambda:us-west-2:123456789012:function:my-function',
-      [SEMATTRS_HTTP_TARGET]: 'http://127.0.0.1:5000/helloworld',
+      [SEMATTRS_HTTP_URL]: 'http://127.0.0.1:5000/helloworld',
       ['abc']: '123',
       ['def']: '456',
       ['ghi']: '789',
@@ -79,6 +79,9 @@ describe('SamplingRuleApplier', () => {
 
     const ruleApplier = new SamplingRuleApplier(rule);
 
+    expect(ruleApplier.matches(attributes, resource)).toEqual(true);
+    delete attributes[SEMATTRS_HTTP_URL];
+    attributes[SEMATTRS_HTTP_TARGET] = '/helloworld';
     expect(ruleApplier.matches(attributes, resource)).toEqual(true);
   });
   it('testApplierWildCardAttributesMatchesSpanAttributes', () => {
@@ -146,7 +149,7 @@ describe('SamplingRuleApplier', () => {
     const attributes: Attributes = {
       [SEMATTRS_HTTP_HOST]: 'localhost',
       [SEMATTRS_HTTP_METHOD]: 'GET',
-      [SEMATTRS_HTTP_TARGET]: 'http://127.0.0.1:5000/helloworld',
+      [SEMATTRS_HTTP_URL]: 'http://127.0.0.1:5000/helloworld',
     };
 
     expect(ruleApplier.matches(attributes, Resource.EMPTY)).toEqual(true);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/utils.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/utils.test.ts
@@ -23,7 +23,7 @@ const positiveTests: any = [
   ['a*a', 'aba'],
   ['a*a*', 'aaaaaaaaaaaaaaaaaaaaaaa'],
   ['a*b*a*b*a*b*a*b*a*', 'akljd9gsdfbkjhaabajkhbbyiaahkjbjhbuykjakjhabkjhbabjhkaabbabbaaakljdfsjklababkjbsdabab'],
-  ['a*na*ha', 'anananahahanahana'],
+  ['a*na*ha', 'anananahahanahanaha'],
   ['***a', 'a'],
   ['**a**', 'a'],
   ['a**b', 'ab'],
@@ -35,15 +35,27 @@ const positiveTests: any = [
   ['?at', 'cat'],
   ['?o?se', 'horse'],
   ['?o?se', 'mouse'],
-  ['*s', 'horse'],
+  ['*s', 'horses'],
   ['J*', 'Jeep'],
   ['J*', 'jeep'],
   ['*/foo', '/bar/foo'],
   ['ja*script', 'javascript'],
+  ['*', undefined],
+  ['*', ''],
+  ['*', 'HelloWorld'],
+  ['HelloWorld', 'HelloWorld'],
+  ['Hello*', 'HelloWorld'],
+  ['*World', 'HelloWorld'],
+  ['?ello*', 'HelloWorld'],
+  ['Hell?W*d', 'HelloWorld'],
+  ['*.World', 'Hello.World'],
+  ['*.World', 'Bye.World'],
 ];
 
 const negativeTests: any = [
   ['', 'whatever'],
+  ['/', 'target'],
+  ['/', '/target'],
   ['foo', 'bar'],
   ['f?o', 'boo'],
   ['f??', 'boo'],
@@ -53,6 +65,8 @@ const negativeTests: any = [
   ['??', 'a'],
   ['??', 'a'],
   ['*?*a', 'a'],
+  ['a*na*ha', 'anananahahanahana'],
+  ['*s', 'horse'],
 ];
 
 describe('SamplingUtils', () => {


### PR DESCRIPTION
*Issue #, if available:*
Saw scenario where `['/', 'target']` pair is a match, but shouldn't be. This is because full regex match isn't being used.
Saw scenario where everything after the second `=` was missing in the sampler endpoint parsing logic.

*Description of changes:*
- Use full regex match in matching logic
- Enhance split `=` logic
- Added more related test cases

Tested:
- Unit tests
- EKS sample app test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

