### PR TITLE
Metric Bug Fix: Strip out Query and Fragment in extractAPIPathValue Logic

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
@@ -176,6 +176,10 @@ describe('AwsSpanProcessingUtilTest', () => {
     let pathValue: string = AwsSpanProcessingUtil.extractAPIPathValue(validTarget);
     expect(pathValue).toEqual('/users');
 
+    validTarget = '/users#fragment?fragment_part_2';
+    pathValue = AwsSpanProcessingUtil.extractAPIPathValue(validTarget);
+    expect(pathValue).toEqual('/users');
+
     validTarget = '/users?query';
     pathValue = AwsSpanProcessingUtil.extractAPIPathValue(validTarget);
     expect(pathValue).toEqual('/users');


### PR DESCRIPTION
*Issue #, if available:*
- `httpTarget` can be of the form `/pathname?q=query#fragment`.
- extractAPIPathValue(httpTarget) will include the query or the fragment parts, which we do not want.
- This isn't caught with the existing unit test (`/users/1/pet?query#fragment`) because the query+fragment is removed after the extractAPIPathValue Logic splits the slashes.

*Description of changes:*
- In this PR, we remove the query and fragment.

Testing:
- Unit tests
- Observed removal of query and fragment from Console Span Exporter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

