### PR TITLE
Add BatchUnsampledSpanProcessor for exporting unsampled spans

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-attribute-keys.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-attribute-keys.ts
@@ -21,6 +21,9 @@ export const AWS_ATTRIBUTE_KEYS: { [key: string]: string } = {
   // Used for JavaScript workaround - attribute for pre-calculated value of isLocalRoot
   AWS_IS_LOCAL_ROOT: 'aws.is.local.root',
 
+  // Trace Span Unsampled flag
+  AWS_TRACE_FLAG_UNSAMPLED: 'aws.trace.flag.unsampled',
+
   // AWS_#_NAME attributes are not supported in JavaScript as they are not part of the Semantic Conventions.
   // TODO：Move to Semantic Conventions when these attributes are added.
   AWS_S3_BUCKET: 'aws.s3.bucket',

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-batch-unsampled-span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-batch-unsampled-span-processor.ts
@@ -1,0 +1,252 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Modifications Copyright The OpenTelemetry Authors. Licensed under the Apache License 2.0 License.
+
+import { context, Context, diag, TraceFlags } from '@opentelemetry/api';
+import {
+  BindOnceFuture,
+  ExportResultCode,
+  getEnv,
+  globalErrorHandler,
+  suppressTracing,
+  unrefTimer,
+} from '@opentelemetry/core';
+import { ReadableSpan, BufferConfig, Span, SpanProcessor, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
+
+/**
+ * This class is a customized version of the `BatchSpanProcessorBase` from the
+ * OpenTelemetry SDK (`@opentelemetry/sdk-trace-base/build/src/export/BatchSpanProcessorBase`).
+ * It inherits much of the behavior of the `BatchSpanProcessorBase` while adding
+ * specific logic to handle unsampled spans.
+ *
+ * It can't directly be inherited `BatchSpanProcessorBase` as child class because
+ * a few stateful fields are private in `BatchSpanProcessorBase` which need to be accessed
+ * in `AwsBatchUnsampledSpanProcessor` and we don't plan to update upstream code for it.
+ *
+ * In particular, the following methods are modified:
+ *
+ * 1. `onStart`: This method is modified to detect unsampled spans and add an
+ *    AWS-specific attribute (`AWS_TRACE_FLAG_UNSAMPLED`) to denote that the span
+ *    is unsampled. This is done by checking the `traceFlags` of the span.
+ *
+ * 2. `onEnd`: The logic here is changed to handle unsampled spans. While the
+ *    default behavior of `BatchSpanProcessorBase` is to ignore unsampled spans,
+ *    this version adds them to the buffer for export. The unsampled spans are
+ *    queued and processed similarly to sampled spans.
+ *
+ * This processor ensures that even unsampled spans are exported, which is a
+ * deviation from the typical span processing behavior in OpenTelemetry.
+ *
+ * The rest of the behavior—batch processing, queuing, and exporting spans in
+ * batches—is inherited from the base class and remains largely the same.
+ */
+export class AwsBatchUnsampledSpanProcessor implements SpanProcessor {
+  private readonly _maxExportBatchSize: number;
+  private readonly _maxQueueSize: number;
+  private readonly _scheduledDelayMillis: number;
+  private readonly _exportTimeoutMillis: number;
+
+  private _isExporting = false;
+  private _finishedSpans: ReadableSpan[] = [];
+  private _timer: NodeJS.Timeout | undefined;
+  private _shutdownOnce: BindOnceFuture<void>;
+  private _droppedSpansCount: number = 0;
+
+  constructor(private readonly _exporter: SpanExporter, config?: BufferConfig) {
+    const env = getEnv();
+    this._maxExportBatchSize =
+      typeof config?.maxExportBatchSize === 'number' ? config.maxExportBatchSize : env.OTEL_BSP_MAX_EXPORT_BATCH_SIZE;
+    this._maxQueueSize = typeof config?.maxQueueSize === 'number' ? config.maxQueueSize : env.OTEL_BSP_MAX_QUEUE_SIZE;
+    this._scheduledDelayMillis =
+      typeof config?.scheduledDelayMillis === 'number' ? config.scheduledDelayMillis : env.OTEL_BSP_SCHEDULE_DELAY;
+    this._exportTimeoutMillis =
+      typeof config?.exportTimeoutMillis === 'number' ? config.exportTimeoutMillis : env.OTEL_BSP_EXPORT_TIMEOUT;
+
+    this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
+
+    if (this._maxExportBatchSize > this._maxQueueSize) {
+      diag.warn(
+        'BatchSpanProcessor: maxExportBatchSize must be smaller or equal to maxQueueSize, setting maxExportBatchSize to match maxQueueSize'
+      );
+      this._maxExportBatchSize = this._maxQueueSize;
+    }
+  }
+
+  forceFlush(): Promise<void> {
+    if (this._shutdownOnce.isCalled) {
+      return this._shutdownOnce.promise;
+    }
+    return this._flushAll();
+  }
+
+  onStart(span: Span, _parentContext: Context): void {
+    if ((span.spanContext().traceFlags & TraceFlags.SAMPLED) === 0) {
+      span.setAttribute(AWS_ATTRIBUTE_KEYS.AWS_TRACE_FLAG_UNSAMPLED, true);
+      return;
+    }
+  }
+
+  onEnd(span: ReadableSpan): void {
+    if (this._shutdownOnce.isCalled) {
+      return;
+    }
+
+    if ((span.spanContext().traceFlags & TraceFlags.SAMPLED) === 1) {
+      return;
+    }
+
+    this._addToBuffer(span);
+  }
+
+  shutdown(): Promise<void> {
+    return this._shutdownOnce.call();
+  }
+
+  private _shutdown() {
+    return Promise.resolve()
+      .then(() => {
+        return this.onShutdown();
+      })
+      .then(() => {
+        return this._flushAll();
+      })
+      .then(() => {
+        return this._exporter.shutdown();
+      });
+  }
+
+  /** Add a span in the buffer. */
+  private _addToBuffer(span: ReadableSpan) {
+    if (this._finishedSpans.length >= this._maxQueueSize) {
+      // limit reached, drop span
+
+      if (this._droppedSpansCount === 0) {
+        diag.debug('maxQueueSize reached, dropping spans');
+      }
+      this._droppedSpansCount++;
+
+      return;
+    }
+
+    if (this._droppedSpansCount > 0) {
+      // some spans were dropped, log once with count of spans dropped
+      diag.warn(`Dropped ${this._droppedSpansCount} spans because maxQueueSize reached`);
+      this._droppedSpansCount = 0;
+    }
+
+    this._finishedSpans.push(span);
+    this._maybeStartTimer();
+  }
+
+  /**
+   * Send all spans to the exporter respecting the batch size limit
+   * This function is used only on forceFlush or shutdown,
+   * for all other cases _flush should be used
+   * */
+  private _flushAll(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const promises = [];
+      // calculate number of batches
+      const count = Math.ceil(this._finishedSpans.length / this._maxExportBatchSize);
+      for (let i = 0, j = count; i < j; i++) {
+        promises.push(this._flushOneBatch());
+      }
+      Promise.all(promises)
+        .then(() => {
+          resolve();
+        })
+        .catch(reject);
+    });
+  }
+
+  private _flushOneBatch(): Promise<void> {
+    this._clearTimer();
+    if (this._finishedSpans.length === 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        // don't wait anymore for export, this way the next batch can start
+        reject(new Error('Timeout'));
+      }, this._exportTimeoutMillis);
+      // prevent downstream exporter calls from generating spans
+      context.with(suppressTracing(context.active()), () => {
+        // Reset the finished spans buffer here because the next invocations of the _flush method
+        // could pass the same finished spans to the exporter if the buffer is cleared
+        // outside the execution of this callback.
+        let spans: ReadableSpan[];
+        if (this._finishedSpans.length <= this._maxExportBatchSize) {
+          spans = this._finishedSpans;
+          this._finishedSpans = [];
+        } else {
+          spans = this._finishedSpans.splice(0, this._maxExportBatchSize);
+        }
+
+        const doExport = () =>
+          this._exporter.export(spans, result => {
+            clearTimeout(timer);
+            if (result.code === ExportResultCode.SUCCESS) {
+              resolve();
+            } else {
+              reject(result.error ?? new Error('BatchSpanProcessor: span export failed'));
+            }
+          });
+
+        let pendingResources: Array<Promise<void>> | null = null;
+        for (let i = 0, len = spans.length; i < len; i++) {
+          const span = spans[i];
+          if (span.resource.asyncAttributesPending && span.resource.waitForAsyncAttributes) {
+            pendingResources ??= [];
+            pendingResources.push(span.resource.waitForAsyncAttributes());
+          }
+        }
+
+        // Avoid scheduling a promise to make the behavior more predictable and easier to test
+        if (pendingResources === null) {
+          doExport();
+        } else {
+          Promise.all(pendingResources).then(doExport, err => {
+            globalErrorHandler(err);
+            reject(err);
+          });
+        }
+      });
+    });
+  }
+
+  private _maybeStartTimer() {
+    if (this._isExporting) return;
+    const flush = () => {
+      this._isExporting = true;
+      this._flushOneBatch()
+        .finally(() => {
+          this._isExporting = false;
+          if (this._finishedSpans.length > 0) {
+            this._clearTimer();
+            this._maybeStartTimer();
+          }
+        })
+        .catch(e => {
+          this._isExporting = false;
+          globalErrorHandler(e);
+        });
+    };
+    // we only wait if the queue doesn't have enough elements yet
+    if (this._finishedSpans.length >= this._maxExportBatchSize) {
+      return flush();
+    }
+    if (this._timer !== undefined) return;
+    this._timer = setTimeout(() => flush(), this._scheduledDelayMillis);
+    unrefTimer(this._timer);
+  }
+
+  private _clearTimer() {
+    if (this._timer !== undefined) {
+      clearTimeout(this._timer);
+      this._timer = undefined;
+    }
+  }
+
+  onShutdown(): void {}
+}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/otlp-udp-exporter.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/otlp-udp-exporter.ts
@@ -9,7 +9,7 @@ import { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
 
 const DEFAULT_ENDPOINT = '127.0.0.1:2000';
 const PROTOCOL_HEADER = '{"format":"json","version":1}\n';
-const FORMAT_OTEL_TRACES_BINARY_PREFIX = 'T1';
+const DEFAULT_FORMAT_OTEL_TRACES_BINARY_PREFIX = 'T1S';
 
 export class UdpExporter {
   private _endpoint: string;
@@ -62,7 +62,7 @@ export class OTLPUdpSpanExporter implements SpanExporter {
   constructor(endpoint?: string, _signalPrefix?: string) {
     this._endpoint = endpoint || DEFAULT_ENDPOINT;
     this._udpExporter = new UdpExporter(this._endpoint);
-    this._signalPrefix = _signalPrefix || FORMAT_OTEL_TRACES_BINARY_PREFIX;
+    this._signalPrefix = _signalPrefix || DEFAULT_FORMAT_OTEL_TRACES_BINARY_PREFIX;
   }
 
   export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-batch-unsampled-span-processor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-batch-unsampled-span-processor.test.ts
@@ -1,0 +1,481 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Modifications Copyright The OpenTelemetry Authors. Licensed under the Apache License 2.0 License.
+
+import { diag, ROOT_CONTEXT } from '@opentelemetry/api';
+import { ExportResult, ExportResultCode, loggingErrorHandler, setGlobalErrorHandler } from '@opentelemetry/core';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import {
+  AlwaysOffSampler,
+  AlwaysOnSampler,
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  ReadableSpan,
+  Span,
+  SpanExporter,
+} from '@opentelemetry/sdk-trace-base';
+import { Resource, ResourceAttributes } from '@opentelemetry/resources';
+import { AwsBatchUnsampledSpanProcessor } from '../src/aws-batch-unsampled-span-processor';
+import { AlwaysRecordSampler } from '../src/always-record-sampler';
+
+/**
+ * This test file is a modified version of `BatchSpanProcessorBase.test.ts`.
+ * It is designed to test the custom behavior of the `AwsBatchUnsampledSpanProcessor`,
+ * specifically focusing on the modifications made to handle unsampled spans.
+ */
+
+function createSampledSpan(spanName: string): Span {
+  const tracer = new BasicTracerProvider({
+    sampler: new AlwaysOnSampler(),
+  }).getTracer('default');
+  const span = tracer.startSpan(spanName);
+  return span as Span;
+}
+
+function createUnsampledSpan(spanName: string): Span {
+  const tracer = new BasicTracerProvider({
+    sampler: AlwaysRecordSampler.create(new AlwaysOffSampler()),
+  }).getTracer('default');
+  const span = tracer.startSpan(spanName);
+  return span as Span;
+}
+
+describe('AwsBatchUnsampledSpanProcessor', () => {
+  const name = 'span-name';
+  const defaultBufferConfig = {
+    maxExportBatchSize: 5,
+    scheduledDelayMillis: 2500,
+  };
+  let exporter: InMemorySpanExporter;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+  });
+
+  afterEach(() => {
+    exporter.reset();
+    sinon.restore();
+  });
+
+  describe('constructor', () => {
+    it('should read defaults from environment', () => {
+      const bspConfig = {
+        OTEL_BSP_MAX_EXPORT_BATCH_SIZE: 256,
+        OTEL_BSP_SCHEDULE_DELAY: 2500,
+      };
+
+      let env: Record<string, any>;
+      if (global.process?.versions?.node === undefined) {
+        env = globalThis as unknown as Record<string, any>;
+      } else {
+        env = process.env as Record<string, any>;
+      }
+
+      Object.entries(bspConfig).forEach(([k, v]) => {
+        env[k] = v;
+      });
+
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter);
+      assert.strictEqual(processor['_maxExportBatchSize'], 256);
+      assert.strictEqual(processor['_scheduledDelayMillis'], 2500);
+      processor.shutdown();
+
+      Object.keys(bspConfig).forEach(k => delete env[k]);
+    });
+  });
+
+  describe('.onStart/.onEnd/.shutdown', () => {
+    it('should call onShutdown', async () => {
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+      const onShutdownSpy = sinon.stub(processor, 'onShutdown');
+      assert.strictEqual(onShutdownSpy.callCount, 0);
+      await processor.shutdown();
+      assert.strictEqual(onShutdownSpy.callCount, 1);
+    });
+
+    it('should do nothing after processor is shutdown', async () => {
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+      const spy: sinon.SinonSpy = sinon.spy(exporter, 'export') as any;
+
+      const span = createUnsampledSpan(`${name}_0`);
+
+      processor.onStart(span, ROOT_CONTEXT);
+      processor.onEnd(span);
+      assert.strictEqual(processor['_finishedSpans'].length, 1);
+
+      await processor.forceFlush();
+      assert.strictEqual(exporter.getFinishedSpans().length, 1);
+
+      processor.onStart(span, ROOT_CONTEXT);
+      processor.onEnd(span);
+      assert.strictEqual(processor['_finishedSpans'].length, 1);
+
+      assert.strictEqual(spy.args.length, 1);
+      await processor.shutdown();
+      assert.strictEqual(spy.args.length, 2);
+      assert.strictEqual(exporter.getFinishedSpans().length, 0);
+
+      processor.onStart(span, ROOT_CONTEXT);
+      processor.onEnd(span);
+      assert.strictEqual(spy.args.length, 2);
+      assert.strictEqual(processor['_finishedSpans'].length, 0);
+      assert.strictEqual(exporter.getFinishedSpans().length, 0);
+    });
+
+    it('should export unsampled spans', async () => {
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+      const spy: sinon.SinonSpy = sinon.spy(exporter, 'export') as any;
+
+      const span = createUnsampledSpan(`${name}_0`);
+
+      processor.onStart(span, ROOT_CONTEXT);
+      processor.onEnd(span);
+
+      await processor.forceFlush();
+      // _finishedSpans should be empty after forceFlush
+      assert.strictEqual(processor['_finishedSpans'].length, 0);
+      assert.strictEqual(exporter.getFinishedSpans().length, 1);
+      assert.strictEqual(spy.args.length, 1);
+    });
+
+    it('should not export sampled spans', async () => {
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+      const spy: sinon.SinonSpy = sinon.spy(exporter, 'export') as any;
+
+      const span = createSampledSpan(`${name}_0`);
+
+      processor.onStart(span, ROOT_CONTEXT);
+      processor.onEnd(span);
+
+      await processor.forceFlush();
+      // _finishedSpans should be empty after forceFlush
+      assert.strictEqual(processor['_finishedSpans'].length, 0);
+      assert.strictEqual(exporter.getFinishedSpans().length, 0);
+      assert.strictEqual(spy.args.length, 0);
+    });
+
+    it('should export the sampled spans with buffer size reached', async () => {
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+      const span = createUnsampledSpan(name);
+      for (let i = 1; i < defaultBufferConfig.maxExportBatchSize; i++) {
+        processor.onStart(span, ROOT_CONTEXT);
+        assert.strictEqual(exporter.getFinishedSpans().length, 0);
+
+        processor.onEnd(span);
+        assert.strictEqual(exporter.getFinishedSpans().length, 0);
+      }
+      processor.onStart(span, ROOT_CONTEXT);
+      processor.onEnd(span);
+      assert.strictEqual(exporter.getFinishedSpans().length, 5);
+      await processor.shutdown();
+      assert.strictEqual(exporter.getFinishedSpans().length, 0);
+    });
+
+    it('should force flush when timeout exceeded', done => {
+      const clock = sinon.useFakeTimers();
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+      const span = createUnsampledSpan(name);
+      for (let i = 1; i < defaultBufferConfig.maxExportBatchSize; i++) {
+        processor.onStart(span, ROOT_CONTEXT);
+        processor.onEnd(span);
+        assert.strictEqual(exporter.getFinishedSpans().length, 0);
+      }
+
+      setTimeout(() => {
+        assert.strictEqual(exporter.getFinishedSpans().length, 4);
+        done();
+      }, defaultBufferConfig.scheduledDelayMillis + 1000);
+
+      clock.tick(defaultBufferConfig.scheduledDelayMillis + 1000);
+
+      clock.restore();
+    });
+
+    it('should force flush on demand', () => {
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+      const span = createUnsampledSpan(name);
+      for (let i = 1; i < defaultBufferConfig.maxExportBatchSize; i++) {
+        processor.onStart(span, ROOT_CONTEXT);
+        processor.onEnd(span);
+      }
+      assert.strictEqual(exporter.getFinishedSpans().length, 0);
+      processor.forceFlush();
+      assert.strictEqual(exporter.getFinishedSpans().length, 4);
+    });
+
+    it('should not export empty span lists', done => {
+      const spy = sinon.spy(exporter, 'export');
+      const clock = sinon.useFakeTimers();
+
+      const tracer = new BasicTracerProvider({
+        sampler: new AlwaysOnSampler(),
+      }).getTracer('default');
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+
+      // start but do not end spans
+      for (let i = 0; i < defaultBufferConfig.maxExportBatchSize; i++) {
+        const span = tracer.startSpan('spanName');
+        processor.onStart(span as Span, ROOT_CONTEXT);
+      }
+
+      setTimeout(() => {
+        assert.strictEqual(exporter.getFinishedSpans().length, 0);
+        // after the timeout, export should not have been called
+        // because no spans are ended
+        sinon.assert.notCalled(spy);
+        done();
+      }, defaultBufferConfig.scheduledDelayMillis + 1000);
+
+      // no spans have been finished
+      assert.strictEqual(exporter.getFinishedSpans().length, 0);
+      clock.tick(defaultBufferConfig.scheduledDelayMillis + 1000);
+
+      clock.restore();
+    });
+
+    it('should export each unsampled span exactly once with buffer size' + ' reached multiple times', done => {
+      const originalTimeout = setTimeout;
+      const clock = sinon.useFakeTimers();
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+      const totalSpans = defaultBufferConfig.maxExportBatchSize * 2;
+      for (let i = 0; i < totalSpans; i++) {
+        const span = createUnsampledSpan(`${name}_${i}`);
+        processor.onStart(span, ROOT_CONTEXT);
+        processor.onEnd(span);
+      }
+      const span = createSampledSpan(`${name}_last`);
+      processor.onStart(span, ROOT_CONTEXT);
+      processor.onEnd(span);
+      clock.tick(defaultBufferConfig.scheduledDelayMillis + 10);
+
+      // because there is an async promise that will be trigger original
+      // timeout is needed to simulate a real tick to the next
+      originalTimeout(() => {
+        clock.tick(defaultBufferConfig.scheduledDelayMillis + 10);
+        originalTimeout(async () => {
+          clock.tick(defaultBufferConfig.scheduledDelayMillis + 10);
+          clock.restore();
+
+          diag.info('finished spans count', exporter.getFinishedSpans().length);
+          assert.strictEqual(exporter.getFinishedSpans().length, totalSpans);
+
+          await processor.shutdown();
+          assert.strictEqual(exporter.getFinishedSpans().length, 0);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('force flush', () => {
+    describe('no waiting spans', () => {
+      it('should call an async callback when flushing is complete', done => {
+        const processor = new AwsBatchUnsampledSpanProcessor(exporter);
+        processor.forceFlush().then(() => {
+          done();
+        });
+      });
+
+      it('should call an async callback when shutdown is complete', done => {
+        const processor = new AwsBatchUnsampledSpanProcessor(exporter);
+        processor.shutdown().then(() => {
+          done();
+        });
+      });
+    });
+
+    describe('spans waiting to flush', () => {
+      let processor: AwsBatchUnsampledSpanProcessor;
+
+      beforeEach(() => {
+        processor = new AwsBatchUnsampledSpanProcessor(exporter, defaultBufferConfig);
+      });
+
+      it('should call an async callback when flushing is complete', done => {
+        const span = createUnsampledSpan('test');
+        processor.onStart(span, ROOT_CONTEXT);
+        processor.onEnd(span);
+        processor.forceFlush().then(() => {
+          assert.strictEqual(exporter.getFinishedSpans().length, 1);
+          done();
+        });
+      });
+
+      it('should call an async callback when shutdown is complete', done => {
+        let exportedSpans = 0;
+        sinon.stub(exporter, 'export').callsFake((spans, callback) => {
+          setTimeout(() => {
+            exportedSpans = exportedSpans + spans.length;
+            callback({ code: ExportResultCode.SUCCESS });
+          }, 0);
+        });
+        const span = createUnsampledSpan('test');
+        processor.onStart(span, ROOT_CONTEXT);
+        processor.onEnd(span);
+
+        processor.shutdown().then(() => {
+          assert.strictEqual(exportedSpans, 1);
+          done();
+        });
+      });
+
+      it('should call globalErrorHandler when exporting fails', done => {
+        const clock = sinon.useFakeTimers();
+        const expectedError = new Error('Exporter failed');
+        sinon.stub(exporter, 'export').callsFake((_, callback) => {
+          setTimeout(() => {
+            callback({ code: ExportResultCode.FAILED, error: expectedError });
+          }, 0);
+        });
+
+        const errorHandlerSpy = sinon.spy();
+
+        setGlobalErrorHandler(errorHandlerSpy);
+
+        for (let i = 0; i < defaultBufferConfig.maxExportBatchSize; i++) {
+          const span = createUnsampledSpan('test');
+          processor.onStart(span, ROOT_CONTEXT);
+          processor.onEnd(span);
+        }
+
+        clock.tick(defaultBufferConfig.scheduledDelayMillis + 1000);
+        clock.restore();
+        setTimeout(async () => {
+          assert.strictEqual(errorHandlerSpy.callCount, 1);
+
+          const [[error]] = errorHandlerSpy.args;
+
+          assert.deepStrictEqual(error, expectedError);
+
+          //reset global error handler
+          setGlobalErrorHandler(loggingErrorHandler());
+          done();
+        });
+      });
+
+      it('should wait for pending resource on flush', async () => {
+        const tracer = new BasicTracerProvider({
+          sampler: AlwaysRecordSampler.create(new AlwaysOffSampler()),
+          resource: new Resource(
+            {},
+            new Promise<ResourceAttributes>(resolve => {
+              setTimeout(() => resolve({ async: 'fromasync' }), 1);
+            })
+          ),
+        }).getTracer('default');
+
+        const span = tracer.startSpan('test') as Span;
+        span.end();
+
+        processor.onStart(span, ROOT_CONTEXT);
+        processor.onEnd(span);
+
+        await processor.forceFlush();
+
+        assert.strictEqual(exporter.getFinishedSpans().length, 1);
+      });
+    });
+  });
+  describe('maxQueueSize', () => {
+    let processor: AwsBatchUnsampledSpanProcessor;
+
+    describe('when there are more spans then "maxQueueSize"', () => {
+      beforeEach(() => {
+        processor = new AwsBatchUnsampledSpanProcessor(
+          exporter,
+          Object.assign({}, defaultBufferConfig, {
+            maxQueueSize: 6,
+          })
+        );
+      });
+      it('should drop spans', () => {
+        const span = createUnsampledSpan('test');
+        for (let i = 0, j = 20; i < j; i++) {
+          processor.onStart(span, ROOT_CONTEXT);
+          processor.onEnd(span);
+        }
+        assert.equal(processor['_finishedSpans'].length, 6);
+      });
+      it('should count and report dropped spans', done => {
+        const debugStub = sinon.spy(diag, 'debug');
+        const warnStub = sinon.spy(diag, 'warn');
+        // const span = createUnsampledSpan('test');
+        for (let i = 0, j = 12; i < j; i++) {
+          const span = createUnsampledSpan('test' + i);
+          processor.onStart(span, ROOT_CONTEXT);
+          processor.onEnd(span);
+        }
+        assert.equal(processor['_finishedSpans'].length, 6);
+        assert.equal(processor['_droppedSpansCount'], 1);
+        sinon.assert.calledOnce(debugStub);
+
+        processor.forceFlush().then(() => {
+          const span = createUnsampledSpan('test');
+          processor.onStart(span, ROOT_CONTEXT);
+          processor.onEnd(span);
+
+          assert.equal(processor['_finishedSpans'].length, 1);
+          assert.equal(processor['_droppedSpansCount'], 0);
+
+          sinon.assert.calledOnce(warnStub);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('maxExportBatchSize', () => {
+    let processor: AwsBatchUnsampledSpanProcessor;
+
+    describe('when "maxExportBatchSize" is greater than "maxQueueSize"', () => {
+      beforeEach(() => {
+        processor = new AwsBatchUnsampledSpanProcessor(exporter, {
+          maxExportBatchSize: 7,
+          maxQueueSize: 6,
+        });
+      });
+      it('should match maxQueueSize', () => {
+        assert.equal(processor['_maxExportBatchSize'], processor['_maxQueueSize']);
+      });
+    });
+  });
+
+  describe('Concurrency', () => {
+    it('should only send a single batch at a time', async () => {
+      const callbacks: ((result: ExportResult) => void)[] = [];
+      const spans: ReadableSpan[] = [];
+      const exporter: SpanExporter = {
+        export: async (exportedSpans: ReadableSpan[], resultCallback: (result: ExportResult) => void) => {
+          callbacks.push(resultCallback);
+          spans.push(...exportedSpans);
+        },
+        shutdown: async () => {},
+      };
+      const processor = new AwsBatchUnsampledSpanProcessor(exporter, {
+        maxExportBatchSize: 5,
+        maxQueueSize: 6,
+      });
+      const totalSpans = 50;
+      for (let i = 0; i < totalSpans; i++) {
+        const span = createUnsampledSpan(`${name}_${i}`);
+        processor.onStart(span, ROOT_CONTEXT);
+        processor.onEnd(span);
+      }
+      assert.equal(callbacks.length, 1);
+      assert.equal(spans.length, 5);
+      callbacks[0]({ code: ExportResultCode.SUCCESS });
+      await new Promise(resolve => setTimeout(resolve, 0));
+      // After the first batch completes we will have dropped a number
+      // of spans and the next batch will be smaller
+      assert.equal(callbacks.length, 2);
+      assert.equal(spans.length, 10);
+      callbacks[1]({ code: ExportResultCode.SUCCESS });
+
+      // We expect that all the other spans have been dropped
+      await new Promise(resolve => setTimeout(resolve, 0));
+      assert.equal(callbacks.length, 2);
+      assert.equal(spans.length, 10);
+    });
+  });
+});

--- a/lambda-layer/build.sh
+++ b/lambda-layer/build.sh
@@ -10,6 +10,8 @@ cd "${SOURCEDIR}/.."
 
 # Install dependencies and compile all projects in the repository
 echo "Installing dependencies and compiling projects..."
+rm -rf ./aws-distro-opentelemetry-node-autoinstrumentation/build
+rm -rf ./aws-distro-opentelemetry-node-autoinstrumentation/node_modules
 npm install
 npm run compile
 


### PR DESCRIPTION
*Description of changes:*
1. Implemented a new `AwsBatchUnsampledSpanProcessor` to only export unsampled spans(`TraceFlags.SAMPLED !==1`)
2. Registered it as an additional SpanProcessor for `TraceProvider`
3. Add different Prefixes for sampled/unsampled OTel span when sending to FluxPump
    * Sampled Spans Prefix  - `T1S`
    * Unsampled Spans Prefix - `T1U` 


*Test*
X-Ray data example
```
{
    "Id": "1-66e11092-767bc32c5717c925604e37e3",
    "Duration": 0.158,
    "LimitExceeded": false,
    "Segments": [
        {
            "Id": "5a5e9957e3a068ef",
            "Document": {
                "id": "5a5e9957e3a068ef",
                "name": "aws-opentelemetry-distro-nodejs",
                "start_time": 1726025874.375,
                "trace_id": "1-66e11092-767bc32c5717c925604e37e3",
                "end_time": 1726025874.527,
                "parent_id": "5ff5cfd8f1c6ed59",
                "http": {
                    "response": {
                        "status": 200
                    }
                },
                "aws": {
                    "request_id": "e4ac3af9-7538-4b8c-84c8-36d154378813"
                },
                "origin": "AWS::Lambda",
                "resource_arn": "arn:aws:lambda:us-west-2:252610625673:function:aws-opentelemetry-distro-nodejs"
            }
        },
        {
            "Id": "30e074d0013a9b6f",
            "Document": {
                "id": "30e074d0013a9b6f",
                "name": "aws-opentelemetry-distro-nodejs/default",
                "start_time": 1726025874.369,
                "trace_id": "1-66e11092-767bc32c5717c925604e37e3",
                "end_time": 1726025874.527,
                "http": {
                    "request": {
                        "url": "https://aixsrfz8n8.execute-api.us-west-2.amazonaws.com/default",
                        "method": "GET",
                        "user_agent": "curl/8.7.1",
                        "client_ip": "205.251.233.233",
                        "x_forwarded_for": true
                    },
                    "response": {
                        "status": 200,
                        "content_length": 0
                    }
                },
                "aws": {
                    "xray": {
                        "sampling_rule_name": "Default"
                    },
                    "api_gateway": {
                        "account_id": "252610625673",
                        "rest_api_id": "aixsrfz8n8",
                        "stage": "default",
                        "request_id": "41da0ef6-b16c-45e9-9334-a11347f5dec7"
                    }
                },
                "annotations": {
                    "aws:api_id": "aixsrfz8n8",
                    "aws:api_stage": "default"
                },
                "metadata": {
                    "default": {
                        "extended_request_id": "d6-G6FsovHcEMoQ=",
                        "request_id": "41da0ef6-b16c-45e9-9334-a11347f5dec7"
                    }
                },
                "origin": "AWS::ApiGateway::Stage",
                "resource_arn": "arn:aws:apigateway:us-west-2::/restapis/aixsrfz8n8/stages/default",
                "subsegments": [
                    {
                        "id": "5ff5cfd8f1c6ed59",
                        "name": "Lambda",
                        "start_time": 1726025874.371,
                        "end_time": 1726025874.527,
                        "http": {
                            "request": {
                                "url": "https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/arn:aws:lambda:us-west-2:252610625673:function:aws-opentelemetry-distro-nodejs/invocations",
                                "method": "ANY"
                            },
                            "response": {
                                "status": 200,
                                "content_length": 120
                            }
                        },
                        "aws": {
                            "function_name": "aws-opentelemetry-distro-nodejs",
                            "region": "us-west-2",
                            "operation": "Invoke",
                            "resource_names": [
                                "aws-opentelemetry-distro-nodejs"
                            ]
                        },
                        "namespace": "aws"
                    }
                ]
            }
        },
        {
            "Id": "7197ce026d312a49",
            "Document": {
                "id": "7197ce026d312a49",
                "name": "aws-opentelemetry-distro-nodejs",
                "start_time": 1726025874.3797677,
                "trace_id": "1-66e11092-767bc32c5717c925604e37e3",
                "end_time": 1726025874.5265381,
                "parent_id": "5a5e9957e3a068ef",
                "aws": {
                    "account_id": "252610625673",
                    "function_arn": "arn:aws:lambda:us-west-2:252610625673:function:aws-opentelemetry-distro-nodejs",
                    "cloudwatch_logs": [
                        {
                            "log_group": "/aws/lambda/aws-opentelemetry-distro-nodejs"
                        }
                    ],
                    "resource_names": [
                        "aws-opentelemetry-distro-nodejs"
                    ]
                },
                "origin": "AWS::Lambda::Function",
                "subsegments": [
                    {
                        "id": "ca73bcb9d61476de",
                        "name": "Invocation",
                        "start_time": 1726025874.3798523,
                        "end_time": 1726025874.5261395,
                        "aws": {
                            "function_arn": "arn:aws:lambda:us-west-2:252610625673:function:aws-opentelemetry-distro-nodejs"
                        }
                    },
                    {
                        "id": "4153b4f45ff3b1e8",
                        "name": "Overhead",
                        "start_time": 1726025874.5261652,
                        "end_time": 1726025874.5264673,
                        "aws": {
                            "function_arn": "arn:aws:lambda:us-west-2:252610625673:function:aws-opentelemetry-distro-nodejs"
                        }
                    }
                ]
            }
        },
        {
            "Id": "ae60d7baedc1cfb5",
            "Document": {
                "id": "ae60d7baedc1cfb5",
                "name": "aws-opentelemetry-distro-nodejs",
                "start_time": 1726025874.38,
                "trace_id": "1-66e11092-767bc32c5717c925604e37e3",
                "end_time": 1726025874.5246706,
                "parent_id": "ca73bcb9d61476de",
                "aws": {
                    "trace.flag.unsampled": true,
                    "is.local.root": true
                },
                "annotations": {
                    "span.kind": "SERVER"
                },
                "metadata": {
                    "faas.id": "arn:aws:lambda:us-west-2:252610625673:function:aws-opentelemetry-distro-nodejs",
                    "cloud.account.id": "252610625673",
                    "faas.execution": "e4ac3af9-7538-4b8c-84c8-36d154378813"
                },
                "subsegments": [
                    {
                        "id": "328592d80ebf7e72",
                        "name": "GET",
                        "start_time": 1726025874.483,
                        "end_time": 1726025874.5237389,
                        "aws": {
                            "trace.flag.unsampled": true,
                            "local.operation": "aws-opentelemetry-distro-nodejs",
                            "is.local.root": false
                        },
                        "annotations": {
                            "span.kind": "CLIENT"
                        },
                        "metadata": {
                            "net.transport": "ip_tcp",
                            "net.peer.name": "jsonplaceholder.typicode.com",
                            "http.status_code": 200,
                            "net.peer.port": 443,
                            "http.target": "/todos/1",
                            "http.flavor": "1.1",
                            "http.url": "https://jsonplaceholder.typicode.com/todos/1",
                            "http.status_text": "OK",
                            "net.peer.ip": "104.21.59.19",
                            "http.method": "GET",
                            "http.host": "jsonplaceholder.typicode.com:443"
                        },
                        "namespace": "remote"
                    },
                    {
                        "id": "6d998c5cf661c0ec",
                        "name": "S3.ListBuckets",
                        "start_time": 1726025874.381,
                        "end_time": 1726025874.4829986,
                        "aws": {
                            "signature.version": "s3",
                            "service.name": "Amazon S3",
                            "trace.flag.unsampled": true,
                            "local.operation": "aws-opentelemetry-distro-nodejs",
                            "service.api": "S3",
                            "region": "us-west-2",
                            "is.local.root": false,
                            "service.identifier": "s3",
                            "operation": "listBuckets",
                            "request.id": "XWEGH4NV5PMQZEHV"
                        },
                        "annotations": {
                            "span.kind": "CLIENT"
                        },
                        "metadata": {
                            "http.status_code": 200,
                            "rpc.service": "S3",
                            "rpc.method": "ListBuckets",
                            "rpc.system": "aws-api"
                        },
                        "namespace": "aws",
                        "subsegments": [
                            {
                                "id": "5b8e13800550b551",
                                "name": "GET",
                                "start_time": 1726025874.381,
                                "end_time": 1726025874.4812143,
                                "aws": {
                                    "trace.flag.unsampled": true,
                                    "local.operation": "aws-opentelemetry-distro-nodejs",
                                    "is.local.root": false,
                                    "sdk.descendant": "true"
                                },
                                "annotations": {
                                    "span.kind": "CLIENT"
                                },
                                "metadata": {
                                    "net.transport": "ip_tcp",
                                    "net.peer.name": "s3.us-west-2.amazonaws.com",
                                    "http.status_code": 200,
                                    "net.peer.port": 443,
                                    "http.target": "/",
                                    "http.flavor": "1.1",
                                    "http.url": "https://s3.us-west-2.amazonaws.com/",
                                    "http.status_text": "OK",
                                    "net.peer.ip": "52.218.178.96",
                                    "http.method": "GET",
                                    "http.host": "s3.us-west-2.amazonaws.com:443"
                                },
                                "namespace": "remote"
                            }
                        ]
                    }
                ]
            }
        },
        {
            "Id": "1c146cef33e14019",
            "Document": {
                "id": "1c146cef33e14019",
                "name": "GET",
                "start_time": 1726025874.381,
                "trace_id": "1-66e11092-767bc32c5717c925604e37e3",
                "end_time": 1726025874.4812143,
                "parent_id": "5b8e13800550b551",
                "inferred": true
            }
        },
        {
            "Id": "2bccb63c011d05ec",
            "Document": {
                "id": "2bccb63c011d05ec",
                "name": "GET",
                "start_time": 1726025874.483,
                "trace_id": "1-66e11092-767bc32c5717c925604e37e3",
                "end_time": 1726025874.5237389,
                "parent_id": "328592d80ebf7e72",
                "inferred": true
            }
        }
    ]
}
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

