### PR TITLE
update release build

### DIFF
--- a/.github/actions/set_up/action.yml
+++ b/.github/actions/set_up/action.yml
@@ -23,6 +23,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node_version }}
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies and compile to build directory
       shell: bash

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -64,27 +64,27 @@ jobs:
           registry: public.ecr.aws
 
 
-      # # Publish to public ECR
-      # - name: Build and push public ECR image
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     push: true
-      #     context: .
-      #     file: ./Dockerfile
-      #     platforms: linux/amd64,linux/arm64
-      #     tags: |
-      #       ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
+      # Publish to public ECR
+      - name: Build and push public ECR image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
 
-      # # Publish to private ECR
-      # - name: Build and push private ECR image
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     push: true
-      #     context: .
-      #     file: ./Dockerfile
-      #     platforms: linux/amd64,linux/arm64
-      #     tags: |
-      #       ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
+      # Publish to private ECR
+      - name: Build and push private ECR image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
 
       # Publish to GitHub releases
       - name: Create GH release


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Re-enable the publishing to public/private ECR repos
* Add `registry-url` for node setup. Otherwise, you will get error in `npx lerna publish` like this: `lerna ERR! E404 Not found`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

