### PR TITLE
Refactor unit tests for xray sampler

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/sampler/aws-xray-remote-sampler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/sampler/aws-xray-remote-sampler.ts
@@ -66,36 +66,8 @@ export class AwsXRayRemoteSampler implements Sampler {
     this.startSamplingTargetsPoller();
   }
 
-  public getRulePoller(): NodeJS.Timer | undefined {
-    return this.rulePoller;
-  }
-
-  public getRulePollingIntervalMillis(): number {
-    return this.rulePollingIntervalMillis;
-  }
-
-  public getTargetPollingInterval(): number {
-    return this.targetPollingInterval;
-  }
-
   public getDefaultTargetPollingInterval(): number {
     return DEFAULT_TARGET_POLLING_INTERVAL_SECONDS;
-  }
-
-  public getSamplingClient(): AwsXraySamplingClient {
-    return this.samplingClient;
-  }
-
-  public getRuleCache(): RuleCache {
-    return this.ruleCache;
-  }
-
-  public getClientId(): string {
-    return this.clientId;
-  }
-
-  public getAwsProxyEndpoint(): string {
-    return this.awsProxyEndpoint;
   }
 
   public shouldSample(

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/sampler/rule-cache.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/sampler/rule-cache.ts
@@ -28,14 +28,6 @@ export class RuleCache {
     this.lastUpdatedEpochMillis = Date.now();
   }
 
-  public getRuleAppliers(): SamplingRuleApplier[] {
-    return this.ruleAppliers;
-  }
-
-  public getSamplerResource(): Resource {
-    return this.samplerResource;
-  }
-
   public isExpired(): boolean {
     const nowInMillis: number = Date.now();
     return nowInMillis > this.lastUpdatedEpochMillis + RULE_CACHE_TTL_MILLIS;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -27,11 +27,11 @@ import {
   customBuildSamplerFromEnv,
 } from '../src/aws-opentelemetry-configurator';
 import { AwsSpanMetricsProcessor } from '../src/aws-span-metrics-processor';
+import { OTLPUdpSpanExporter } from '../src/otlp-udp-exporter';
 import { setAwsDefaultEnvironmentVariables } from '../src/register';
 import { AwsXRayRemoteSampler } from '../src/sampler/aws-xray-remote-sampler';
 import { AwsXraySamplingClient } from '../src/sampler/aws-xray-sampling-client';
 import { GetSamplingRulesResponse } from '../src/sampler/remote-sampler.types';
-import { OTLPUdpSpanExporter } from '../src/otlp-udp-exporter';
 
 // Tests AwsOpenTelemetryConfigurator after running Environment Variable setup in register.ts
 describe('AwsOpenTelemetryConfiguratorTest', () => {
@@ -117,8 +117,8 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     const sampler = customBuildSamplerFromEnv(Resource.empty());
 
     expect(sampler).toBeInstanceOf(AwsXRayRemoteSampler);
-    expect((sampler as AwsXRayRemoteSampler).getAwsProxyEndpoint()).toEqual('http://localhost:2000');
-    expect((sampler as AwsXRayRemoteSampler).getRulePollingIntervalMillis()).toEqual(300000); // ms
+    expect((sampler as any).awsProxyEndpoint).toEqual('http://localhost:2000');
+    expect((sampler as any).rulePollingIntervalMillis).toEqual(300000); // ms
 
     clearInterval((sampler as any).rulePoller);
     clearInterval((sampler as any).targetPoller);
@@ -132,12 +132,12 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     const sampler = customBuildSamplerFromEnv(Resource.empty());
 
     expect(sampler).toBeInstanceOf(AwsXRayRemoteSampler);
-    expect((sampler as AwsXRayRemoteSampler).getAwsProxyEndpoint()).toEqual('http://asdfghjkl:2000');
-    expect((sampler as AwsXRayRemoteSampler).getRulePollingIntervalMillis()).toEqual(600000); // ms
-    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).getSamplingRulesEndpoint).toEqual(
+    expect((sampler as any).awsProxyEndpoint).toEqual('http://asdfghjkl:2000');
+    expect((sampler as any).rulePollingIntervalMillis).toEqual(600000); // ms
+    expect(((sampler as any).samplingClient as any).getSamplingRulesEndpoint).toEqual(
       'http://asdfghjkl:2000/GetSamplingRules'
     );
-    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).samplingTargetsEndpoint).toEqual(
+    expect(((sampler as any).samplingClient as any).samplingTargetsEndpoint).toEqual(
       'http://asdfghjkl:2000/SamplingTargets'
     );
 
@@ -155,12 +155,12 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     const sampler = customBuildSamplerFromEnv(Resource.empty());
 
     expect(sampler).toBeInstanceOf(AwsXRayRemoteSampler);
-    expect((sampler as AwsXRayRemoteSampler).getAwsProxyEndpoint()).toEqual('http://asdfghjkl:2000');
-    expect((sampler as AwsXRayRemoteSampler).getRulePollingIntervalMillis()).toEqual(300000); // default value
-    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).getSamplingRulesEndpoint).toEqual(
+    expect((sampler as any).awsProxyEndpoint).toEqual('http://asdfghjkl:2000');
+    expect((sampler as any).rulePollingIntervalMillis).toEqual(300000); // default value
+    expect(((sampler as any).samplingClient as any).getSamplingRulesEndpoint).toEqual(
       'http://asdfghjkl:2000/GetSamplingRules'
     );
-    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).samplingTargetsEndpoint).toEqual(
+    expect(((sampler as any).samplingClient as any).samplingTargetsEndpoint).toEqual(
       'http://asdfghjkl:2000/SamplingTargets'
     );
 
@@ -187,12 +187,12 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     let sampler = customBuildSamplerFromEnv(Resource.empty());
 
     expect(sampler).toBeInstanceOf(AwsXRayRemoteSampler);
-    expect((sampler as AwsXRayRemoteSampler).getAwsProxyEndpoint()).toEqual('http://lo=cal=host=:2000');
-    expect((sampler as AwsXRayRemoteSampler).getRulePollingIntervalMillis()).toEqual(600000);
-    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).getSamplingRulesEndpoint).toEqual(
+    expect((sampler as any).awsProxyEndpoint).toEqual('http://lo=cal=host=:2000');
+    expect((sampler as any).rulePollingIntervalMillis).toEqual(600000);
+    expect(((sampler as any).samplingClient as any).getSamplingRulesEndpoint).toEqual(
       'http://lo=cal=host=:2000/GetSamplingRules'
     );
-    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).samplingTargetsEndpoint).toEqual(
+    expect(((sampler as any).samplingClient as any).samplingTargetsEndpoint).toEqual(
       'http://lo=cal=host=:2000/SamplingTargets'
     );
 
@@ -201,12 +201,12 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     sampler = customBuildSamplerFromEnv(Resource.empty());
 
     expect(sampler).toBeInstanceOf(AwsXRayRemoteSampler);
-    expect((sampler as AwsXRayRemoteSampler).getAwsProxyEndpoint()).toEqual('http://localhost:2000');
-    expect((sampler as AwsXRayRemoteSampler).getRulePollingIntervalMillis()).toEqual(550000);
-    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).getSamplingRulesEndpoint).toEqual(
+    expect((sampler as any).awsProxyEndpoint).toEqual('http://localhost:2000');
+    expect((sampler as any).rulePollingIntervalMillis).toEqual(550000);
+    expect(((sampler as any).samplingClient as any).getSamplingRulesEndpoint).toEqual(
       'http://localhost:2000/GetSamplingRules'
     );
-    expect(((sampler as AwsXRayRemoteSampler).getSamplingClient() as any).samplingTargetsEndpoint).toEqual(
+    expect(((sampler as any).samplingClient as any).samplingTargetsEndpoint).toEqual(
       'http://localhost:2000/SamplingTargets'
     );
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
@@ -21,11 +21,11 @@ describe('AwsXrayRemoteSampler', () => {
   it('testCreateRemoteSamplerWithEmptyResource', () => {
     const sampler: AwsXRayRemoteSampler = new AwsXRayRemoteSampler({ resource: Resource.EMPTY });
 
-    expect(sampler.getRulePoller()).not.toBeFalsy();
-    expect(sampler.getRulePollingIntervalMillis()).toEqual(300 * 1000);
-    expect(sampler.getSamplingClient()).not.toBeFalsy();
-    expect(sampler.getRuleCache()).not.toBeFalsy();
-    expect(sampler.getClientId()).toMatch(/[a-f0-9]{24}/);
+    expect((sampler as any).rulePoller).not.toBeFalsy();
+    expect((sampler as any).rulePollingIntervalMillis).toEqual(300 * 1000);
+    expect((sampler as any).samplingClient).not.toBeFalsy();
+    expect((sampler as any).ruleCache).not.toBeFalsy();
+    expect((sampler as any).clientId).toMatch(/[a-f0-9]{24}/);
   });
 
   it('testCreateRemoteSamplerWithPopulatedResource', () => {
@@ -35,12 +35,12 @@ describe('AwsXrayRemoteSampler', () => {
     });
     const sampler = new AwsXRayRemoteSampler({ resource: resource });
 
-    expect(sampler.getRulePoller()).not.toBeFalsy();
-    expect(sampler.getRulePollingIntervalMillis()).toEqual(300 * 1000);
-    expect(sampler.getSamplingClient()).not.toBeFalsy();
-    expect(sampler.getRuleCache()).not.toBeFalsy();
-    expect(sampler.getRuleCache().getSamplerResource().attributes).toEqual(resource.attributes);
-    expect(sampler.getClientId()).toMatch(/[a-f0-9]{24}/);
+    expect((sampler as any).rulePoller).not.toBeFalsy();
+    expect((sampler as any).rulePollingIntervalMillis).toEqual(300 * 1000);
+    expect((sampler as any).samplingClient).not.toBeFalsy();
+    expect((sampler as any).ruleCache).not.toBeFalsy();
+    expect(((sampler as any).ruleCache as any).samplerResource.attributes).toEqual(resource.attributes);
+    expect((sampler as any).clientId).toMatch(/[a-f0-9]{24}/);
   });
 
   it('testCreateRemoteSamplerWithAllFieldsPopulated', () => {
@@ -54,13 +54,13 @@ describe('AwsXrayRemoteSampler', () => {
       pollingInterval: 120, // seconds
     });
 
-    expect(sampler.getRulePoller()).not.toBeFalsy();
-    expect(sampler.getRulePollingIntervalMillis()).toEqual(120 * 1000);
-    expect(sampler.getSamplingClient()).not.toBeFalsy();
-    expect(sampler.getRuleCache()).not.toBeFalsy();
-    expect(sampler.getRuleCache().getSamplerResource().attributes).toEqual(resource.attributes);
-    expect(sampler.getAwsProxyEndpoint()).toEqual('http://abc.com');
-    expect(sampler.getClientId()).toMatch(/[a-f0-9]{24}/);
+    expect((sampler as any).rulePoller).not.toBeFalsy();
+    expect((sampler as any).rulePollingIntervalMillis).toEqual(120 * 1000);
+    expect((sampler as any).samplingClient).not.toBeFalsy();
+    expect((sampler as any).ruleCache).not.toBeFalsy();
+    expect(((sampler as any).ruleCache as any).samplerResource.attributes).toEqual(resource.attributes);
+    expect((sampler as any).awsProxyEndpoint).toEqual('http://abc.com');
+    expect((sampler as any).clientId).toMatch(/[a-f0-9]{24}/);
   });
 
   it('testUpdateSamplingRulesAndTargetsWithPollersAndShouldSampled', done => {
@@ -81,7 +81,7 @@ describe('AwsXrayRemoteSampler', () => {
     });
 
     setTimeout(() => {
-      expect(sampler.getRuleCache().getRuleAppliers()[0].samplingRule.RuleName).toEqual('test');
+      expect(((sampler as any).ruleCache as any).ruleAppliers[0].samplingRule.RuleName).toEqual('test');
       expect(
         sampler.shouldSample(context.active(), '1234', 'name', SpanKind.CLIENT, { abc: '1234' }, []).decision
       ).toEqual(SamplingDecision.NOT_RECORD);
@@ -123,7 +123,7 @@ describe('AwsXrayRemoteSampler', () => {
     });
 
     setTimeout(() => {
-      expect(sampler.getRuleCache().getRuleAppliers()[0].samplingRule.RuleName).toEqual('test');
+      expect(((sampler as any).ruleCache as any).ruleAppliers[0].samplingRule.RuleName).toEqual('test');
       expect(sampler.shouldSample(context.active(), '1234', 'name', SpanKind.CLIENT, attributes, []).decision).toEqual(
         SamplingDecision.NOT_RECORD
       );
@@ -138,7 +138,9 @@ describe('AwsXrayRemoteSampler', () => {
             sampled++;
           }
         }
-        expect((sampler.getRuleCache().getRuleAppliers()[0] as any).reservoirSampler._root.quota).toEqual(100000);
+        expect((((sampler as any).ruleCache as any).ruleAppliers[0] as any).reservoirSampler._root.quota).toEqual(
+          100000
+        );
         expect(sampled).toEqual(100000);
         // reset function
         (AwsXRayRemoteSampler.prototype as any).getDefaultTargetPollingInterval = tmp;
@@ -166,7 +168,7 @@ describe('AwsXrayRemoteSampler', () => {
     });
 
     setTimeout(() => {
-      expect(sampler.getRuleCache().getRuleAppliers()[0].samplingRule.RuleName).toEqual('test');
+      expect(((sampler as any).ruleCache as any).ruleAppliers[0].samplingRule.RuleName).toEqual('test');
       expect(sampler.shouldSample(context.active(), '1234', 'name', SpanKind.CLIENT, attributes, []).decision).toEqual(
         SamplingDecision.NOT_RECORD
       );

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/rule-cache.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/rule-cache.test.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Resource } from '@opentelemetry/resources';
 import { expect } from 'expect';
 import * as sinon from 'sinon';
-import { Resource } from '@opentelemetry/resources';
 import { RuleCache } from '../../src/sampler/rule-cache';
 import { SamplingRule } from '../../src/sampler/sampling-rule';
 import { SamplingRuleApplier } from '../../src/sampler/sampling-rule-applier';
@@ -33,7 +33,7 @@ describe('RuleCache', () => {
     cache.updateRules([defaultRule]);
 
     // Expect default rule to exist
-    expect(cache.getRuleAppliers().length).toEqual(1);
+    expect((cache as any).ruleAppliers.length).toEqual(1);
 
     // Set up incoming rules
     const rule1 = createRule('low', 200, 0, 0.0);
@@ -47,13 +47,13 @@ describe('RuleCache', () => {
     cache.updateRules(rules);
 
     // Default rule should be removed because it doesn't exist in the new list
-    expect(cache.getRuleAppliers().length).toEqual(rules.length);
-    expect(cache.getRuleAppliers()[0].samplingRule.RuleName).toEqual('high');
-    expect(cache.getRuleAppliers()[1].samplingRule.RuleName).toEqual('A');
-    expect(cache.getRuleAppliers()[2].samplingRule.RuleName).toEqual('Abc');
-    expect(cache.getRuleAppliers()[3].samplingRule.RuleName).toEqual('ab');
-    expect(cache.getRuleAppliers()[4].samplingRule.RuleName).toEqual('abc');
-    expect(cache.getRuleAppliers()[5].samplingRule.RuleName).toEqual('low');
+    expect((cache as any).ruleAppliers.length).toEqual(rules.length);
+    expect((cache as any).ruleAppliers[0].samplingRule.RuleName).toEqual('high');
+    expect((cache as any).ruleAppliers[1].samplingRule.RuleName).toEqual('A');
+    expect((cache as any).ruleAppliers[2].samplingRule.RuleName).toEqual('Abc');
+    expect((cache as any).ruleAppliers[3].samplingRule.RuleName).toEqual('ab');
+    expect((cache as any).ruleAppliers[4].samplingRule.RuleName).toEqual('abc');
+    expect((cache as any).ruleAppliers[5].samplingRule.RuleName).toEqual('low');
   });
 
   it('testRuleCacheExpirationLogic', () => {
@@ -79,40 +79,40 @@ describe('RuleCache', () => {
 
     cache.updateRules(ruleAppliers);
 
-    const ruleAppliersCopy = cache.getRuleAppliers();
+    const ruleAppliersCopy = (cache as any).ruleAppliers;
 
     const newRule3 = createRule('new_rule_3', 5, 0, 0.0);
     const newRuleAppliers = [rule1, rule2, newRule3];
     cache.updateRules(newRuleAppliers);
 
     // Check rule cache is still correct length and has correct rules
-    expect(cache.getRuleAppliers().length).toEqual(3);
-    expect(cache.getRuleAppliers()[0].samplingRule.RuleName).toEqual('rule_1');
-    expect(cache.getRuleAppliers()[1].samplingRule.RuleName).toEqual('new_rule_3');
-    expect(cache.getRuleAppliers()[2].samplingRule.RuleName).toEqual('rule_2');
+    expect((cache as any).ruleAppliers.length).toEqual(3);
+    expect((cache as any).ruleAppliers[0].samplingRule.RuleName).toEqual('rule_1');
+    expect((cache as any).ruleAppliers[1].samplingRule.RuleName).toEqual('new_rule_3');
+    expect((cache as any).ruleAppliers[2].samplingRule.RuleName).toEqual('rule_2');
 
     // Assert before and after of rule cache
-    expect(ruleAppliersCopy[0]).toEqual(cache.getRuleAppliers()[0]);
-    expect(ruleAppliersCopy[1]).toEqual(cache.getRuleAppliers()[2]);
-    expect(ruleAppliersCopy[2]).not.toEqual(cache.getRuleAppliers()[1]);
+    expect(ruleAppliersCopy[0]).toEqual((cache as any).ruleAppliers[0]);
+    expect(ruleAppliersCopy[1]).toEqual((cache as any).ruleAppliers[2]);
+    expect(ruleAppliersCopy[2]).not.toEqual((cache as any).ruleAppliers[1]);
   });
 
   it('testUpdateRulesRemovesOlderRule', () => {
     // Set up default rule in rule cache
     const cache = new RuleCache(new Resource({}));
-    expect(cache.getRuleAppliers().length).toEqual(0);
+    expect((cache as any).ruleAppliers.length).toEqual(0);
 
     const rule1 = createRule('first_rule', 200, 0, 0.0);
     const rules = [rule1];
     cache.updateRules(rules);
-    expect(cache.getRuleAppliers().length).toEqual(1);
-    expect(cache.getRuleAppliers()[0].samplingRule.RuleName).toEqual('first_rule');
+    expect((cache as any).ruleAppliers.length).toEqual(1);
+    expect((cache as any).ruleAppliers[0].samplingRule.RuleName).toEqual('first_rule');
 
     const replacement_rule1 = createRule('second_rule', 200, 0, 0.0);
     const replacementRules = [replacement_rule1];
     cache.updateRules(replacementRules);
-    expect(cache.getRuleAppliers().length).toEqual(1);
-    expect(cache.getRuleAppliers()[0].samplingRule.RuleName).toEqual('second_rule');
+    expect((cache as any).ruleAppliers.length).toEqual(1);
+    expect((cache as any).ruleAppliers[0].samplingRule.RuleName).toEqual('second_rule');
   });
 
   it('testUpdateSamplingTargets', () => {
@@ -121,11 +121,11 @@ describe('RuleCache', () => {
     const cache = new RuleCache(new Resource({}));
     cache.updateRules([rule1, rule2]);
 
-    expect((cache.getRuleAppliers()[0] as any).reservoirSampler._root.quota).toEqual(1);
-    expect((cache.getRuleAppliers()[0] as any).fixedRateSampler._root._ratio).toEqual(rule2.samplingRule.FixedRate);
+    expect(((cache as any).ruleAppliers[0] as any).reservoirSampler._root.quota).toEqual(1);
+    expect(((cache as any).ruleAppliers[0] as any).fixedRateSampler._root._ratio).toEqual(rule2.samplingRule.FixedRate);
 
-    expect((cache.getRuleAppliers()[1] as any).reservoirSampler._root.quota).toEqual(1);
-    expect((cache.getRuleAppliers()[1] as any).fixedRateSampler._root._ratio).toEqual(rule1.samplingRule.FixedRate);
+    expect(((cache as any).ruleAppliers[1] as any).reservoirSampler._root.quota).toEqual(1);
+    expect(((cache as any).ruleAppliers[1] as any).fixedRateSampler._root._ratio).toEqual(rule1.samplingRule.FixedRate);
 
     const time = Date.now() / 1000;
     const target1 = {
@@ -156,12 +156,12 @@ describe('RuleCache', () => {
     expect(nextPollingInterval).toEqual(target2.Interval);
 
     // Ensure cache is still of length 2
-    expect(cache.getRuleAppliers().length).toEqual(2);
+    expect((cache as any).ruleAppliers.length).toEqual(2);
 
-    expect((cache.getRuleAppliers()[0] as any).reservoirSampler._root.quota).toEqual(target2.ReservoirQuota);
-    expect((cache.getRuleAppliers()[0] as any).fixedRateSampler._root._ratio).toEqual(target2.FixedRate);
-    expect((cache.getRuleAppliers()[1] as any).reservoirSampler._root.quota).toEqual(target1.ReservoirQuota);
-    expect((cache.getRuleAppliers()[1] as any).fixedRateSampler._root._ratio).toEqual(target1.FixedRate);
+    expect(((cache as any).ruleAppliers[0] as any).reservoirSampler._root.quota).toEqual(target2.ReservoirQuota);
+    expect(((cache as any).ruleAppliers[0] as any).fixedRateSampler._root._ratio).toEqual(target2.FixedRate);
+    expect(((cache as any).ruleAppliers[1] as any).reservoirSampler._root.quota).toEqual(target1.ReservoirQuota);
+    expect(((cache as any).ruleAppliers[1] as any).fixedRateSampler._root._ratio).toEqual(target1.FixedRate);
 
     const [refreshSamplingRulesAfter, _] = cache.updateTargets(targetMap, time + 1);
     expect(refreshSamplingRulesAfter).toBe(true);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove [methods introduced for testing](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/15/commits/074600497ab9e4f1ee2282720c3fd762a146f9b7), use workaround to access private vars

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

