### PR TITLE
Optimize Instrumentation Configure for Lambda cases

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-batch-unsampled-span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-batch-unsampled-span-processor.ts
@@ -2,17 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Modifications Copyright The OpenTelemetry Authors. Licensed under the Apache License 2.0 License.
 
-import { context, Context, diag, TraceFlags } from '@opentelemetry/api';
-import {
-  BindOnceFuture,
-  ExportResultCode,
-  getEnv,
-  globalErrorHandler,
-  suppressTracing,
-  unrefTimer,
-} from '@opentelemetry/core';
-import { ReadableSpan, BufferConfig, Span, SpanProcessor, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { Context, TraceFlags } from '@opentelemetry/api';
+import { ReadableSpan, BufferConfig, Span } from '@opentelemetry/sdk-trace-base';
 import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
+import { BatchSpanProcessorBase } from '@opentelemetry/sdk-trace-base/build/src/export/BatchSpanProcessorBase';
 
 /**
  * This class is a customized version of the `BatchSpanProcessorBase` from the
@@ -41,54 +34,16 @@ import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
  * The rest of the behavior—batch processing, queuing, and exporting spans in
  * batches—is inherited from the base class and remains largely the same.
  */
-export class AwsBatchUnsampledSpanProcessor implements SpanProcessor {
-  private readonly _maxExportBatchSize: number;
-  private readonly _maxQueueSize: number;
-  private readonly _scheduledDelayMillis: number;
-  private readonly _exportTimeoutMillis: number;
-
-  private _isExporting = false;
-  private _finishedSpans: ReadableSpan[] = [];
-  private _timer: NodeJS.Timeout | undefined;
-  private _shutdownOnce: BindOnceFuture<void>;
-  private _droppedSpansCount: number = 0;
-
-  constructor(private readonly _exporter: SpanExporter, config?: BufferConfig) {
-    const env = getEnv();
-    this._maxExportBatchSize =
-      typeof config?.maxExportBatchSize === 'number' ? config.maxExportBatchSize : env.OTEL_BSP_MAX_EXPORT_BATCH_SIZE;
-    this._maxQueueSize = typeof config?.maxQueueSize === 'number' ? config.maxQueueSize : env.OTEL_BSP_MAX_QUEUE_SIZE;
-    this._scheduledDelayMillis =
-      typeof config?.scheduledDelayMillis === 'number' ? config.scheduledDelayMillis : env.OTEL_BSP_SCHEDULE_DELAY;
-    this._exportTimeoutMillis =
-      typeof config?.exportTimeoutMillis === 'number' ? config.exportTimeoutMillis : env.OTEL_BSP_EXPORT_TIMEOUT;
-
-    this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
-
-    if (this._maxExportBatchSize > this._maxQueueSize) {
-      diag.warn(
-        'BatchSpanProcessor: maxExportBatchSize must be smaller or equal to maxQueueSize, setting maxExportBatchSize to match maxQueueSize'
-      );
-      this._maxExportBatchSize = this._maxQueueSize;
-    }
-  }
-
-  forceFlush(): Promise<void> {
-    if (this._shutdownOnce.isCalled) {
-      return this._shutdownOnce.promise;
-    }
-    return this._flushAll();
-  }
-
-  onStart(span: Span, _parentContext: Context): void {
+export class AwsBatchUnsampledSpanProcessor extends BatchSpanProcessorBase<BufferConfig> {
+  override onStart(span: Span, _parentContext: Context): void {
     if ((span.spanContext().traceFlags & TraceFlags.SAMPLED) === 0) {
       span.setAttribute(AWS_ATTRIBUTE_KEYS.AWS_TRACE_FLAG_UNSAMPLED, true);
       return;
     }
   }
 
-  onEnd(span: ReadableSpan): void {
-    if (this._shutdownOnce.isCalled) {
+  override onEnd(span: ReadableSpan): void {
+    if ((this as any)._shutdownOnce.isCalled) {
       return;
     }
 
@@ -96,156 +51,7 @@ export class AwsBatchUnsampledSpanProcessor implements SpanProcessor {
       return;
     }
 
-    this._addToBuffer(span);
-  }
-
-  shutdown(): Promise<void> {
-    return this._shutdownOnce.call();
-  }
-
-  private _shutdown() {
-    return Promise.resolve()
-      .then(() => {
-        return this.onShutdown();
-      })
-      .then(() => {
-        return this._flushAll();
-      })
-      .then(() => {
-        return this._exporter.shutdown();
-      });
-  }
-
-  /** Add a span in the buffer. */
-  private _addToBuffer(span: ReadableSpan) {
-    if (this._finishedSpans.length >= this._maxQueueSize) {
-      // limit reached, drop span
-
-      if (this._droppedSpansCount === 0) {
-        diag.debug('maxQueueSize reached, dropping spans');
-      }
-      this._droppedSpansCount++;
-
-      return;
-    }
-
-    if (this._droppedSpansCount > 0) {
-      // some spans were dropped, log once with count of spans dropped
-      diag.warn(`Dropped ${this._droppedSpansCount} spans because maxQueueSize reached`);
-      this._droppedSpansCount = 0;
-    }
-
-    this._finishedSpans.push(span);
-    this._maybeStartTimer();
-  }
-
-  /**
-   * Send all spans to the exporter respecting the batch size limit
-   * This function is used only on forceFlush or shutdown,
-   * for all other cases _flush should be used
-   * */
-  private _flushAll(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const promises = [];
-      // calculate number of batches
-      const count = Math.ceil(this._finishedSpans.length / this._maxExportBatchSize);
-      for (let i = 0, j = count; i < j; i++) {
-        promises.push(this._flushOneBatch());
-      }
-      Promise.all(promises)
-        .then(() => {
-          resolve();
-        })
-        .catch(reject);
-    });
-  }
-
-  private _flushOneBatch(): Promise<void> {
-    this._clearTimer();
-    if (this._finishedSpans.length === 0) {
-      return Promise.resolve();
-    }
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        // don't wait anymore for export, this way the next batch can start
-        reject(new Error('Timeout'));
-      }, this._exportTimeoutMillis);
-      // prevent downstream exporter calls from generating spans
-      context.with(suppressTracing(context.active()), () => {
-        // Reset the finished spans buffer here because the next invocations of the _flush method
-        // could pass the same finished spans to the exporter if the buffer is cleared
-        // outside the execution of this callback.
-        let spans: ReadableSpan[];
-        if (this._finishedSpans.length <= this._maxExportBatchSize) {
-          spans = this._finishedSpans;
-          this._finishedSpans = [];
-        } else {
-          spans = this._finishedSpans.splice(0, this._maxExportBatchSize);
-        }
-
-        const doExport = () =>
-          this._exporter.export(spans, result => {
-            clearTimeout(timer);
-            if (result.code === ExportResultCode.SUCCESS) {
-              resolve();
-            } else {
-              reject(result.error ?? new Error('BatchSpanProcessor: span export failed'));
-            }
-          });
-
-        let pendingResources: Array<Promise<void>> | null = null;
-        for (let i = 0, len = spans.length; i < len; i++) {
-          const span = spans[i];
-          if (span.resource.asyncAttributesPending && span.resource.waitForAsyncAttributes) {
-            pendingResources ??= [];
-            pendingResources.push(span.resource.waitForAsyncAttributes());
-          }
-        }
-
-        // Avoid scheduling a promise to make the behavior more predictable and easier to test
-        if (pendingResources === null) {
-          doExport();
-        } else {
-          Promise.all(pendingResources).then(doExport, err => {
-            globalErrorHandler(err);
-            reject(err);
-          });
-        }
-      });
-    });
-  }
-
-  private _maybeStartTimer() {
-    if (this._isExporting) return;
-    const flush = () => {
-      this._isExporting = true;
-      this._flushOneBatch()
-        .finally(() => {
-          this._isExporting = false;
-          if (this._finishedSpans.length > 0) {
-            this._clearTimer();
-            this._maybeStartTimer();
-          }
-        })
-        .catch(e => {
-          this._isExporting = false;
-          globalErrorHandler(e);
-        });
-    };
-    // we only wait if the queue doesn't have enough elements yet
-    if (this._finishedSpans.length >= this._maxExportBatchSize) {
-      return flush();
-    }
-    if (this._timer !== undefined) return;
-    this._timer = setTimeout(() => flush(), this._scheduledDelayMillis);
-    unrefTimer(this._timer);
-  }
-
-  private _clearTimer() {
-    if (this._timer !== undefined) {
-      clearTimeout(this._timer);
-      this._timer = undefined;
-    }
+    (this as any)._addToBuffer(span);
   }
 
   onShutdown(): void {}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
@@ -18,6 +18,7 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
 import * as SQL_DIALECT_KEYWORDS_JSON from './configuration/sql_dialect_keywords.json';
+import { AWS_LAMBDA_FUNCTION_NAME_CONFIG, isLambdaEnvironment } from './aws-opentelemetry-configurator';
 
 /** Utility class designed to support shared logic across AWS Span Processors. */
 export class AwsSpanProcessingUtil {
@@ -50,6 +51,9 @@ export class AwsSpanProcessingUtil {
     let operation: string = span.name;
     if (AwsSpanProcessingUtil.shouldUseInternalOperation(span)) {
       operation = AwsSpanProcessingUtil.INTERNAL_OPERATION;
+    }
+    if (isLambdaEnvironment()) {
+      operation = process.env[AWS_LAMBDA_FUNCTION_NAME_CONFIG] + '/Handler';
     } else if (!AwsSpanProcessingUtil.isValidOperation(span, operation)) {
       operation = AwsSpanProcessingUtil.generateIngressOperation(span);
     }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -32,6 +32,7 @@ import { AwsXRayRemoteSampler } from '../src/sampler/aws-xray-remote-sampler';
 import { AwsXraySamplingClient } from '../src/sampler/aws-xray-sampling-client';
 import { GetSamplingRulesResponse } from '../src/sampler/remote-sampler.types';
 import { OTLPUdpSpanExporter } from '../src/otlp-udp-exporter';
+import { AwsBatchUnsampledSpanProcessor } from '../src/aws-batch-unsampled-span-processor';
 
 // Tests AwsOpenTelemetryConfigurator after running Environment Variable setup in register.ts
 describe('AwsOpenTelemetryConfiguratorTest', () => {
@@ -368,6 +369,34 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     delete process.env.AWS_LAMBDA_FUNCTION_NAME;
     delete process.env.OTEL_TRACES_EXPORTER;
     delete process.env.AWS_XRAY_DAEMON_ADDRESS;
+  });
+
+  it('tests configureOTLP on Lambda with ApplicationSignals False', () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'TestFunction';
+    process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED = 'False';
+    process.env.OTEL_TRACES_EXPORTER = 'otlp';
+    process.env.AWS_XRAY_DAEMON_ADDRESS = 'www.test.com:2222';
+    const spanExporter: SpanExporter = AwsSpanProcessorProvider.configureOtlp();
+    expect(spanExporter).toBeInstanceOf(OTLPUdpSpanExporter);
+    expect((spanExporter as OTLPUdpSpanExporter)['_endpoint']).toBe('www.test.com:2222');
+    delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;
+    delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+    delete process.env.OTEL_TRACES_EXPORTER;
+    delete process.env.AWS_XRAY_DAEMON_ADDRESS;
+  });
+
+  it('Test CustomizeSpanProcessors for Lambda', () => {
+    process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED = 'True';
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'TestFunction';
+    const spanProcessors: SpanProcessor[] = [];
+    AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, Resource.empty());
+    expect(spanProcessors.length).toEqual(2);
+    const firstProcessor: SpanProcessor = spanProcessors[0];
+    expect(firstProcessor).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    const secondProcessor: SpanProcessor = spanProcessors[1];
+    expect(secondProcessor).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
+    delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;
+    delete process.env.AWS_LAMBDA_FUNCTION_NAME;
   });
 
   function validateConfiguratorEnviron() {

--- a/lambda-layer/README.md
+++ b/lambda-layer/README.md
@@ -28,10 +28,8 @@ anymore.
 
 ## Steps to Deploy this Lambda function
 
-Go to `${root}/lambda-layer/sample-apps/aws-sdk` director,
-
-1. run `npm install`.
-2. run `terraform init` and `terraform apply`.
+1. Go to `${root}/lambda-layer/sample-apps/aws-sdk` director, run `npm install`.
+2. Go to `${root}/lambda-layer/terraform/lambda`, run `terraform init` and `terraform apply`.
 
 The lambda function(`aws-opentelemetry-distro-nodejs`) will be initialized and the URL for an API Gateway invoking the Lambda
 will be displayed at the end. Send a request to the URL in a browser or using curl to execute the function. Then,

--- a/lambda-layer/packages/layer/scripts/otel-instrument
+++ b/lambda-layer/packages/layer/scripts/otel-instrument
@@ -1,12 +1,30 @@
 #!/bin/bash
 export NODE_OPTIONS="${NODE_OPTIONS} --require /opt/wrapper.js"
 export LAMBDA_RESOURCE_ATTRIBUTES="cloud.region=$AWS_REGION,cloud.provider=aws,faas.name=$AWS_LAMBDA_FUNCTION_NAME,faas.version=$AWS_LAMBDA_FUNCTION_VERSION,faas.instance=$AWS_LAMBDA_LOG_STREAM_NAME,aws.log.group.names=$AWS_LAMBDA_LOG_GROUP_NAME";
-export OTEL_NODE_ENABLED_INSTRUMENTATIONS="http,aws-lambda,aws-sdk"
+export OTEL_NODE_ENABLED_INSTRUMENTATIONS="aws-lambda,aws-sdk"
+
+# - If OTEL_EXPORTER_OTLP_PROTOCOL is not set by user, the default exporting protocol is http/protobuf.
+if [ -z "${OTEL_EXPORTER_OTLP_PROTOCOL}" ]; then
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+fi
+
+# - Set the service name
+if [ -z "${OTEL_SERVICE_NAME}" ]; then
+    export OTEL_SERVICE_NAME=$AWS_LAMBDA_FUNCTION_NAME;
+fi
+
+# - Set the propagators
+if [[ -z "$OTEL_PROPAGATORS" ]]; then
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray"
+fi
 
 # - Set Application Signals configuration
-if [ "${OTEL_AWS_APPLICATION_SIGNALS_ENABLED}" = "true" ]; then
+if [ -z "${OTEL_AWS_APPLICATION_SIGNALS_ENABLED}" ]; then
+    export OTEL_AWS_APPLICATION_SIGNALS_ENABLED="true";
+fi
+
+if [ -z "${OTEL_METRICS_EXPORTER}" ]; then
     export OTEL_METRICS_EXPORTER="none";
-    export OTEL_LOGS_EXPORTER="none";
 fi
 
 # - Append Lambda Resource Attributes to OTel Resource Attribute List
@@ -16,10 +34,6 @@ else
     export OTEL_RESOURCE_ATTRIBUTES="$LAMBDA_RESOURCE_ATTRIBUTES,$OTEL_RESOURCE_ATTRIBUTES";
 fi
 
-# - Set the service name
-if [ -z "${OTEL_SERVICE_NAME}" ]; then
-    export OTEL_SERVICE_NAME=$AWS_LAMBDA_FUNCTION_NAME;
-fi
 if [[ $OTEL_RESOURCE_ATTRIBUTES != *"service.name="* ]]; then
   export OTEL_RESOURCE_ATTRIBUTES="service.name=${AWS_LAMBDA_FUNCTION_NAME},${OTEL_RESOURCE_ATTRIBUTES}"
 fi

--- a/lambda-layer/sample-apps/aws-sdk/src/index.ts
+++ b/lambda-layer/sample-apps/aws-sdk/src/index.ts
@@ -5,6 +5,9 @@ import {
 } from 'aws-lambda';
 
 import AWS from 'aws-sdk';
+import {
+  traceContextEnvironmentKey
+} from "@aws/aws-distro-opentelemetry-node-autoinstrumentation/build/src/patches/instrumentation-patch";
 
 const s3 = new AWS.S3();
 
@@ -13,9 +16,12 @@ exports.handler = async (event: APIGatewayProxyEvent, context: Context) => {
 
   const result = await s3.listBuckets().promise();
 
+  console.log('Fetched OTel Resource Attrs:' + process.env.OTEL_RESOURCE_ATTRIBUTES);
+  console.log('Fetched X-Ray Trace Header:' + process.env['_X_AMZN_TRACE_ID']);
+
   const response: APIGatewayProxyResult = {
     statusCode: 200,
-    body: `Hello lambda - found ${result.Buckets?.length || 0} buckets`,
+    body: `Hello lambda - found ${result.Buckets?.length || 0}`,
   };
   return response;
 };


### PR DESCRIPTION
*Description of changes:*
Update Instrumentation Configure for the following changes
1. Disable `AwsSpanMetricsProcessor` for Lambda
2. Disable AWS platform Resource Detectors for Lambda 
3. Update Lambda Instrumentation propagation for supporting PassThru case
4. Update Lambda Local Operation to `{function_name}/Hander`
5. Set Batch Sampled/UnSampled Span processor size to 10 for Lambda only

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

