### PR TITLE
Update README regarding Env Vars, Reorder Env Detector in Env Var logic

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/README.md
@@ -15,14 +15,21 @@ node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register'
 ## Sample Environment Variables for Application Signals
 
 ```shell
-export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true \
-export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics \
-export OTEL_PROPAGATORS=xray,tracecontext,b3,b3multi \
-export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
-export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces \
-export OTEL_TRACES_EXPORTER=console,otlp \
-export OTEL_TRACES_SAMPLER=xray \
-export OTEL_TRACES_SAMPLER_ARG=endpoint=http://localhost:2000,polling_interval=300 \
-export OTEL_RESOURCE_ATTRIBUTES=service.name=test-adot-sdk-ec2-service-name \
-export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs
+export OTEL_RESOURCE_ATTRIBUTES=service.name=example-application-service-name
+export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true
+export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces
+export OTEL_TRACES_EXPORTER=console,otlp
+export OTEL_TRACES_SAMPLER=xray
+export OTEL_TRACES_SAMPLER_ARG=endpoint=http://localhost:2000,polling_interval=300
 ```
+
+### General Recommendations
+
+| Environment Variable | Description | Example |
+| -------------------- | ----------- | ------- |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Leave unset so that ADOT JS will use a recommended OTLP protocol | `http/protobuf` |
+| `OTEL_PROPAGATORS` | Leave unset so that ADOT JS will use a recommended list of propagators | `xray,tracecontext,b3,b3multi` |
+| `OTEL_NODE_DISABLED_INSTRUMENTATIONS` | Leave unset so that ADOT JS will disable a recommended list of instrumentations | `fs,dns` |
+| `OTEL_NODE_RESOURCE_DETECTORS` | Leave unset so that ADOT JS will use a recommended list of Resource Detectors. If set, `env` should be at the end of the list | `aws,env` |

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -122,11 +122,11 @@ export class AwsOpentelemetryConfigurator {
       defaultDetectors = getResourceDetectorsFromEnv();
       // Add Env/AWS Resource Detectors if not present
       const resourceDetectorsFromEnv: string[] = process.env.OTEL_NODE_RESOURCE_DETECTORS.split(',');
-      if (!resourceDetectorsFromEnv.includes('env')) {
-        defaultDetectors.push(envDetectorSync);
-      }
       if (!resourceDetectorsFromEnv.includes('aws')) {
         defaultDetectors.push(awsEc2Detector, awsEcsDetector, awsEksDetector);
+      }
+      if (!resourceDetectorsFromEnv.includes('env')) {
+        defaultDetectors.push(envDetectorSync);
       }
     } else {
       /*


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add `General Recommendations` table for ADOT JS Env Vars.
2. If user sets the `OTEL_NODE_RESOURCE_DETECTORS` Env Var, ensure that `env` is at the end of the list if not added by user. (see related [#53](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/53))

*Testing:*
- See [README in branch here](https://github.com/aws-observability/aws-otel-js-instrumentation/tree/readme-env-var-update/aws-distro-opentelemetry-node-autoinstrumentation).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

