### PR TITLE
Enable `suppressInternalInstrumentation` for AWS-SDK and Mongoose Instrumentations

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
@@ -17,8 +17,8 @@ import {
   SEMATTRS_RPC_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
 import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
-import * as SQL_DIALECT_KEYWORDS_JSON from './configuration/sql_dialect_keywords.json';
 import { AWS_LAMBDA_FUNCTION_NAME_CONFIG, isLambdaEnvironment } from './aws-opentelemetry-configurator';
+import * as SQL_DIALECT_KEYWORDS_JSON from './configuration/sql_dialect_keywords.json';
 
 /** Utility class designed to support shared logic across AWS Span Processors. */
 export class AwsSpanProcessingUtil {
@@ -124,23 +124,6 @@ export class AwsSpanProcessingUtil {
   }
 
   static shouldGenerateDependencyMetricAttributes(span: ReadableSpan): boolean {
-    // Divergence from Java/Python
-    // In OTel JS, the AWS SDK instrumentation creates two Client Spans, one for AWS SDK,
-    // and another for the underlying HTTP Client used by the SDK. The following code block
-    // ensures that dependency metrics are not generated for direct descendent of AWS SDK Spans.
-    const isAwsSdkDescendent: AttributeValue | undefined = span.attributes[AWS_ATTRIBUTE_KEYS.AWS_SDK_DESCENDANT];
-    if (isAwsSdkDescendent !== undefined && isAwsSdkDescendent === 'true') {
-      return false;
-    }
-
-    // TODO:
-    // Telemetry improvements:
-    // - return false for dns instrumentation client spans
-    //   (suppress metrics for spans with name: `dns.lookup`)
-    // - return false for mongoose instrumentation client spans in
-    //   favor of lower level mongodb instrumentation client spans
-    //   (suppress metrics for spans attribute 'db.system': 'mongoose')
-
     return (
       SpanKind.CLIENT === span.kind ||
       SpanKind.PRODUCER === span.kind ||

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
@@ -1,25 +1,25 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import {
+  diag,
+  isSpanContextValid,
+  Context as OtelContext,
+  context as otelContext,
+  propagation,
+  ROOT_CONTEXT,
+  TextMapGetter,
+  trace,
+} from '@opentelemetry/api';
 import { Instrumentation } from '@opentelemetry/instrumentation';
+import { AwsLambdaInstrumentation } from '@opentelemetry/instrumentation-aws-lambda';
 import { AwsSdkInstrumentationConfig, NormalizedRequest } from '@opentelemetry/instrumentation-aws-sdk';
+import { AWSXRAY_TRACE_ID_HEADER, AWSXRayPropagator } from '@opentelemetry/propagator-aws-xray';
+import { APIGatewayProxyEventHeaders, Context } from 'aws-lambda';
 import { AWS_ATTRIBUTE_KEYS } from '../aws-attribute-keys';
 import { RequestMetadata } from '../third-party/otel/aws/services/ServiceExtension';
 import { KinesisServiceExtension } from './aws/services/kinesis';
 import { S3ServiceExtension } from './aws/services/s3';
-import { AwsLambdaInstrumentation } from '@opentelemetry/instrumentation-aws-lambda';
-import {
-  Context as OtelContext,
-  context as otelContext,
-  trace,
-  propagation,
-  TextMapGetter,
-  isSpanContextValid,
-  ROOT_CONTEXT,
-  diag,
-} from '@opentelemetry/api';
-import { APIGatewayProxyEventHeaders, Context } from 'aws-lambda';
-import { AWSXRAY_TRACE_ID_HEADER, AWSXRayPropagator } from '@opentelemetry/propagator-aws-xray';
 
 export const traceContextEnvironmentKey = '_X_AMZN_TRACE_ID';
 const awsPropagator = new AWSXRayPropagator();

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Modifications Copyright The OpenTelemetry Authors. Licensed under the Apache License 2.0 License.
 
-import { DiagConsoleLogger, diag } from '@opentelemetry/api';
-import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { diag, DiagConsoleLogger } from '@opentelemetry/api';
+import { getNodeAutoInstrumentations, InstrumentationConfigMap } from '@opentelemetry/auto-instrumentations-node';
 import { Instrumentation } from '@opentelemetry/instrumentation';
 import * as opentelemetry from '@opentelemetry/sdk-node';
 import { AwsOpentelemetryConfigurator } from './aws-opentelemetry-configurator';
@@ -43,7 +43,15 @@ export function setAwsDefaultEnvironmentVariables(): void {
 }
 setAwsDefaultEnvironmentVariables();
 
-const instrumentations: Instrumentation[] = getNodeAutoInstrumentations();
+const instrumentationConfigs: InstrumentationConfigMap = {
+  '@opentelemetry/instrumentation-aws-sdk': {
+    suppressInternalInstrumentation: true,
+  },
+  '@opentelemetry/instrumentation-mongoose': {
+    suppressInternalInstrumentation: true,
+  },
+};
+const instrumentations: Instrumentation[] = getNodeAutoInstrumentations(instrumentationConfigs);
 
 // Apply instrumentation patches
 applyInstrumentationPatches(instrumentations);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Enable `suppressInternalInstrumentation` for AWS-SDK and Mongoose Instrumentations
2. Remove workaround that suppresses metrics from child spans of AWS SDK spans


*Testing:*
- Tested on ECS Fargate and Local machine
  - AWS SDK has no http child span
  - Mongoose has no mongodb child span

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

