### PR TITLE
Add E2E test to main build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -1,0 +1,77 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+# This is a reusable workflow for running the E2E test for Application Signals.
+# It is meant to be called from another workflow.
+# Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
+name: E2E Testing
+on:
+  workflow_call:
+    inputs:
+      staging-instrumentation-name:
+        required: true
+        type: string
+      adot-image-name:
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
+  cancel-in-progress: false
+
+
+jobs:
+  upload-main-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::637423224110:role/${{ secrets.STAGING_ARTIFACTS_ACCESS_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.staging-instrumentation-name }}
+
+      - name: Upload main-build instrumentation to S3
+        run: aws s3 cp ${{ inputs.staging-instrumentation-name }} s3://adot-autoinstrumentation-node-staging/${{ inputs.staging-instrumentation-name }}
+
+  ec2-default:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/node-ec2-default-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      staging-instrumentation-name: ${{ inputs.staging-instrumentation-name }}
+      caller-workflow-name: 'main-build'
+
+  ec2-asg:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/node-ec2-asg-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      staging-instrumentation-name: ${{ inputs.staging-instrumentation-name }}
+      caller-workflow-name: 'main-build'
+
+  eks:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/node-eks-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-node-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+
+  k8s:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/node-k8s-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - "release/v*"
-      - e2e-parallel
 
 env:
   AWS_DEFAULT_REGION: us-east-1
@@ -84,15 +83,14 @@ jobs:
       #     pip install pytest
       #     pytest contract-tests/tests
 
-  # TODO - implement E2E tests in NodeJS
-  # application-signals-e2e-test:
-  #   name: "Application Signals E2E Test"
-  #   needs: [ build ]
-  #   uses: ./.github/workflows/application-signals-e2e-test.yml
-  #   secrets: inherit
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   with:
-  #     staging-wheel-name: ${{ needs.build.outputs.staging_wheel_file }}
-  #     adot-image-name: ${{ needs.build.outputs.staging_registry }}/aws-observability/adot-autoinstrumentation-python-staging:${{ needs.build.outputs.python_image_tag }}
+  application-signals-e2e-test:
+    name: "Application Signals E2E Test"
+    needs: [ build ]
+    uses: ./.github/workflows/application-signals-e2e-test.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      staging-instrumentation-name: ${{ needs.build.outputs.staging_tarball_file }}
+      adot-image-name: ${{ needs.build.outputs.staging_registry }}/aws-observability/adot-autoinstrumentation-node-staging:${{ needs.build.outputs.node_image_tag }}


### PR DESCRIPTION
### Issue
Main build does not currently run out E2E test suite

### Description of changes
- Added a workflow file that calls all the E2E tests we own for NodeJS
- Uncommented the E2E test call in the main build file
- Removed `e2e-parallel` from the `on-push` of main build, since that branch doesn't exist and was likely used for testing

### Testing
Testing using `on-push` to `js-release-test` branch which was removed right after for the PR.
https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/11075046062


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

