### PR TITLE
[Unit Tests] Fix lag after Unit Tests finish, fix flakiness in Sampling test

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-batch-unsampled-span-processor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-batch-unsampled-span-processor.test.ts
@@ -457,6 +457,7 @@ describe('AwsBatchUnsampledSpanProcessor', () => {
       const processor = new AwsBatchUnsampledSpanProcessor(exporter, {
         maxExportBatchSize: 5,
         maxQueueSize: 6,
+        exportTimeoutMillis: 1000,
       });
       const totalSpans = 50;
       for (let i = 0; i < totalSpans; i++) {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
@@ -87,6 +87,9 @@ describe('AwsXrayRemoteSampler', () => {
       ).toEqual(SamplingDecision.NOT_RECORD);
 
       setTimeout(() => {
+        // restore function
+        (AwsXRayRemoteSampler.prototype as any).getDefaultTargetPollingInterval = tmp;
+
         expect(
           sampler.shouldSample(context.active(), '1234', 'name', SpanKind.CLIENT, { abc: '1234' }, []).decision
         ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
@@ -97,8 +100,6 @@ describe('AwsXrayRemoteSampler', () => {
           sampler.shouldSample(context.active(), '1234', 'name', SpanKind.CLIENT, { abc: '1234' }, []).decision
         ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
 
-        // reset function
-        (AwsXRayRemoteSampler.prototype as any).getDefaultTargetPollingInterval = tmp;
         done();
       }, 300);
     }, 10);
@@ -138,12 +139,14 @@ describe('AwsXrayRemoteSampler', () => {
             sampled++;
           }
         }
+
+        // restore function
+        (AwsXRayRemoteSampler.prototype as any).getDefaultTargetPollingInterval = tmp;
+
         expect((((sampler as any).ruleCache as any).ruleAppliers[0] as any).reservoirSampler._root.quota).toEqual(
           100000
         );
         expect(sampled).toEqual(100000);
-        // reset function
-        (AwsXRayRemoteSampler.prototype as any).getDefaultTargetPollingInterval = tmp;
         done();
       }, 2000);
     }, 100);
@@ -185,13 +188,13 @@ describe('AwsXrayRemoteSampler', () => {
             sampled++;
           }
         }
-        expect(sampled).toEqual(100);
-        // reset function
-        (AwsXRayRemoteSampler.prototype as any).getDefaultTargetPollingInterval = tmp;
         clock.restore();
+        // restore function
+        (AwsXRayRemoteSampler.prototype as any).getDefaultTargetPollingInterval = tmp;
+        expect(sampled).toEqual(100);
         done();
       }, 2000);
-    }, 100);
+    }, 300);
   });
 
   it('generates valid ClientId', () => {


### PR DESCRIPTION
*Issue #, if available:*
- `npm run test` command stalls for 20s after all tests pass (or fail), discovered caused by `Concurrency` test, likely due to `exportTimeoutMillis` default value being set in `AwsBatchUnsampledSpanProcessor`
- Flaky test case `testSomeReservoir` that may fail when sampling targets are not refreshed in time for the unit tests (due to the test being reliant on `setTimeout` which doesn't guarantee exact time of execution).
  - https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/11023689994/job/30615442620#step:7:560

*Description of changes:*
- Add short `exportTimeoutMillis` value for `AwsBatchUnsampledSpanProcessor` config in `Concurrency` test
- Update `testSomeReservoir` to properly cleanup the fake clock, provide more time for Sampling targets to refresh on time for the unit test run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

