### PR TITLE
[XRay Sampler] Fix - Ensure all XRay Sampler functionality is under ParentBased logic

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/sampler/aws-xray-remote-sampler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/sampler/aws-xray-remote-sampler.ts
@@ -45,6 +45,9 @@ export class AwsXRayRemoteSampler implements Sampler {
   }
 }
 
+// _AwsXRayRemoteSampler contains all core XRay Sampler Functionality,
+// however it is NOT Parent-based (e.g. Sample logic runs for each span)
+// Not intended for external use, use Parent-based `AwsXRayRemoteSampler` instead.
 export class _AwsXRayRemoteSampler implements Sampler {
   private rulePollingIntervalMillis: number;
   private targetPollingInterval: number;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
@@ -220,6 +220,9 @@ describe('AwsXrayRemoteSampler', () => {
         span2.end();
         span1.end();
         span0.end();
+
+        // span1 and span2 are child spans of root span0
+        // For AwsXRayRemoteSampler (ParentBased), expect only span0 to update statistics
         expect((sampler as any)._root._root.ruleCache.ruleAppliers[0].statistics.RequestCount).toBe(1);
         expect((sampler as any)._root._root.ruleCache.ruleAppliers[0].statistics.SampleCount).toBe(1);
         done();
@@ -242,6 +245,9 @@ describe('AwsXrayRemoteSampler', () => {
         span2.end();
         span1.end();
         span0.end();
+
+        // span1 and span2 are child spans of root span0
+        // For _AwsXRayRemoteSampler (Non-ParentBased), expect all 3 spans to update statistics
         expect((sampler as any).ruleCache.ruleAppliers[0].statistics.RequestCount).toBe(3);
         expect((sampler as any).ruleCache.ruleAppliers[0].statistics.SampleCount).toBe(3);
         done();

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/data/get-sampling-rules-response-sample-sample-all.json
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/data/get-sampling-rules-response-sample-sample-all.json
@@ -1,0 +1,24 @@
+{
+    "NextToken": null,
+    "SamplingRuleRecords": [
+        {
+            "CreatedAt": 0.0,
+            "ModifiedAt": 1.611564245E9,
+            "SamplingRule": {
+                "Attributes": {},
+                "FixedRate": 1.00,
+                "HTTPMethod": "*",
+                "Host": "*",
+                "Priority": 10000,
+                "ReservoirSize": 1,
+                "ResourceARN": "*",
+                "RuleARN": "arn:aws:xray:us-west-2:123456789000:sampling-rule/Default",
+                "RuleName": "Default",
+                "ServiceName": "*",
+                "ServiceType": "*",
+                "URLPath": "*",
+                "Version": 1
+            }
+        }
+    ]
+}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/rule-cache.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/rule-cache.test.ts
@@ -121,11 +121,11 @@ describe('RuleCache', () => {
     const cache = new RuleCache(new Resource({}));
     cache.updateRules([rule1, rule2]);
 
-    expect(((cache as any).ruleAppliers[0] as any).reservoirSampler._root.quota).toEqual(1);
-    expect(((cache as any).ruleAppliers[0] as any).fixedRateSampler._root._ratio).toEqual(rule2.samplingRule.FixedRate);
+    expect(((cache as any).ruleAppliers[0] as any).reservoirSampler.quota).toEqual(1);
+    expect(((cache as any).ruleAppliers[0] as any).fixedRateSampler._ratio).toEqual(rule2.samplingRule.FixedRate);
 
-    expect(((cache as any).ruleAppliers[1] as any).reservoirSampler._root.quota).toEqual(1);
-    expect(((cache as any).ruleAppliers[1] as any).fixedRateSampler._root._ratio).toEqual(rule1.samplingRule.FixedRate);
+    expect(((cache as any).ruleAppliers[1] as any).reservoirSampler.quota).toEqual(1);
+    expect(((cache as any).ruleAppliers[1] as any).fixedRateSampler._ratio).toEqual(rule1.samplingRule.FixedRate);
 
     const time = Date.now() / 1000;
     const target1 = {
@@ -158,10 +158,10 @@ describe('RuleCache', () => {
     // Ensure cache is still of length 2
     expect((cache as any).ruleAppliers.length).toEqual(2);
 
-    expect(((cache as any).ruleAppliers[0] as any).reservoirSampler._root.quota).toEqual(target2.ReservoirQuota);
-    expect(((cache as any).ruleAppliers[0] as any).fixedRateSampler._root._ratio).toEqual(target2.FixedRate);
-    expect(((cache as any).ruleAppliers[1] as any).reservoirSampler._root.quota).toEqual(target1.ReservoirQuota);
-    expect(((cache as any).ruleAppliers[1] as any).fixedRateSampler._root._ratio).toEqual(target1.FixedRate);
+    expect(((cache as any).ruleAppliers[0] as any).reservoirSampler.quota).toEqual(target2.ReservoirQuota);
+    expect(((cache as any).ruleAppliers[0] as any).fixedRateSampler._ratio).toEqual(target2.FixedRate);
+    expect(((cache as any).ruleAppliers[1] as any).reservoirSampler.quota).toEqual(target1.ReservoirQuota);
+    expect(((cache as any).ruleAppliers[1] as any).fixedRateSampler._ratio).toEqual(target1.FixedRate);
 
     const [refreshSamplingRulesAfter, _] = cache.updateTargets(targetMap, time + 1);
     expect(refreshSamplingRulesAfter).toBe(true);


### PR DESCRIPTION
### Issue #, if available:

This PR fixes https://github.com/aws-observability/aws-otel-js-instrumentation/issues/79
This fixes the bug where:
- While the subcomponents of XRay Sampler uses ParentBased logic to short-circuit the Parent's Sampling Decision, the XRay Sampling Statistics recording logic is not skipped when a Parent's Sampling Decision is found. This causes XRay Sampler to produce Sampling Statistics based on number of Spans (regardless of Parent's Sampling Decision), while XRay Sampler should produce Sampling Statistics based on number of Traces (aka the number of root Spans that makes the Sampling Decision)

###  Description of changes:
1. Wrap entire XRay Sampler Internal Logic under a single ParentBased Sampler
2. Remove use of redundant ParentBased Sampler logic for internal subcomponents for XRay Sampler.

### Testing:
1. Added unit tests to verify ParentBased sampling decisions
3. Original Sampler functionality tested locally using [Sampler Test Bed](https://github.com/aws-observability/aws-otel-community/tree/master/centralized-sampling-tests)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

