### PR TITLE
[Logs] Workaround to avoid unwanted OTel log when OTEL_TRACES_SAMPLER = `xray`

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -104,7 +104,7 @@ export class AwsOpentelemetryConfigurator {
    * @constructor
    * @param {Instrumentation[]} instrumentations - Auto-Instrumentations to be added to the ADOT Config
    */
-  public constructor(instrumentations: Instrumentation[]) {
+  public constructor(instrumentations: Instrumentation[], useXraySampler: boolean = false) {
     /*
      * Set and Detect Resources via Resource Detectors
      *
@@ -167,7 +167,9 @@ export class AwsOpentelemetryConfigurator {
     // https://github.com/aws-observability/aws-otel-java-instrumentation/blob/a011b8cc29ee32b7f668c04ccfdf64cd30de467c/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsTracerCustomizerProvider.java#L36
     this.idGenerator = new AWSXRayIdGenerator();
 
-    this.sampler = AwsOpentelemetryConfigurator.customizeSampler(customBuildSamplerFromEnv(this.resource));
+    this.sampler = AwsOpentelemetryConfigurator.customizeSampler(
+      customBuildSamplerFromEnv(this.resource, useXraySampler)
+    );
 
     // default SpanProcessors with Span Exporters wrapped inside AwsMetricAttributesSpanExporter
     const awsSpanProcessorProvider: AwsSpanProcessorProvider = new AwsSpanProcessorProvider(this.resource);
@@ -291,37 +293,36 @@ export class AwsOpentelemetryConfigurator {
   }
 }
 
-export function customBuildSamplerFromEnv(resource: Resource): Sampler {
-  switch (process.env.OTEL_TRACES_SAMPLER) {
-    case 'xray': {
-      const samplerArgumentEnv: string | undefined = process.env.OTEL_TRACES_SAMPLER_ARG;
-      let endpoint: string | undefined = undefined;
-      let pollingInterval: number | undefined = undefined;
+export function customBuildSamplerFromEnv(resource: Resource, useXraySampler: boolean = false): Sampler {
+  if (useXraySampler || process.env.OTEL_TRACES_SAMPLER === 'xray') {
+    const samplerArgumentEnv: string | undefined = process.env.OTEL_TRACES_SAMPLER_ARG;
+    let endpoint: string | undefined = undefined;
+    let pollingInterval: number | undefined = undefined;
 
-      if (samplerArgumentEnv !== undefined) {
-        const args: string[] = samplerArgumentEnv.split(',');
-        for (const arg of args) {
-          const equalIndex: number = arg.indexOf('=');
-          if (equalIndex === -1) {
-            continue;
-          }
-          const keyValue: string[] = [arg.substring(0, equalIndex), arg.substring(equalIndex + 1)];
-          if (keyValue[0] === 'endpoint') {
-            endpoint = keyValue[1];
-          } else if (keyValue[0] === 'polling_interval') {
-            pollingInterval = Number(keyValue[1]);
-            if (isNaN(pollingInterval)) {
-              pollingInterval = undefined;
-              diag.error('polling_interval in OTEL_TRACES_SAMPLER_ARG must be a valid number');
-            }
+    if (samplerArgumentEnv !== undefined) {
+      const args: string[] = samplerArgumentEnv.split(',');
+      for (const arg of args) {
+        const equalIndex: number = arg.indexOf('=');
+        if (equalIndex === -1) {
+          continue;
+        }
+        const keyValue: string[] = [arg.substring(0, equalIndex), arg.substring(equalIndex + 1)];
+        if (keyValue[0] === 'endpoint') {
+          endpoint = keyValue[1];
+        } else if (keyValue[0] === 'polling_interval') {
+          pollingInterval = Number(keyValue[1]);
+          if (isNaN(pollingInterval)) {
+            pollingInterval = undefined;
+            diag.error('polling_interval in OTEL_TRACES_SAMPLER_ARG must be a valid number');
           }
         }
       }
-
-      diag.debug(`XRay Sampler Endpoint: ${endpoint}`);
-      diag.debug(`XRay Sampler Polling Interval: ${pollingInterval}`);
-      return new AwsXRayRemoteSampler({ resource: resource, endpoint: endpoint, pollingInterval: pollingInterval });
     }
+
+    diag.info('AWS XRay Sampler enabled');
+    diag.debug(`XRay Sampler Endpoint: ${endpoint}`);
+    diag.debug(`XRay Sampler Polling Interval: ${pollingInterval}`);
+    return new AwsXRayRemoteSampler({ resource: resource, endpoint: endpoint, pollingInterval: pollingInterval });
   }
 
   return buildSamplerFromEnv();


### PR DESCRIPTION
*Issue #, if available:*
Short-term workaround to avoid Upsteam OTel emitting logs such as:
- `OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".`

OTel dependencies will always load a default Sampler configuration. Although unused, that load process will read the `OTEL_TRACES_SAMPLER` value and may emit the above log, which is unwanted for `xray` value. `xray` does not yet exist in upstream OTel, but in ADOT, we define it as valid. Thus we temporarily remove this env var to avoid the unwanted log only if `xray` is set in that Env Var.

When `xray` sampler is available in upstream, this workaround should be removed.

*Description of changes:*
- Unset `process.env.OTEL_TRACES_SAMPLER` if equal to `xray`, then use boolean variable to enable `xray` sampler instead of Env Var. Restore Env Var value later.
- Add log to state that `AWS XRay Sampler enabled`, if enabled

*Testing:*
- Tested that the log `OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".` doesn't appear in this repo's sample app.

Before:
```
node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' sample-app-express-server.js
'pollingInterval' is undefined or too small. Defaulting to 300 seconds
OTEL_TRACES_EXPORTER is empty. Using default otlp exporter.
AWS Application Signals enabled.
AWS Application Signals metrics export interval capped to 60000
OTEL_LOGS_EXPORTER is empty. Using default otlp exporter.
OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".
Setting TraceProvider for instrumentations at the end of initialization
OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".
OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".
...
OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".
AWS Distro of OpenTelemetry automatic instrumentation started successfully
Listening for requests on http://localhost:8080
...
OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".
OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".
OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".
OTEL_TRACES_SAMPLER value "xray invalid, defaulting to always_on".
```

After:
```
node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' sample-app-express-server.js
AWS XRay Sampler enabled
'pollingInterval' is undefined or too small. Defaulting to 300 seconds
OTEL_TRACES_EXPORTER is empty. Using default otlp exporter.
AWS Application Signals enabled.
AWS Application Signals metrics export interval capped to 60000
OTEL_LOGS_EXPORTER is empty. Using default otlp exporter.
Setting TraceProvider for instrumentations at the end of initialization
AWS Distro of OpenTelemetry automatic instrumentation started successfully
Listening for requests on http://localhost:8080
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

