### PR TITLE
use public ecr images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Install ADOT nodejs instrumentation in the /operator-build folder
-FROM node:20 AS build
+FROM public.ecr.aws/docker/library/node:20 AS build
 
 # Build the ADOT JS SDK Tarball: aws-aws-distro-opentelemetry-node-autoinstrumentation-x.y.z.tgz
 WORKDIR /adot-js-build
@@ -18,7 +18,7 @@ RUN npm install aws-aws-distro-opentelemetry-node-autoinstrumentation-$(node -p 
 RUN npm install
 
 # Stage 2: Build the cp-utility binary
-FROM rust:1.75 as builder
+FROM public.ecr.aws/docker/library/rust:1.75 as builder
 
 WORKDIR /usr/src/cp-utility
 COPY ./tools/cp-utility .

--- a/contract-tests/images/applications/aws-sdk/Dockerfile
+++ b/contract-tests/images/applications/aws-sdk/Dockerfile
@@ -1,6 +1,5 @@
 # Use an official Node.js runtime as the base image
-FROM node:20-alpine
-#FROM node:20
+FROM public.ecr.aws/docker/library/node:20-alpine
 
 # Set the working directory inside the container
 WORKDIR /aws-sdk

--- a/contract-tests/images/applications/http/Dockerfile
+++ b/contract-tests/images/applications/http/Dockerfile
@@ -1,6 +1,5 @@
 # Use an official Node.js runtime as the base image
-FROM node:20-alpine
-#FROM node:20
+FROM public.ecr.aws/docker/library/node:20-alpine
 
 # Set the working directory inside the container
 WORKDIR /http

--- a/contract-tests/images/applications/mongodb/Dockerfile
+++ b/contract-tests/images/applications/mongodb/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as the base image
-FROM node:20-alpine
+FROM public.ecr.aws/docker/library/node:20-alpine
 
 # Set the working directory inside the container
 WORKDIR /mongodb

--- a/contract-tests/images/applications/mongoose/Dockerfile
+++ b/contract-tests/images/applications/mongoose/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as the base image
-FROM node:20-alpine
+FROM public.ecr.aws/docker/library/node:20-alpine
 #FROM node:20
 
 # Set the working directory inside the container

--- a/contract-tests/images/applications/mysql2/Dockerfile
+++ b/contract-tests/images/applications/mysql2/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as the base image
-FROM node:20-alpine
+FROM public.ecr.aws/docker/library/node:20-alpine
 
 # Set the working directory inside the container
 WORKDIR /mysql2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replace the docker hub images with public ECR images. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

