### PR TITLE
Propagate Lambda ResourceId or FaasId for the child spans

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/attribute-propagating-span-processor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/attribute-propagating-span-processor.test.ts
@@ -240,6 +240,44 @@ describe('AttributePropagatingSpanProcessorTest', () => {
     );
   });
 
+  it('testLambdaResourceIdAttributeExist', () => {
+    const parentSpan: APISpan = tracer.startSpan('parent', { kind: SpanKind.SERVER });
+
+    parentSpan.setAttribute(AwsSpanProcessingUtil.CLOUD_RESOURCE_ID, 'resource-123');
+
+    const childSpan: APISpan = createNestedSpan(parentSpan, 1);
+    expect((childSpan as any).attributes[AwsSpanProcessingUtil.CLOUD_RESOURCE_ID]).not.toBeUndefined();
+    expect((childSpan as any).attributes[AwsSpanProcessingUtil.CLOUD_RESOURCE_ID]).toEqual('resource-123');
+  });
+
+  it('testLambdaFaasIdAttributeExist', () => {
+    const parentSpan: APISpan = tracer.startSpan('parent', { kind: SpanKind.SERVER });
+
+    parentSpan.setAttribute('faas.id', 'faas-123');
+
+    const childSpan: APISpan = createNestedSpan(parentSpan, 1);
+    expect((childSpan as any).attributes['faas.id']).not.toBeUndefined();
+    expect((childSpan as any).attributes['faas.id']).toEqual('faas-123');
+  });
+
+  it('testBothLambdaFaasIdAndResourceIdAttributesExist', () => {
+    const parentSpan: APISpan = tracer.startSpan('parent', { kind: SpanKind.SERVER });
+
+    parentSpan.setAttribute('faas.id', 'faas-123');
+    parentSpan.setAttribute(AwsSpanProcessingUtil.CLOUD_RESOURCE_ID, 'resource-123');
+
+    const childSpan: APISpan = createNestedSpan(parentSpan, 1);
+    expect((childSpan as any).attributes[AwsSpanProcessingUtil.CLOUD_RESOURCE_ID]).not.toBeUndefined();
+    expect((childSpan as any).attributes[AwsSpanProcessingUtil.CLOUD_RESOURCE_ID]).toEqual('resource-123');
+  });
+
+  it('testLambdaNoneResourceAttributesExist', () => {
+    const parentSpan: APISpan = tracer.startSpan('parent', { kind: SpanKind.SERVER });
+
+    const childSpan: APISpan = createNestedSpan(parentSpan, 1);
+    expect((childSpan as any).attributes[AwsSpanProcessingUtil.CLOUD_RESOURCE_ID]).toBeUndefined();
+  });
+
   function createNestedSpan(parentSpan: APISpan, depth: number): APISpan {
     if (depth === 0) {
       return parentSpan;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
@@ -377,6 +377,36 @@ describe('AwsSpanProcessingUtilTest', () => {
     const actualOperation: string = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
     expect(actualOperation).toEqual('TestFunction/Handler');
   });
+
+  it('should return cloud.resource_id when present', () => {
+    spanDataMock.attributes[AwsSpanProcessingUtil.CLOUD_RESOURCE_ID] = 'cloud-123';
+    const result = AwsSpanProcessingUtil.getResourceId(spanDataMock);
+    expect(result).toBe('cloud-123');
+  });
+
+  it('should return faas.id when cloud.resource_id is not present', () => {
+    spanDataMock.attributes['faas.id'] = 'faas-123';
+    const result = AwsSpanProcessingUtil.getResourceId(spanDataMock);
+    expect(result).toBe('faas-123');
+  });
+
+  it('should return cloud.resource_id when both cloud.resource_id and faas.id are present', () => {
+    spanDataMock.attributes[AwsSpanProcessingUtil.CLOUD_RESOURCE_ID] = 'cloud-123';
+    spanDataMock.attributes['faas.id'] = 'faas-123';
+    const result = AwsSpanProcessingUtil.getResourceId(spanDataMock);
+    expect(result).toBe('cloud-123');
+  });
+
+  it('should return undefined when neither cloud.resource_id nor faas.id are present', () => {
+    const result = AwsSpanProcessingUtil.getResourceId(spanDataMock);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined if cloud.resource_id is not a string', () => {
+    spanDataMock.attributes[AwsSpanProcessingUtil.CLOUD_RESOURCE_ID] = 123; // Incorrect type
+    const result = AwsSpanProcessingUtil.getResourceId(spanDataMock);
+    expect(result).toBeUndefined();
+  });
 });
 
 function createMockSpanContext(): SpanContext {


### PR DESCRIPTION
*Description of changes:*
For Lambda case, the Lambda resource attribute only exists on Handler span, it needs to be propagated to its child spans.  This PR includes the changes,
1. if parent span contains `cloud.resource_id` or `faas.i` but not in child span, child span will be propagated with one of these attribute from parent. 
2. if both exist `cloud.resource_id` takes priority
3. if none of two Lambda resource attrs exists, do nothing.

*Test:*

**Hander Span**
```
2024-10-16T17:53:20.216Z | 'faas.id': 'arn:aws:lambda:us-west-1:889414516288:function:aws-opentelemetry-distro-nodejs',
-- | --
  | 2024-10-16T17:53:20.216Z | 'cloud.account.id': '889414516288',
  | 2024-10-16T17:53:20.216Z | 'aws.is.local.root': true,
  | 2024-10-16T17:53:20.216Z | 'aws.local.service': 'aws-opentelemetry-distro-nodejs',
  | 2024-10-16T17:53:20.216Z | 'aws.local.operation': 'aws-opentelemetry-distro-nodejs/Handler',
```
**Child Span**
```
  | 2024-10-16T17:53:20.194Z | attributes: {
-- | -- | --
  | 2024-10-16T17:53:20.194Z | 'rpc.system': 'aws-api',
  | 2024-10-16T17:53:20.194Z | 'rpc.method': 'ListBuckets',
  | 2024-10-16T17:53:20.194Z | 'rpc.service': 'S3',
  | 2024-10-16T17:53:20.194Z | 'aws.is.local.root': false,
  | 2024-10-16T17:53:20.194Z | 'faas.id': 'arn:aws:lambda:us-west-1:889414516288:function:aws-opentelemetry-distro-nodejs',
  | 2024-10-16T17:53:20.194Z | 'aws.local.operation': 'aws-opentelemetry-distro-nodejs/Handler',
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

