### PR TITLE
Update Lambda local.operation name

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
@@ -63,7 +63,7 @@ export class AwsSpanProcessingUtil {
       operation = AwsSpanProcessingUtil.INTERNAL_OPERATION;
     }
     if (isLambdaEnvironment()) {
-      operation = process.env[AWS_LAMBDA_FUNCTION_NAME_CONFIG] + '/Handler';
+      operation = process.env[AWS_LAMBDA_FUNCTION_NAME_CONFIG] + '/FunctionHandler';
     } else if (!AwsSpanProcessingUtil.isValidOperation(span, operation)) {
       operation = AwsSpanProcessingUtil.generateIngressOperation(span);
     }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
@@ -375,7 +375,7 @@ describe('AwsSpanProcessingUtilTest', () => {
     (spanDataMock as any).name = validName;
     (spanDataMock as any).kind = SpanKind.SERVER;
     const actualOperation: string = AwsSpanProcessingUtil.getIngressOperation(spanDataMock);
-    expect(actualOperation).toEqual('TestFunction/Handler');
+    expect(actualOperation).toEqual('TestFunction/FunctionHandler');
   });
 
   it('should return cloud.resource_id when present', () => {

--- a/lambda-layer/terraform/lambda/main.tf
+++ b/lambda-layer/terraform/lambda/main.tf
@@ -64,5 +64,5 @@ resource "aws_iam_role_policy_attachment" "hello-lambda-cloudwatch" {
 
 resource "aws_iam_role_policy_attachment" "test_xray" {
   role       = module.hello-lambda-function.lambda_function_name
-  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchLambdaApplicationSignalsExecutionRolePolicy"
 }


### PR DESCRIPTION
*Description of changes:*
* Update Lambda local operation name from `/Hander` to `FunctionHandler`
* Update sample app to use the new lambda managed policy`CloudWatchLambdaApplicationSignalsExecutionRolePolicy`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

