### PR TITLE
Remove Lambda Metric ForceFlush error msg

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/aws/services/aws-lambda.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/aws/services/aws-lambda.ts
@@ -10,8 +10,10 @@ import {
   InstrumentationNodeModuleFile,
   isWrapped,
 } from '@opentelemetry/instrumentation';
-import { diag } from '@opentelemetry/api';
+import { diag, Span, SpanStatusCode } from '@opentelemetry/api';
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 export class AwsLambdaInstrumentationPatch extends AwsLambdaInstrumentation {
   override init() {
     // Custom logic before calling the original implementation
@@ -116,5 +118,39 @@ export class AwsLambdaInstrumentationPatch extends AwsLambdaInstrumentation {
         ),
       ];
     }
+  }
+
+  // Override the upstream private _endSpan method to remove the unnecessary metric force-flush error message
+  // https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts#L358-L398
+  override _endSpan(span: Span, err: string | Error | null | undefined, callback: () => void) {
+    if (err) {
+      span.recordException(err);
+    }
+
+    let errMessage;
+    if (typeof err === 'string') {
+      errMessage = err;
+    } else if (err) {
+      errMessage = err.message;
+    }
+    if (errMessage) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: errMessage,
+      });
+    }
+
+    span.end();
+
+    const flushers = [];
+    if ((this as any)._traceForceFlusher) {
+      flushers.push((this as any)._traceForceFlusher());
+    } else {
+      diag.error(
+        'Spans may not be exported for the lambda function because we are not force flushing before callback.'
+      );
+    }
+
+    Promise.all(flushers).then(callback, callback);
   }
 }


### PR DESCRIPTION
*Description of changes:*
Remove the unnecessary Lambda Metric ForceFlush warning message which is not applicable to ADOT Lambda case

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

