### PR TITLE
use sync resource detectors

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -17,7 +17,7 @@ import { OTLPTraceExporter as OTLPProtoTraceExporter } from '@opentelemetry/expo
 import { ZipkinExporter } from '@opentelemetry/exporter-zipkin';
 import { AWSXRayIdGenerator } from '@opentelemetry/id-generator-aws-xray';
 import { Instrumentation } from '@opentelemetry/instrumentation';
-import { awsEc2Detector, awsEcsDetector, awsEksDetector } from '@opentelemetry/resource-detector-aws';
+import { awsEc2DetectorSync, awsEcsDetectorSync, awsEksDetectorSync } from '@opentelemetry/resource-detector-aws';
 import {
   Detector,
   DetectorSync,
@@ -126,7 +126,7 @@ export class AwsOpentelemetryConfigurator {
       // Add Env/AWS Resource Detectors if not present
       const resourceDetectorsFromEnv: string[] = process.env.OTEL_NODE_RESOURCE_DETECTORS.split(',');
       if (!resourceDetectorsFromEnv.includes('aws')) {
-        defaultDetectors.push(awsEc2Detector, awsEcsDetector, awsEksDetector);
+        defaultDetectors.push(awsEc2DetectorSync, awsEcsDetectorSync, awsEksDetectorSync);
       }
       if (!resourceDetectorsFromEnv.includes('env')) {
         defaultDetectors.push(envDetectorSync);
@@ -145,9 +145,9 @@ export class AwsOpentelemetryConfigurator {
       defaultDetectors = [
         processDetector,
         hostDetector,
-        awsEc2Detector,
-        awsEcsDetector,
-        awsEksDetector,
+        awsEc2DetectorSync,
+        awsEcsDetectorSync,
+        awsEksDetectorSync,
         envDetectorSync,
       ];
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Due to a [bug](https://github.com/open-telemetry/opentelemetry-js/pull/4687) in upstream, the `detectResourcesSync` doesn't wait for the async attributes. This happens if we use the async version of some resource detector. The [fix](https://github.com/open-telemetry/opentelemetry-js/pull/4687) is in another upstream release. We don't want to upgrade the upstream version for now. To avoid this issue, we switch to the sync version of the detectors and this should have no impact for the functionalities (as `detectResourcesSync` waits for all async detectors anyway and works for both sync and async detectors). In the future, even if we upgrade upstream version, we don't need to switch back to async detectors. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

