### PR TITLE
feat: Add Contract Tests for new Gen AI attributes for foundational models

### DIFF
--- a/contract-tests/images/applications/aws-sdk/server.js
+++ b/contract-tests/images/applications/aws-sdk/server.js
@@ -10,7 +10,6 @@ const { S3Client, CreateBucketCommand, PutObjectCommand, GetObjectCommand } = re
 const { DynamoDBClient, CreateTableCommand, PutItemCommand } = require('@aws-sdk/client-dynamodb');
 const { SQSClient, CreateQueueCommand, SendMessageCommand, ReceiveMessageCommand } = require('@aws-sdk/client-sqs');
 const { KinesisClient, CreateStreamCommand, PutRecordCommand } = require('@aws-sdk/client-kinesis');
-const fetch = require('node-fetch');
 const { BedrockClient, GetGuardrailCommand } = require('@aws-sdk/client-bedrock');
 const { BedrockAgentClient, GetKnowledgeBaseCommand, GetDataSourceCommand, GetAgentCommand } = require('@aws-sdk/client-bedrock-agent');
 const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime');
@@ -553,15 +552,17 @@ async function handleBedrockRequest(req, res, path) {
       });
       res.statusCode = 200;
     } else if (path.includes('invokemodel/invoke-model')) {
-      await withInjected200Success(bedrockRuntimeClient, ['InvokeModelCommand'], {}, async () => {
-        let modelId = ''
-        let body = {}
-        const userMessage = "Describe the purpose of a 'hello world' program in one line.";
-        const prompt = `<s>[INST] ${userMessage} [/INST]`;
-
-        if (path.includes('amazon.titan')) {
+        const get_model_request_response = function () {
+          const prompt = "Describe the purpose of a 'hello world' program in one line.";
+          let modelId = ''
+          let request_body = {}
+          let response_body = {}
+          
+          if (path.includes('amazon.titan')) {
+            
             modelId = 'amazon.titan-text-premier-v1:0';
-            body = JSON.stringify({
+
+            request_body = {
               inputText: prompt,
               textGenerationConfig: {
                 maxTokenCount: 3072,
@@ -569,12 +570,26 @@ async function handleBedrockRequest(req, res, path) {
                 temperature: 0.7,
                 topP: 0.9,
               },
-            });
-        }
+            };
 
-        if (path.includes('anthropic.claude')) {
+            response_body = {
+              inputTextTokenCount: 15,
+              results: [
+                {
+                  tokenCount: 13,
+                  outputText: 'text-test-response',
+                  completionReason: 'CONTENT_FILTERED',
+                },
+              ],
+            }
+
+          }
+
+          if (path.includes('anthropic.claude')) {
+            
             modelId = 'anthropic.claude-v2:1';
-            body = JSON.stringify({
+            
+            request_body = {
               anthropic_version: 'bedrock-2023-05-31',
               max_tokens: 1000,
               temperature: 0.99,
@@ -585,64 +600,120 @@ async function handleBedrockRequest(req, res, path) {
                   content: [{ type: 'text', text: prompt }],
                 },
               ],
-            });
-        }
+            };
 
-        if (path.includes('meta.llama')) {
-          modelId = 'meta.llama2-13b-chat-v1';
-          body = JSON.stringify({
-            prompt,
-            max_gen_len: 512,
-            temperature: 0.5,
-            top_p: 0.9
-          });
-        }
-
-        if (path.includes('cohere.command')) {
-          modelId = 'cohere.command-light-text-v14';
-          body = JSON.stringify({
-            prompt,
-            max_tokens: 512,
-            temperature: 0.5,
-            p: 0.65,
-          });
-        }
-
-        if (path.includes('ai21.jamba')) {
-          modelId = 'ai21.jamba-1-5-large-v1:0';
-          body = JSON.stringify({
-            messages: [
-              {
-                role: 'user',
-                content: prompt,
+            response_body = {
+              stop_reason: 'end_turn',
+              usage: {
+                input_tokens: 15,
+                output_tokens: 13,
               },
-            ],
-            top_p: 0.8,
-            temperature: 0.6,
-            max_tokens: 512,
-          });
-        }
+            }
+          }
 
-        if (path.includes('mistral.mistral')) {
-          modelId = 'mistral.mistral-7b-instruct-v0:2';
-          body = JSON.stringify({
-            prompt,
-            max_tokens: 4096,
-            temperature: 0.75,
-            top_p: 0.99,
-          });
-        }
+          if (path.includes('meta.llama')) {
+            modelId = 'meta.llama2-13b-chat-v1';
+            
+            request_body = {
+              prompt,
+              max_gen_len: 512,
+              temperature: 0.5,
+              top_p: 0.9
+            };
 
+            response_body = {
+              prompt_token_count: 31,
+              generation_token_count: 49,
+              stop_reason: 'stop'
+            }
+          }
+
+          if (path.includes('cohere.command')) {
+            modelId = 'cohere.command-light-text-v14';
+            
+            request_body = {
+              prompt,
+              max_tokens: 512,
+              temperature: 0.5,
+              p: 0.65,
+            };
+
+            response_body = {
+              generations: [
+                {
+                  finish_reason: 'COMPLETE',
+                  text: 'test-generation-text',
+                },
+              ],
+              prompt: prompt,
+            };
+          }
+  
+          if (path.includes('ai21.jamba')) {
+            modelId = 'ai21.jamba-1-5-large-v1:0';
+            
+            request_body = {
+              messages: [
+                {
+                  role: 'user',
+                  content: prompt,
+                },
+              ],
+              top_p: 0.8,
+              temperature: 0.6,
+              max_tokens: 512,
+            };
+
+            response_body = {
+              stop_reason: 'end_turn',
+              usage: {
+                prompt_tokens: 21,
+                completion_tokens: 24,
+              },
+              choices: [
+                {
+                  finish_reason: 'stop',
+                },
+              ],
+            }
+          }
+  
+          if (path.includes('mistral.mistral')) {
+            modelId = 'mistral.mistral-7b-instruct-v0:2';
+            
+            request_body = {
+              prompt,
+              max_tokens: 4096,
+              temperature: 0.75,
+              top_p: 0.99,
+            };
+
+            response_body = {
+              outputs: [
+                {
+                  text: 'test-output-text',
+                  stop_reason: 'stop',
+                },
+              ]
+            }
+          }
+          
+          return [modelId, JSON.stringify(request_body), new TextEncoder().encode(JSON.stringify(response_body))]
+        }
+        
+        const [modelId, request_body, response_body] = get_model_request_response();
+
+      await withInjected200Success(bedrockRuntimeClient, ['InvokeModelCommand'], { body: response_body }, async () => {          
         await bedrockRuntimeClient.send(
           new InvokeModelCommand({
-            body: body,
+            body: request_body,
             modelId: modelId,
             accept: 'application/json',
             contentType: 'application/json',
           })
         );
       });
-      
+
       res.statusCode = 200;
     } else {
       res.statusCode = 404;

--- a/contract-tests/images/applications/aws-sdk/server.js
+++ b/contract-tests/images/applications/aws-sdk/server.js
@@ -577,7 +577,7 @@ async function handleBedrockRequest(req, res, path) {
             body = JSON.stringify({
               anthropic_version: 'bedrock-2023-05-31',
               max_tokens: 1000,
-              temperature: 1.1,
+              temperature: 0.99,
               top_p: 1,
               messages: [
                 {
@@ -586,7 +586,52 @@ async function handleBedrockRequest(req, res, path) {
                 },
               ],
             });
-        }      
+        }
+
+        if (path.includes('meta.llama')) {
+          modelId = 'meta.llama2-13b-chat-v1';
+          body = JSON.stringify({
+            prompt,
+            max_gen_len: 512,
+            temperature: 0.5,
+            top_p: 0.9
+          });
+        }
+
+        if (path.includes('cohere.command')) {
+          modelId = 'cohere.command-light-text-v14';
+          body = JSON.stringify({
+            prompt,
+            max_tokens: 512,
+            temperature: 0.5,
+            p: 0.65,
+          });
+        }
+
+        if (path.includes('ai21.jamba')) {
+          modelId = 'ai21.jamba-1-5-large-v1:0';
+          body = JSON.stringify({
+            messages: [
+              {
+                role: 'user',
+                content: prompt,
+              },
+            ],
+            top_p: 0.8,
+            temperature: 0.6,
+            max_tokens: 512,
+          });
+        }
+
+        if (path.includes('mistral.mistral')) {
+          modelId = 'mistral.mistral-7b-instruct-v0:2';
+          body = JSON.stringify({
+            prompt,
+            max_tokens: 4096,
+            temperature: 0.75,
+            top_p: 0.99,
+          });
+        }
 
         await bedrockRuntimeClient.send(
           new InvokeModelCommand({

--- a/contract-tests/images/applications/aws-sdk/server.js
+++ b/contract-tests/images/applications/aws-sdk/server.js
@@ -648,6 +648,28 @@ async function handleBedrockRequest(req, res, path) {
               prompt: prompt,
             };
           }
+
+          if (path.includes('cohere.command-r')) {
+            modelId = 'cohere.command-r-v1:0';
+            
+            request_body = {
+              message: prompt,
+              max_tokens: 512,
+              temperature: 0.5,
+              p: 0.65,
+            };
+
+            response_body = {
+              finish_reason: 'COMPLETE',
+              text: 'test-generation-text',
+              prompt: prompt,
+              request: {
+                commandInput: {
+                  modelId: modelId,
+                },
+              },
+            }
+          }
   
           if (path.includes('ai21.jamba')) {
             modelId = 'ai21.jamba-1-5-large-v1:0';
@@ -678,7 +700,7 @@ async function handleBedrockRequest(req, res, path) {
             }
           }
   
-          if (path.includes('mistral.mistral')) {
+          if (path.includes('mistral')) {
             modelId = 'mistral.mistral-7b-instruct-v0:2';
             
             request_body = {
@@ -761,3 +783,4 @@ prepareAwsServer().then(() => {
     console.log('Ready');
   });
 });
+

--- a/contract-tests/tests/test/amazon/aws-sdk/aws_sdk_test.py
+++ b/contract-tests/tests/test/amazon/aws-sdk/aws_sdk_test.py
@@ -493,7 +493,35 @@ class AWSSDKTest(ContractTestBase):
                 },
             span_name="BedrockRuntime.InvokeModel"
         )
+    
+    def test_bedrock_runtime_invoke_model_cohere_command_r(self):
+        self.do_test_requests(
+            "bedrock/invokemodel/invoke-model/cohere.command-r-v1:0",
+            "GET",
+            200,
+            0,
+            0,
+            local_operation="GET /bedrock",
+            rpc_service="BedrockRuntime",
+            remote_service="AWS::BedrockRuntime",
+            remote_operation="InvokeModel",
+            remote_resource_type="AWS::Bedrock::Model",
+            remote_resource_identifier='cohere.command-r-v1:0',
+            request_specific_attributes={
+                _GEN_AI_REQUEST_MODEL: 'cohere.command-r-v1:0',
+                _GEN_AI_REQUEST_MAX_TOKENS: 512,
+                _GEN_AI_REQUEST_TEMPERATURE: 0.5,
+                _GEN_AI_REQUEST_TOP_P: 0.65
+                },
+            response_specific_attributes={
+                _GEN_AI_RESPONSE_FINISH_REASONS: ['COMPLETE'],
+                _GEN_AI_USAGE_INPUT_TOKENS: math.ceil(len("Describe the purpose of a 'hello world' program in one line.") / 6),
+                _GEN_AI_USAGE_OUTPUT_TOKENS: math.ceil(len("test-generation-text") / 6)
+                },
+            span_name="BedrockRuntime.InvokeModel"
+        )
 
+    # Delete once this model is fully deprecated on node
     def test_bedrock_runtime_invoke_model_cohere_command(self):
         self.do_test_requests(
             "bedrock/invokemodel/invoke-model/cohere.command-light-text-v14",

--- a/contract-tests/tests/test/amazon/aws-sdk/aws_sdk_test.py
+++ b/contract-tests/tests/test/amazon/aws-sdk/aws_sdk_test.py
@@ -447,12 +447,100 @@ class AWSSDKTest(ContractTestBase):
             request_specific_attributes={
                 _GEN_AI_REQUEST_MODEL: 'anthropic.claude-v2:1',
                 _GEN_AI_REQUEST_MAX_TOKENS: 1000,
-                _GEN_AI_REQUEST_TEMPERATURE: 1.1,
+                _GEN_AI_REQUEST_TEMPERATURE: 0.99,
                 _GEN_AI_REQUEST_TOP_P: 1
                 },
             span_name="BedrockRuntime.InvokeModel"
         )
 
+    def test_bedrock_runtime_invoke_model_meta_llama(self):
+        self.do_test_requests(
+            "bedrock/invokemodel/invoke-model/meta.llama2-13b-chat-v1",
+            "GET",
+            200,
+            0,
+            0,
+            local_operation="GET /bedrock",
+            rpc_service="BedrockRuntime",
+            remote_service="AWS::BedrockRuntime",
+            remote_operation="InvokeModel",
+            remote_resource_type="AWS::Bedrock::Model",
+            remote_resource_identifier='meta.llama2-13b-chat-v1',
+            request_specific_attributes={
+                _GEN_AI_REQUEST_MODEL: 'meta.llama2-13b-chat-v1',
+                _GEN_AI_REQUEST_MAX_TOKENS: 512,
+                _GEN_AI_REQUEST_TEMPERATURE: 0.5,
+                _GEN_AI_REQUEST_TOP_P: 0.9
+                },
+            span_name="BedrockRuntime.InvokeModel"
+        )
+
+    def test_bedrock_runtime_invoke_model_cohere_command(self):
+        self.do_test_requests(
+            "bedrock/invokemodel/invoke-model/cohere.command-light-text-v14",
+            "GET",
+            200,
+            0,
+            0,
+            local_operation="GET /bedrock",
+            rpc_service="BedrockRuntime",
+            remote_service="AWS::BedrockRuntime",
+            remote_operation="InvokeModel",
+            remote_resource_type="AWS::Bedrock::Model",
+            remote_resource_identifier='cohere.command-light-text-v14',
+            request_specific_attributes={
+                _GEN_AI_REQUEST_MODEL: 'cohere.command-light-text-v14',
+                _GEN_AI_REQUEST_MAX_TOKENS: 512,
+                _GEN_AI_REQUEST_TEMPERATURE: 0.5,
+                _GEN_AI_REQUEST_TOP_P: 0.65
+                },
+            span_name="BedrockRuntime.InvokeModel"
+        )
+
+    def test_bedrock_runtime_invoke_model_ai21_jamba(self):
+        self.do_test_requests(
+            "bedrock/invokemodel/invoke-model/ai21.jamba-1-5-large-v1:0",
+            "GET",
+            200,
+            0,
+            0,
+            local_operation="GET /bedrock",
+            rpc_service="BedrockRuntime",
+            remote_service="AWS::BedrockRuntime",
+            remote_operation="InvokeModel",
+            remote_resource_type="AWS::Bedrock::Model",
+            remote_resource_identifier='ai21.jamba-1-5-large-v1:0',
+            request_specific_attributes={
+                _GEN_AI_REQUEST_MODEL: 'ai21.jamba-1-5-large-v1:0',
+                _GEN_AI_REQUEST_MAX_TOKENS: 512,
+                _GEN_AI_REQUEST_TEMPERATURE: 0.6,
+                _GEN_AI_REQUEST_TOP_P: 0.8
+                },
+            span_name="BedrockRuntime.InvokeModel"
+        )
+    
+    def test_bedrock_runtime_invoke_model_mistral_mistral(self):
+        self.do_test_requests(
+            "bedrock/invokemodel/invoke-model/mistral.mistral-7b-instruct-v0:2",
+            "GET",
+            200,
+            0,
+            0,
+            local_operation="GET /bedrock",
+            rpc_service="BedrockRuntime",
+            remote_service="AWS::BedrockRuntime",
+            remote_operation="InvokeModel",
+            remote_resource_type="AWS::Bedrock::Model",
+            remote_resource_identifier='mistral.mistral-7b-instruct-v0:2',
+            request_specific_attributes={
+                _GEN_AI_REQUEST_MODEL: 'mistral.mistral-7b-instruct-v0:2',
+                _GEN_AI_REQUEST_MAX_TOKENS: 4096,
+                _GEN_AI_REQUEST_TEMPERATURE: 0.75,
+                _GEN_AI_REQUEST_TOP_P: 0.99
+                },
+            span_name="BedrockRuntime.InvokeModel"
+        )
+    
     def test_bedrock_get_guardrail(self):
         self.do_test_requests(
             "bedrock/getguardrail/get-guardrail",

--- a/contract-tests/tests/test/amazon/base/contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/contract_test_base.py
@@ -230,6 +230,12 @@ class ContractTestBase(TestCase):
         self.assertIsNotNone(actual_value)
         self.assertEqual(expected_value, actual_value.int_value)
 
+    def _assert_float_attribute(self, attributes_dict: Dict[str, AnyValue], key: str, expected_value: float) -> None:
+        self.assertIn(key, attributes_dict)
+        actual_value: AnyValue = attributes_dict[key]
+        self.assertIsNotNone(actual_value)
+        self.assertEqual(expected_value, actual_value.double_value)
+
     def check_sum(self, metric_name: str, actual_sum: float, expected_sum: float) -> None:
         if metric_name is LATENCY_METRIC:
             self.assertTrue(0 < actual_sum < expected_sum)


### PR DESCRIPTION
*Description of changes:*

 contract tests for new gen_ai inference parameter added in 

https://github.com/aws-observability/aws-otel-js-instrumentation/commit/e8c96ae1b98d87b48507e8b5ea93813c021ff464#diff-20c2ca1cb28cda6e03ec0cb986933b2abd103bee39995ad232cc2e8c2d23e4aaR368

<img width="1344" alt="image" src="https://github.com/user-attachments/assets/1d63b019-fe49-4222-9663-34e4f10d3d5b">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

