### PR TITLE
[Chore] Cleanup comment regarding OTLP Protocols

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -25,13 +25,10 @@ diag.setLogger(new DiagConsoleLogger(), opentelemetry.core.getEnv().OTEL_LOG_LEV
 /*
 Sets up default environment variables and apply patches
 
-Set default OTEL_EXPORTER_OTLP_PROTOCOL to be `http/protobuf`. This must be run before `configurator.configure()`, which will use this value to
-create an OTel Metric Exporter that is used for the customized AWS Span Procesors. The default value of OTEL_EXPORTER_OTLP_PROTOCOL should be `http/protobuf`:
+Set default OTEL_EXPORTER_OTLP_PROTOCOL to be `http/protobuf` to remain consistent with other ADOT languages. This must be run before
+`configurator.configure()`, which will use this value to create an OTel Metric Exporter that is used for the customized AWS Span Procesors.
+The default value of OTEL_EXPORTER_OTLP_PROTOCOL should be `http/protobuf`:
 https://github.com/open-telemetry/opentelemetry-js/blob/34003c9b7ef7e7e95e86986550d1c7fb6c1c56c6/packages/opentelemetry-core/src/utils/environment.ts#L233
-
-We are setting OTEL_EXPORTER_OTLP_PROTOCOL to HTTP to avoid any potential issues with gRPC. In the ADOT Python SDKs, gRPC did not not work out of the box for
-the vended docker image, due to gRPC having a strict dependency on the Python version the artifact was built for (OTEL observed this:
-https://github.com/open-telemetry/opentelemetry-operator/blob/461ba68e80e8ac6bf2603eb353547cd026119ed2/autoinstrumentation/python/requirements.txt#L2-L3)
 
 Also sets default OTEL_PROPAGATORS to ensure good compatibility with X-Ray and Application Signals.
 


### PR DESCRIPTION
*Issue #, if available:*
`gRPC` is the already default exporter as of the OTel JS version that we are dependent on (See: https://github.com/open-telemetry/opentelemetry-operator/issues/3412)
Closing as Python's issue with `gRPC` does not apply to NodeJS.

*Description of changes:*
Cleanup comment regarding OTLP Protocols


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

