### PR TITLE
Update rustc version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install aws-aws-distro-opentelemetry-node-autoinstrumentation-$(node -p 
 RUN npm install
 
 # Stage 2: Build the cp-utility binary
-FROM public.ecr.aws/docker/library/rust:1.75 as builder
+FROM public.ecr.aws/docker/library/rust:1.81 as builder
 
 WORKDIR /usr/src/cp-utility
 COPY ./tools/cp-utility .


### PR DESCRIPTION
*Description of changes:*
Bumping the version of rustc to 1.81 in our Dockerfile to fix any docker errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

