### PR TITLE
Added missing cloudformation attribute assertion in nova contract test

### DIFF
--- a/contract-tests/tests/test/amazon/aws-sdk/aws_sdk_test.py
+++ b/contract-tests/tests/test/amazon/aws-sdk/aws_sdk_test.py
@@ -480,6 +480,7 @@ class AWSSDKTest(ContractTestBase):
             remote_operation="InvokeModel",
             remote_resource_type="AWS::Bedrock::Model",
             remote_resource_identifier='amazon.nova-pro-v1:0',
+            cloudformation_primary_identifier="amazon.nova-pro-v1:0",
             request_specific_attributes={
                 _GEN_AI_REQUEST_MODEL: 'amazon.nova-pro-v1:0',
                 _GEN_AI_REQUEST_MAX_TOKENS: 800,


### PR DESCRIPTION
*Description of changes:*
Added missing cloudformation_primary_identifier assertion in Amazon nova contract test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

