### PR TITLE
Enable http instrumentations for lambda

### DIFF
--- a/lambda-layer/packages/layer/scripts/otel-instrument
+++ b/lambda-layer/packages/layer/scripts/otel-instrument
@@ -68,7 +68,7 @@ fi
 
 # - Set the propagators
 if [[ -z "$OTEL_PROPAGATORS" ]]; then
-  export OTEL_PROPAGATORS="xray,tracecontext,b3,b3multi"
+  export OTEL_PROPAGATORS="xray,tracecontext,baggage,b3,b3multi"
 fi
 
 # - Set Application Signals configuration

--- a/lambda-layer/packages/layer/scripts/otel-instrument
+++ b/lambda-layer/packages/layer/scripts/otel-instrument
@@ -68,7 +68,7 @@ fi
 
 # - Set the propagators
 if [[ -z "$OTEL_PROPAGATORS" ]]; then
-  export OTEL_PROPAGATORS="xray,baggage,tracecontext,b3,b3multi"
+  export OTEL_PROPAGATORS="xray,tracecontext,b3,b3multi"
 fi
 
 # - Set Application Signals configuration

--- a/lambda-layer/packages/layer/scripts/otel-instrument
+++ b/lambda-layer/packages/layer/scripts/otel-instrument
@@ -68,7 +68,7 @@ fi
 
 # - Set the propagators
 if [[ -z "$OTEL_PROPAGATORS" ]]; then
-  export OTEL_PROPAGATORS="xray,tracecontext,b3,b3multi"
+  export OTEL_PROPAGATORS="xray,baggage,tracecontext,b3,b3multi"
 fi
 
 # - Set Application Signals configuration

--- a/lambda-layer/packages/layer/scripts/otel-instrument
+++ b/lambda-layer/packages/layer/scripts/otel-instrument
@@ -68,7 +68,7 @@ fi
 
 # - Set the propagators
 if [[ -z "$OTEL_PROPAGATORS" ]]; then
-  export OTEL_PROPAGATORS="tracecontext,baggage,xray,b3,b3multi"
+  export OTEL_PROPAGATORS="xray,tracecontext,b3,b3multi"
 fi
 
 # - Set Application Signals configuration

--- a/lambda-layer/packages/layer/scripts/otel-instrument
+++ b/lambda-layer/packages/layer/scripts/otel-instrument
@@ -44,19 +44,19 @@ if [ -z "${OTEL_EXPORTER_OTLP_PROTOCOL}" ]; then
 fi
 
 # If both OTEL_NODE_ENABLED_INSTRUMENTATIONS and OTEL_NODE_DISABLED_INSTRUMENTATIONS are not configured,
-# set OTEL_NODE_ENABLED_INSTRUMENTATIONS="aws-sdk,aws-lambda"
+# set OTEL_NODE_ENABLED_INSTRUMENTATIONS="aws-sdk,aws-lambda,http"
 if [ -z "${OTEL_NODE_ENABLED_INSTRUMENTATIONS}" ] && [ -z "${OTEL_NODE_DISABLED_INSTRUMENTATIONS}" ]; then
-    export OTEL_NODE_ENABLED_INSTRUMENTATIONS="aws-sdk,aws-lambda"
+    export OTEL_NODE_ENABLED_INSTRUMENTATIONS="aws-sdk,aws-lambda,http"
 
 # Else if OTEL_NODE_ENABLED_INSTRUMENTATIONS is configured and OTEL_NODE_DISABLED_INSTRUMENTATIONS is not,
-# append OTEL_NODE_ENABLED_INSTRUMENTATIONS with "aws-lambda"
+# append OTEL_NODE_ENABLED_INSTRUMENTATIONS with "aws-lambda,http"
 elif [ -n "${OTEL_NODE_ENABLED_INSTRUMENTATIONS}" ] && [ -z "${OTEL_NODE_DISABLED_INSTRUMENTATIONS}" ]; then
-    export OTEL_NODE_ENABLED_INSTRUMENTATIONS="${OTEL_NODE_ENABLED_INSTRUMENTATIONS},aws-lambda"
+    export OTEL_NODE_ENABLED_INSTRUMENTATIONS="${OTEL_NODE_ENABLED_INSTRUMENTATIONS},aws-lambda,http"
 
 # Else if both OTEL_NODE_ENABLED_INSTRUMENTATIONS and OTEL_NODE_DISABLED_INSTRUMENTATIONS are configured,
-# append OTEL_NODE_ENABLED_INSTRUMENTATIONS with "aws-lambda"
+# append OTEL_NODE_ENABLED_INSTRUMENTATIONS with "aws-lambda,http"
 elif [ -n "${OTEL_NODE_ENABLED_INSTRUMENTATIONS}" ] && [ -n "${OTEL_NODE_DISABLED_INSTRUMENTATIONS}" ]; then
-    export OTEL_NODE_ENABLED_INSTRUMENTATIONS="${OTEL_NODE_ENABLED_INSTRUMENTATIONS},aws-lambda"
+    export OTEL_NODE_ENABLED_INSTRUMENTATIONS="${OTEL_NODE_ENABLED_INSTRUMENTATIONS},aws-lambda,http"
 
 # Else do nothing
 fi
@@ -68,7 +68,7 @@ fi
 
 # - Set the propagators
 if [[ -z "$OTEL_PROPAGATORS" ]]; then
-  export OTEL_PROPAGATORS="tracecontext,baggage,xray"
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray,b3,b3multi"
 fi
 
 # - Set Application Signals configuration


### PR DESCRIPTION
*Issue #, if available:*

Enabling Javascript http libraries in order to fix the broken xray propagation issue when calling downstream APIGW in Lambda layer.

Performance testing results: https://quip-amazon.com/asqwA9QvcfjI/Performance-Testing-Enabled-Instrumentations-in-Lambda-Layer

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

