### PR TITLE
UDPExporter should be useable when Application Signals is disabled on Lambda

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -188,35 +188,23 @@ export class AwsOpentelemetryConfigurator {
   }
 
   public configure(): Partial<NodeSDKConfiguration> {
-    let config: Partial<NodeSDKConfiguration>;
-    if (AwsOpentelemetryConfigurator.isApplicationSignalsEnabled()) {
-      // config.autoDetectResources is set to False, as the resources are detected and added to the
-      // resource ahead of time. The resource is needed to be populated ahead of time instead of letting
-      // the OTel Node SDK do the population work because the constructed resource was required to build
-      // the sampler (if using XRay sampler) and the AwsMetricAttributesSpanExporter and AwsSpanMetricsProcessor
-      config = {
-        instrumentations: this.instrumentations,
-        resource: this.resource,
-        idGenerator: this.idGenerator,
-        sampler: this.sampler,
-        // Error message 'Exporter "otlp" requested through environment variable is unavailable.'
-        // will appear from BasicTracerProvider that is used in the OTel JS SDK, even though the
-        // span processors are specified
-        // https://github.com/open-telemetry/opentelemetry-js/issues/3449
-        spanProcessors: this.spanProcessors,
-        autoDetectResources: false,
-        textMapPropagator: this.propagator,
-      };
-    } else {
-      // Default experience config
-      config = {
-        instrumentations: this.instrumentations,
-        resource: this.resource,
-        sampler: this.sampler,
-        idGenerator: this.idGenerator,
-        autoDetectResources: false,
-      };
-    }
+    // config.autoDetectResources is set to False, as the resources are detected and added to the
+    // resource ahead of time. The resource is needed to be populated ahead of time instead of letting
+    // the OTel Node SDK do the population work because the constructed resource was required to build
+    // the sampler (if using XRay sampler) and the AwsMetricAttributesSpanExporter and AwsSpanMetricsProcessor
+    const config: Partial<NodeSDKConfiguration> = {
+      instrumentations: this.instrumentations,
+      resource: this.resource,
+      idGenerator: this.idGenerator,
+      sampler: this.sampler,
+      // Error message 'Exporter "otlp" requested through environment variable is unavailable.'
+      // will appear from BasicTracerProvider that is used in the OTel JS SDK, even though the
+      // span processors are specified
+      // https://github.com/open-telemetry/opentelemetry-js/issues/3449
+      spanProcessors: this.spanProcessors,
+      autoDetectResources: false,
+      textMapPropagator: this.propagator,
+    };
 
     return config;
   }


### PR DESCRIPTION
*Issue #, if available:*
Currently, if AppSignals is disabled, UDP Span Exporter not usable in Lambda.

[According to this comment](https://github.com/aws-observability/aws-otel-js-instrumentation/blob/v0.5.0/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts#L440-L443), the correct logic should be:

>If isLambdaEnvironment is true, we will default to exporting OTel spans via udp_exporter, regardless of whether AppSignals is true or false.

Currently, this is not respected because when AppSignals is disabled, ADOT's otel config cannot use the UDPExporter
- Currently, the only difference between the `AppSignals enabled` and `AppSignals disabled` configurations is that in the "disabled" case, ADOT leaves the Span Exporter/Processor and textMapPropagator initialization work to the OTel JS SDK. Only in `AppSignals enabled` scenario, the configured UDPExporter is accessible.

*Description of changes:*
Update `configure()` to not depend on AppSignalsEnabled flag (always use the Span Exporter/Processor and textMapPropagator configurations made from the ADOT configurator)
- [Similarly to Python](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/v0.8.0/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py#L181), always use the ADOT configured Span Exporter/Processor, which is already configured based on the AppSignalsEnabled flag
- textMapPropagator configuration is still using [upstream's configuration](https://github.com/aws-observability/aws-otel-js-instrumentation/blob/v0.5.0/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts#L163) (includes the XRay Propagator)

*Testing:*
- Add Unit Test
- Test that spans are exported in Lambda when AppSignals is disabled

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

