### PR TITLE
Fix: Lambda Topology Issue

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-attribute-keys.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-attribute-keys.ts
@@ -9,6 +9,7 @@ export const AWS_ATTRIBUTE_KEYS: { [key: string]: string } = {
   AWS_LOCAL_SERVICE: 'aws.local.service',
   AWS_LOCAL_OPERATION: 'aws.local.operation',
   AWS_REMOTE_SERVICE: 'aws.remote.service',
+  AWS_REMOTE_ENVIRONMENT: 'aws.remote.environment',
   AWS_REMOTE_OPERATION: 'aws.remote.operation',
   AWS_REMOTE_RESOURCE_TYPE: 'aws.remote.resource.type',
   AWS_REMOTE_RESOURCE_IDENTIFIER: 'aws.remote.resource.identifier',

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-metric-attribute-generator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-metric-attribute-generator.test.ts
@@ -774,6 +774,16 @@ describe('AwsMetricAttributeGeneratorTest', () => {
     validateRemoteResourceAttributes('AWS::SecretsManager::Secret', 'testSecret');
     mockAttribute(AWS_ATTRIBUTE_KEYS.AWS_SECRETSMANAGER_SECRET_ARN, undefined);
 
+    // Validate behaviour of AWS_LAMBDA_FUNCTION_NAME and AWS_LAMBDA_FUNCTION_ARN
+    mockAttribute(AWS_ATTRIBUTE_KEYS.AWS_LAMBDA_FUNCTION_NAME, 'aws_lambda_function_name');
+    mockAttribute(
+      AWS_ATTRIBUTE_KEYS.AWS_LAMBDA_FUNCTION_ARN,
+      'arn:aws:lambda:us-east-1:123456789012:function:aws_lambda_function_name'
+    );
+    validateRemoteResourceAttributes('AWS::Lambda::Function', 'aws_lambda_function_name');
+    mockAttribute(AWS_ATTRIBUTE_KEYS.AWS_LAMBDA_FUNCTION_NAME, undefined);
+    mockAttribute(AWS_ATTRIBUTE_KEYS.AWS_LAMBDA_FUNCTION_ARN, undefined);
+
     // Validate behaviour of AWS_LAMBDA_RESOURCE_MAPPING_ID attribute then remove it.
     mockAttribute(AWS_ATTRIBUTE_KEYS.AWS_LAMBDA_RESOURCE_MAPPING_ID, 'aws_lambda_resource_mapping_id');
     validateRemoteResourceAttributes('AWS::Lambda::EventSourceMapping', 'aws_lambda_resource_mapping_id');


### PR DESCRIPTION
**Issue #, if available:**
Lambda Topology Issue Context: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/319

**Description of changes:**
- Apply fix for the Lambda Topology issue. The logic mimics the fix in our ADOT Python SDK.
- Adding back logic to generate `aws.lambda.function.name` and `aws.lambda.function.arn` span attributes for Lambda. Previously, we removed these changes in the AWS Resources expansion due to the Lambda Topology issue.
  - More context about adding support for Lambda as AWS Resource: 
    - https://github.com/aws-observability/aws-otel-python-instrumentation/pull/265

**Test plan:**

The same cases in the test plan of this [PR](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/319) were validated by building a custom JavaScript lambda layer. Below is a screenshot of all the test cases in a single topology. 

We can observe the following:
- Service entity node for `Invoke` call to downstream lambda.
- AWS Resource node for `GetFunction` call to downstream lambda.
- AWS Resource node for `ListBuckets` call to downstream s3.
- Another AWS Resource node for `GetBucketLocation` call to downstream s3.

<img width="1359" alt="Screenshot 2025-02-05 at 10 15 26 AM" src="https://github.com/user-attachments/assets/14d38cad-32c7-4e2c-a987-c424c7fb7296" />

Here we see downstream lambda called with `Invoke` is correctly treated as RemoteService entity when not instrumented:
![image](https://github.com/user-attachments/assets/7f1cfcec-8827-4dc7-beaf-2a1b9b98e4f4)

Additionally, I generated the spans locally to validate the new lambda instrumentation patch behaves correctly.

**Generated span for `Invoke` call**

We see the new `aws.remote.environment` attribute is present in span so the downstream lambda will be treated as a Service type in Application Signals backend.

<img width="1124" alt="invoke" src="https://github.com/user-attachments/assets/81cefb44-c951-4ad0-8aeb-9a2064d7d0ea" />


**Generated span for `GetFunction` call**

We see `aws.remote.resource.identifier` and `aws.cloudformation.primary.identifier` are set so the downstream lambda will be treated as an AWS resource type in Application Signals backend.

<img width="1124" alt="get-function" src="https://github.com/user-attachments/assets/abfd700b-7966-4d93-bb47-868c31be9a34" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

