### PR TITLE
remove lambda remote service override configuration

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-metric-attribute-generator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-metric-attribute-generator.ts
@@ -417,13 +417,13 @@ export class AwsMetricAttributeGenerator implements MetricAttributeGenerator {
         // This addresses a Lambda topology issue in Application Signals.
         // More context in PR: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/319
         //
-        // NOTE: The env vars LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE and
-        // LAMBDA_APPLICATION_SIGNALS_REMOTE_ENVIRONMENT were introduced as part of this fix.
-        // They are optional and allow users to override the default values if needed.
+        // NOTE: The env var LAMBDA_APPLICATION_SIGNALS_REMOTE_ENVIRONMENT was introduced as part of this fix.
+        // It is optional and allow users to override the default value if needed.
         if (AwsMetricAttributeGenerator.getRemoteOperation(span, SEMATTRS_RPC_METHOD) === 'Invoke') {
-          attributes[AWS_ATTRIBUTE_KEYS.AWS_REMOTE_SERVICE] =
-            process.env.LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE ||
-            span.attributes[AWS_ATTRIBUTE_KEYS.AWS_LAMBDA_FUNCTION_NAME];
+          attributes[AWS_ATTRIBUTE_KEYS.AWS_REMOTE_SERVICE] = AwsMetricAttributeGenerator.escapeDelimiters(
+            span.attributes[AWS_ATTRIBUTE_KEYS.AWS_LAMBDA_FUNCTION_NAME]
+          );
+
           attributes[AWS_ATTRIBUTE_KEYS.AWS_REMOTE_ENVIRONMENT] = `lambda:${
             process.env.LAMBDA_APPLICATION_SIGNALS_REMOTE_ENVIRONMENT || 'default'
           }`;


### PR DESCRIPTION
**Issue #, if available:**
If user decides to override `RemoteService value`, the Lambda Topology issue solution will not be able to support multiple downstream Lambdas.

For example, consider lambdaA calls both lambdaB and lambdaC. If the user overrides `LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE`, it will effectively hardcode the `RemoteService` value. As a result, we are left with an either/or situation where only one node will be connected to lambdaA in the topology depending on the hardcoded value. This issue is not present when the user does not override this `RemoteService` value because that attribute will dynamically take on whatever the lambda function name is.


My proposal is we remove the `LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE` env var. That is, we do not allow customers to override the `RemoteService` attribute value. This should not cause issues for customers to lose this configuration option. If the customer needs to change the downstream lambda service name, they can change the lambda function name itself rather than having to use an env var. 

**Description of changes:**
Removing option to override `RemoteService` attribute value.

**Test plan:**
Sanity e2e test by building custom lambda layer and ensuring the correct EMF Logs are still generated after change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

