### PR TITLE
fix deprecated github artifacts

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -72,7 +72,7 @@ jobs:
           aws s3 cp aws-distro-opentelemetry-node-autoinstrumentation/${{ steps.staging_tarball_output.outputs.STAGING_TARBALL }} s3://${{ env.STAGING_S3_BUCKET }}
 
       - name: Upload Tarball to GitHub Actions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.staging_tarball_output.outputs.STAGING_TARBALL}}
           path: aws-distro-opentelemetry-node-autoinstrumentation/${{ steps.staging_tarball_output.outputs.STAGING_TARBALL}}

--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -133,7 +133,7 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.LAYER_NAME }}
+          name: ${{ env.LAYER_NAME }}-${{ matrix.aws_region }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
       - name: clean s3
         if: always()
@@ -149,8 +149,9 @@ jobs:
       - name: download layerARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.LAYER_NAME }}
+          name: ${{ env.LAYER_NAME }}-*
           path: ${{ env.LAYER_NAME }}
+          merge-multiple: true
       - name: show layerARNs
         run: |
           for file in ${{ env.LAYER_NAME }}/*


### PR DESCRIPTION
*Issue #, if available:*
Github workflows are failing due to:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

A downstream effect of upgrading to `v4` is this version no longer allows uploading artifacts with same name.
See: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1014/files

*Description of changes:*
We apply the same fix in the above PR


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

