### PR TITLE
Fix: Deprecated artifacts follow up

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -34,7 +34,7 @@ jobs:
           role-to-assume: arn:aws:iam::637423224110:role/${{ secrets.STAGING_ARTIFACTS_ACCESS_ROLE_NAME }}
           aws-region: us-east-1
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.staging-instrumentation-name }}
 

--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -149,7 +149,7 @@ jobs:
       - name: download layerARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.LAYER_NAME }}-*
+          pattern: ${{ env.LAYER_NAME }}-*
           path: ${{ env.LAYER_NAME }}
           merge-multiple: true
       - name: show layerARNs


### PR DESCRIPTION
*Issue #, if available:*
The previous fix did not work because `download-artifacts@v3` is also deprecated and must be updated.
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/download-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

Previous fix: https://github.com/aws-observability/aws-otel-js-instrumentation/pull/152

*Description of changes:*
- Updating `download-artifacts@v3` to `v4`.
- Also fixing syntax error for name pattern.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

