### PR TITLE
Add `@opentelemetry/otlp-transformer` as direct dependency

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/package.json
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/package.json
@@ -103,6 +103,7 @@
     "@opentelemetry/id-generator-aws-xray": "1.2.2",
     "@opentelemetry/instrumentation": "0.53.0",
     "@opentelemetry/instrumentation-aws-sdk": "0.44.0",
+    "@opentelemetry/otlp-transformer": "0.53.0",
     "@opentelemetry/propagator-aws-xray": "1.26.0",
     "@opentelemetry/resource-detector-aws": "1.6.1",
     "@opentelemetry/resources": "1.26.0",


### PR DESCRIPTION
*Issue #, if available:*

`@opentelemetry/otlp-transformer`  should be a direct dependency because of it's usage in the package here:
- https://github.com/aws-observability/aws-otel-js-instrumentation/blob/v0.5.0/aws-distro-opentelemetry-node-autoinstrumentation/src/otlp-udp-exporter.ts#L7

Currently it is brought in as an indirect dependency from `@opentelemetry/sdk-node`, `@opentelemetry/exporter-trace-otlp-proto`, ...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

