### PR TITLE
Remove old SigV4 headers before signing

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -448,6 +448,7 @@ export class AwsSpanProcessorProvider {
         return new OTLPHttpTraceExporter();
       case 'http/protobuf':
         if (otlp_exporter_traces_endpoint && isXrayOtlpEndpoint(otlp_exporter_traces_endpoint)) {
+          diag.debug('Detected XRay OTLP Traces endpoint. Switching exporter to OtlpAwsSpanExporter');
           return new OTLPAwsSpanExporter(otlp_exporter_traces_endpoint);
         }
         return new OTLPProtoTraceExporter();
@@ -457,6 +458,7 @@ export class AwsSpanProcessorProvider {
       default:
         diag.warn(`Unsupported OTLP traces protocol: ${protocol}. Using http/protobuf.`);
         if (otlp_exporter_traces_endpoint && isXrayOtlpEndpoint(otlp_exporter_traces_endpoint)) {
+          diag.debug('Detected XRay OTLP Traces endpoint. Switching exporter to OtlpAwsSpanExporter');
           return new OTLPAwsSpanExporter(otlp_exporter_traces_endpoint);
         }
         return new OTLPProtoTraceExporter();
@@ -672,3 +674,4 @@ function isXrayOtlpEndpoint(otlpEndpoint: string | undefined) {
 }
 
 // END The OpenTelemetry Authors code
+

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -674,4 +674,3 @@ function isXrayOtlpEndpoint(otlpEndpoint: string | undefined) {
 }
 
 // END The OpenTelemetry Authors code
-

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/otlp-aws-span-exporter.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/otlp-aws-span-exporter.ts
@@ -96,9 +96,10 @@ export class OTLPAwsSpanExporter extends OTLPProtoTraceExporter {
   // Need to ensure old SigV4 headers do not remain when we inject new SigV4 authorization headers.
   private removeSigV4Headers(headers: Record<string, string>) {
     const newHeaders: Record<string, string> = {};
+    const sigV4Headers = ['x-amz-date', 'authorization', 'x-amz-content-sha256', 'x-amz-security-token'];
 
     for (const key in headers) {
-      if (!key.toLowerCase().startsWith('x-amz-') && key.toLowerCase() !== 'authorization') {
+      if (!sigV4Headers.includes(key.toLowerCase())) {
         newHeaders[key] = headers[key];
       }
     }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/otlp-aws-span-exporter.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/otlp-aws-span-exporter.ts
@@ -93,7 +93,7 @@ export class OTLPAwsSpanExporter extends OTLPProtoTraceExporter {
     await super.export(items, resultCallback);
   }
 
-  // Need to ensure old SigV4 headers do not remain when we inject new SigV4 authorization headers.
+  // Removes Sigv4 headers from old headers to avoid accidentally copying them to the new headers
   private removeSigV4Headers(headers: Record<string, string>) {
     const newHeaders: Record<string, string> = {};
     const sigV4Headers = ['x-amz-date', 'authorization', 'x-amz-content-sha256', 'x-amz-security-token'];

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/otlp-aws-span-exporter.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/otlp-aws-span-exporter.ts
@@ -139,4 +139,3 @@ export class OTLPAwsSpanExporter extends OTLPProtoTraceExporter {
     return newConfig;
   }
 }
-


### PR DESCRIPTION
*Description of changes:*
There was a bug where the old headers were not cleaned before the request was signed causing 403 errors to occur when exporting traces to XRay OTLP endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

