### PR TITLE
Add SigV4 release test to main build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -115,3 +115,13 @@ jobs:
     with:
       aws-region: us-east-1
       caller-workflow-name: 'main-build'
+
+  
+  adot-sigv4:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/node-ec2-adot-sigv4-test.yml@main
+    secrets: inherit
+    with:
+      node-version: 22
+      staging-instrumentation-name: ${{ inputs.staging-instrumentation-name }}
+      caller-workflow-name: 'main-build'


### PR DESCRIPTION
Follow up to: [aws-observability/aws-application-signals-test-framework #379](https://github.com/aws-observability/aws-application-signals-test-framework/pull/379)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

