### PR TITLE
Decouple SigV4 from Application Signals

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -240,10 +240,6 @@ export class AwsOpentelemetryConfigurator {
 
     spanProcessors.push(AttributePropagatingSpanProcessorBuilder.create().build());
 
-    if (isXrayOtlpEndpoint(process.env['OTEL_EXPORTER_OTLP_TRACES_ENDPOINT'])) {
-      return;
-    }
-
     const applicationSignalsMetricExporter: PushMetricExporter =
       ApplicationSignalsExporterProvider.Instance.createExporter();
     const periodicExportingMetricReader: PeriodicExportingMetricReader = new PeriodicExportingMetricReader({


### PR DESCRIPTION
*Description of changes:*
We do not want to automatically disable Application Signals if SigV4 is enabled. This PR allows Application Signals to run normally with SigV4.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

