### PR TITLE
Replace Console with bunyan logger in Sample App

### DIFF
--- a/sample-applications/simple-express-server/sample-app-express-server.js
+++ b/sample-applications/simple-express-server/sample-app-express-server.js
@@ -69,5 +69,5 @@ app.get('/aws-sdk-s3', async (req, res) => {
 });
 
 app.listen(PORT, () => {
-  logger.info(`Listening for requests on http://localhost:${PORT}`);
+  console.log(`Listening for requests on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
*Description of changes:*
There are currently no OTel supported logs being emitted from the sample-app.

Replaces sample-app logging with `bunyan` in order for OpenTelemetry to auto-instrument the logging library from the app.

/aws-sdk-s3:
```
{"name":"express-app","hostname":"ip-172-31-7-29.us-west-2.compute.internal","pid":2522078,"level":30,"msg":"done aws sdk s3 request","time":"2025-05-28T17:52:53.115Z","v":0}
{"name":"express-app","hostname":"ip-172-31-7-29.us-west-2.compute.internal","pid":2522078,"level":50,"msg":"Exception thrown: Invalid value \"undefined\" for header \"X-Amzn-Trace-Id\"","time":"2025-05-28T17:52:54.132Z","v":0}
```

/http:
```
{"name":"express-app","hostname":"ip-172-31-7-29.us-west-2.compute.internal","pid":2522078,"level":30,"msg":"random value from http request: [94]\n","time":"2025-05-28T17:54:09.786Z","v":0}
```
/rolldice:
```
{"name":"express-app","hostname":"ip-172-31-7-29.us-west-2.compute.internal","pid":2522987,"level":30,"msg":"rolldice: 1","time":"2025-05-28T17:54:52.830Z","v":0}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

