### PR TITLE
Check for undefined XRay Trace Id in AwsSdk Instrumentation 

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
@@ -311,9 +311,12 @@ function patchAwsSdkInstrumentation(instrumentation: Instrumentation): void {
             // Need to set capitalized version of the trace id to ensure that the Recursion Detection Middleware
             // of aws-sdk-js-v3 will detect the propagated X-Ray Context
             // See: https://github.com/aws/aws-sdk-js-v3/blob/v3.768.0/packages/middleware-recursion-detection/src/index.ts#L13
-            middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER_CAPITALIZED] =
-              middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER];
-            delete middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER];
+            const xray_trace_id = middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER];
+
+            if (xray_trace_id) {
+              middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER_CAPITALIZED] = xray_trace_id;
+              delete middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER];
+            }
             const result = await next(middlewareArgs);
             return result;
           },

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
@@ -38,6 +38,8 @@ import { AwsLambdaInstrumentation } from '@opentelemetry/instrumentation-aws-lam
 import type { Command as AwsV3Command } from '@aws-sdk/types';
 
 export const traceContextEnvironmentKey = '_X_AMZN_TRACE_ID';
+export const AWSXRAY_TRACE_ID_HEADER_CAPITALIZED = 'X-Amzn-Trace-Id';
+
 const awsPropagator = new AWSXRayPropagator();
 export const headerGetter: TextMapGetter<APIGatewayProxyEventHeaders> = {
   keys(carrier: any): string[] {
@@ -294,7 +296,6 @@ function patchAwsLambdaInstrumentation(instrumentation: Instrumentation): void {
 // Override the upstream private _getV3SmithyClientSendPatch method to add middleware to inject X-Ray Trace Context into HTTP Headers
 // https://github.com/open-telemetry/opentelemetry-js-contrib/blob/instrumentation-aws-sdk-v0.48.0/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts#L373-L384
 const awsXrayPropagator = new AWSXRayPropagator();
-const AWSXRAY_TRACE_ID_HEADER_CAPITALIZED = 'X-Amzn-Trace-Id';
 const V3_CLIENT_CONFIG_KEY = Symbol('opentelemetry.instrumentation.aws-sdk.client.config');
 type V3PluginCommand = AwsV3Command<any, any, any, any, any> & {
   [V3_CLIENT_CONFIG_KEY]?: any;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
@@ -311,10 +311,10 @@ function patchAwsSdkInstrumentation(instrumentation: Instrumentation): void {
             // Need to set capitalized version of the trace id to ensure that the Recursion Detection Middleware
             // of aws-sdk-js-v3 will detect the propagated X-Ray Context
             // See: https://github.com/aws/aws-sdk-js-v3/blob/v3.768.0/packages/middleware-recursion-detection/src/index.ts#L13
-            const xray_trace_id = middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER];
+            const xrayTraceId = middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER];
 
-            if (xray_trace_id) {
-              middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER_CAPITALIZED] = xray_trace_id;
+            if (xrayTraceId) {
+              middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER_CAPITALIZED] = xrayTraceId;
               delete middlewareArgs.request.headers[AWSXRAY_TRACE_ID_HEADER];
             }
             const result = await next(middlewareArgs);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
@@ -546,11 +546,6 @@ describe('InstrumentationPatchTest', () => {
       let mockedMiddlewareStackInternal: any;
       let mockedMiddlewareStack;
       let middlewareArgsHeader: any;
-
-      const send = extractAwsSdkInstrumentation(PATCHED_INSTRUMENTATIONS)
-        ['_getV3SmithyClientSendPatch']((...args: unknown[]) => Promise.resolve())
-        .bind({ middlewareStack: mockedMiddlewareStack });
-
       const testXrayTraceHeader = 'test-xray-trace-header';
 
       beforeEach(async () => {
@@ -559,6 +554,9 @@ describe('InstrumentationPatchTest', () => {
         mockedMiddlewareStack = {
           add: (arg1: any, arg2: any) => mockedMiddlewareStackInternal.push([arg1, arg2]),
         };
+        const send = extractAwsSdkInstrumentation(PATCHED_INSTRUMENTATIONS)
+          ['_getV3SmithyClientSendPatch']((...args: unknown[]) => Promise.resolve())
+          .bind({ middlewareStack: mockedMiddlewareStack });
 
         middlewareArgsHeader = {
           request: {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
@@ -565,13 +565,13 @@ describe('InstrumentationPatchTest', () => {
           },
         };
 
-        afterEach(() => {
-          sinon.restore();
-        });
-
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         await send({}, null);
+      });
+
+      afterEach(() => {
+        sinon.restore();
       });
 
       it('Updates trace header casing when AWSXRayPropagator injects trace header successfully', async () => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
@@ -12,9 +12,7 @@ import {
   Tracer,
   AttributeValue,
   TextMapSetter,
-  ROOT_CONTEXT,
   INVALID_SPAN_CONTEXT,
-  ContextAPI,
 } from '@opentelemetry/api';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { Instrumentation } from '@opentelemetry/instrumentation';

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
@@ -545,8 +545,12 @@ describe('InstrumentationPatchTest', () => {
     describe('overridden _getV3SmithyClientSendPatch updates MiddlewareStack', async () => {
       let mockedMiddlewareStackInternal: any;
       let mockedMiddlewareStack;
-      let send;
       let middlewareArgsHeader: any;
+
+      const send = extractAwsSdkInstrumentation(PATCHED_INSTRUMENTATIONS)
+        ['_getV3SmithyClientSendPatch']((...args: unknown[]) => Promise.resolve())
+        .bind({ middlewareStack: mockedMiddlewareStack });
+
       const testXrayTraceHeader = 'test-xray-trace-header';
 
       beforeEach(async () => {
@@ -555,9 +559,6 @@ describe('InstrumentationPatchTest', () => {
         mockedMiddlewareStack = {
           add: (arg1: any, arg2: any) => mockedMiddlewareStackInternal.push([arg1, arg2]),
         };
-        send = extractAwsSdkInstrumentation(PATCHED_INSTRUMENTATIONS)
-          ['_getV3SmithyClientSendPatch']((...args: unknown[]) => Promise.resolve())
-          .bind({ middlewareStack: mockedMiddlewareStack });
 
         middlewareArgsHeader = {
           request: {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
@@ -565,7 +565,7 @@ describe('InstrumentationPatchTest', () => {
         await send({}, null);
       });
 
-      it('Injecting with existing X-Ray header', async () => {
+      it('propagator injects with valid context', async () => {
         sinon
           .stub(AWSXRayPropagator.prototype, 'inject')
           .callsFake((context: OtelContext, carrier: unknown, setter: TextMapSetter) => {
@@ -584,7 +584,7 @@ describe('InstrumentationPatchTest', () => {
         expect(mockedMiddlewareStackInternal[0][1].name).toEqual('_adotInjectXrayContextMiddleware');
       });
 
-      it('Injecting without existing X-Ray header', async () => {
+      it('propagator does not inject with invalid context', async () => {
         const invalidContext = trace.setSpanContext(ROOT_CONTEXT, {
           traceId: 'invalid-trace-id',
           spanId: 'invalid-span',


### PR DESCRIPTION
*Issue #, if available:*

There is a bug where an undefined XRay Trace id is injected into the headers. However, this bug is difficult to reproduce:
![image](https://github.com/user-attachments/assets/8d2fdafb-60e3-4a3f-b59e-858183c8e47e)

The header in the export request to error out:
```
Failed to sign/authenticate the given exported Span request to OTLP XRay endpoint with error: TypeError [ERR_HTTP_INVALID_HEADER_VALUE]: Invalid value "undefined" for header "X-Amzn-Trace-Id"
```

However it's unclear whether or not this is the root-cause, for now we will add a null-safety check to mitigate any potential future bugs with this code.

*Description of changes:*
Added null check before injecting `AWSXRAY_TRACE_ID_HEADER`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

