### PR TITLE
Bump Rust Version in Dockerfile to 1.87

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install aws-aws-distro-opentelemetry-node-autoinstrumentation-$(node -p 
 RUN npm install
 
 # Stage 2: Build the cp-utility binary
-FROM public.ecr.aws/docker/library/rust:1.81 as builder
+FROM public.ecr.aws/docker/library/rust:1.87 as builder
 
 WORKDIR /usr/src/cp-utility
 COPY ./tools/cp-utility .


### PR DESCRIPTION
## What does this pull request do?
Proactively bumping rust version in our Dockerfile to 1.87 to align with our ADOT Python SDK repo: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/386

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

