### PR TITLE
[Genesis] Add Genesis release test to main build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -125,3 +125,12 @@ jobs:
       node-version: 22
       staging-instrumentation-name: ${{ inputs.staging-instrumentation-name }}
       caller-workflow-name: 'main-build'
+
+  adot-genesis:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/node-ec2-adot-genesis-test.yml@main
+    secrets: inherit
+    with:
+      node-version: 22
+      staging-instrumentation-name: ${{ inputs.staging-instrumentation-name }}
+      caller-workflow-name: 'main-build'


### PR DESCRIPTION
*Description of changes:*
Adding Genesis release test to main build, follow up to:
https://github.com/aws-observability/aws-application-signals-test-framework/pull/430

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

