### PR TITLE
Update AWS SDK middleware patch to use global propagator instead of X-Ray propagator

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/patches/instrumentation-patch.ts
@@ -295,7 +295,6 @@ function patchAwsLambdaInstrumentation(instrumentation: Instrumentation): void {
 
 // Override the upstream private _getV3SmithyClientSendPatch method to add middleware to inject X-Ray Trace Context into HTTP Headers
 // https://github.com/open-telemetry/opentelemetry-js-contrib/blob/instrumentation-aws-sdk-v0.48.0/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts#L373-L384
-const awsXrayPropagator = new AWSXRayPropagator();
 const V3_CLIENT_CONFIG_KEY = Symbol('opentelemetry.instrumentation.aws-sdk.client.config');
 type V3PluginCommand = AwsV3Command<any, any, any, any, any> & {
   [V3_CLIENT_CONFIG_KEY]?: any;
@@ -308,7 +307,7 @@ function patchAwsSdkInstrumentation(instrumentation: Instrumentation): void {
       return function send(this: any, command: V3PluginCommand, ...args: unknown[]): Promise<any> {
         this.middlewareStack?.add(
           (next: any, context: any) => async (middlewareArgs: any) => {
-            awsXrayPropagator.inject(otelContext.active(), middlewareArgs.request.headers, defaultTextMapSetter);
+            propagation.inject(otelContext.active(), middlewareArgs.request.headers, defaultTextMapSetter);
             // Need to set capitalized version of the trace id to ensure that the Recursion Detection Middleware
             // of aws-sdk-js-v3 will detect the propagated X-Ray Context
             // See: https://github.com/aws/aws-sdk-js-v3/blob/v3.768.0/packages/middleware-recursion-detection/src/index.ts#L13


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update AWS SDK middleware patch to use global propagator instead of X-Ray propagator

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

