### PR TITLE
enable manual triggering for main build

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "release/v*"
+  workflow_dispatch:
 
 env:
   AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
*Description of changes:*
Enable manual triggering for main build so that `Run workflow` button shows up under `Actions` tab for the workflow.

*Reference*
https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
