### PR TITLE
Revert "Add BedrockAgentCore release test to main build"

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -125,12 +125,3 @@ jobs:
       node-version: 22
       staging-instrumentation-name: ${{ inputs.staging-instrumentation-name }}
       caller-workflow-name: 'main-build'
-
-  adot-genesis:
-    needs: [ upload-main-build ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/node-ec2-adot-genesis-test.yml@main
-    secrets: inherit
-    with:
-      node-version: 22
-      staging-instrumentation-name: ${{ inputs.staging-instrumentation-name }}
-      caller-workflow-name: 'main-build'


### PR DESCRIPTION
Reverts aws-observability/aws-otel-js-instrumentation#219 (temporarily) since the `aws-application-signals-test-framework` does not contain `node-ec2-adot-genesis-test.yml` as of now.