### PR TITLE
Add main build validation for release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,9 +29,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check main build status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           WORKFLOW_ID=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | select(.name=="NodeJS Instrumentation Main Build") | .id')
-          LATEST_RUN=$(gh api repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs --jq '.workflow_runs[] | select(.head_branch=="${{ github.ref_name }}") | {conclusion, status}' | head -1)
+          LATEST_RUN=$(gh api repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs --jq '[.workflow_runs[] | select(.head_branch=="${{ github.ref_name }}")] | sort_by(.created_at) | reverse | .[0] | {conclusion, status}')
           STATUS=$(echo "$LATEST_RUN" | jq -r '.status')
           CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
           
@@ -43,8 +45,6 @@ jobs:
             exit 1
           fi
           echo "Main build succeeded, proceeding with release"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Build Tarball and Image Files
         uses: ./.github/actions/artifacts_build

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,7 +21,20 @@ permissions:
   contents: write
 
 jobs:
+  wait-for-main-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for main-build workflow to succeed
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'NodeJS Instrumentation Main Build'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+          allowed-conclusions: success
+
   build:
+    needs: wait-for-main-build
     environment: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           WORKFLOW_ID=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | select(.name=="NodeJS Instrumentation Main Build") | .id')
-          LATEST_RUN=$(gh api repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs --jq '[.workflow_runs[] | select(.head_branch=="${{ github.ref_name }}")] | sort_by(.created_at) | reverse | .[0] | {conclusion, status}')
+          LATEST_RUN=$(gh api repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs --jq '[.workflow_runs[] | select(.head_branch=="${{ github.ref_name }}")] | sort_by(.created_at) | .[-1] | {conclusion, status}')
           STATUS=$(echo "$LATEST_RUN" | jq -r '.status')
           CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
           

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,25 +21,30 @@ permissions:
   contents: write
 
 jobs:
-  wait-for-main-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for E2E test to succeed
-        uses: ezhang6811/wait-on-check-action@6275ea93847ce5952ab8ceeac8fb1111820cf44d
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Application Signals E2E Test'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-          allowed-conclusions: success
-
   build:
-    needs: wait-for-main-build
     environment: Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
+
+      - name: Check main build status
+        run: |
+          WORKFLOW_ID=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | select(.name=="NodeJS Instrumentation Main Build") | .id')
+          LATEST_RUN=$(gh api repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs --jq '.workflow_runs[] | select(.head_branch=="${{ github.ref_name }}") | {conclusion, status}' | head -1)
+          STATUS=$(echo "$LATEST_RUN" | jq -r '.status')
+          CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
+          
+          if [ "$STATUS" = "in_progress" ] || [ "$STATUS" = "queued" ]; then
+            echo "Main build is still running (status: $STATUS). Cannot proceed with release."
+            exit 1
+          elif [ "$CONCLUSION" != "success" ]; then
+            echo "Latest main build on branch ${{ github.ref_name }} conclusion: $CONCLUSION"
+            exit 1
+          fi
+          echo "Main build succeeded, proceeding with release"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Build Tarball and Image Files
         uses: ./.github/actions/artifacts_build

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -24,7 +24,7 @@ jobs:
   wait-for-main-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for main-build workflow to succeed
+      - name: Wait for E2E test to succeed
         uses: ezhang6811/wait-on-check-action@master
         with:
           ref: ${{ github.ref }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for main-build workflow to succeed
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: ezhang6811/wait-on-check-action@master
         with:
           ref: ${{ github.ref }}
-          check-name: 'NodeJS Instrumentation Main Build'
+          check-name: 'Application Signals E2E Test'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
           allowed-conclusions: success

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for E2E test to succeed
-        uses: ezhang6811/wait-on-check-action@master
+        uses: ezhang6811/wait-on-check-action@6275ea93847ce5952ab8ceeac8fb1111820cf44d
         with:
           ref: ${{ github.ref }}
           check-name: 'Application Signals E2E Test'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR modifies the release build workflow to wait for the main build workflow in the same branch to complete successfully. before proceeding with the release. see [Python PR](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/443) for more details and testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

