### PR TITLE
Send main build metrics

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -104,3 +104,24 @@ jobs:
     with:
       staging-instrumentation-name: ${{ needs.build.outputs.staging_tarball_file }}
       adot-image-name: ${{ needs.build.outputs.staging_registry }}/aws-observability/adot-autoinstrumentation-node-staging:${{ needs.build.outputs.node_image_tag }}
+
+  publish-main-build-status:
+    name: "Publish Main Build Status"
+    needs: [ build, application-signals-e2e-test ]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Configure AWS Credentials for emitting metrics
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.MONITORING_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Publish main build status
+        run: |
+          success="${{ needs.build.result == 'success' && needs.application-signals-e2e-test.result == 'success' }}"
+          value="${success}" == "true" && "0.0" || "1.0"
+          aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
+            --metric-name Failure \
+            --dimensions repository=${{ github.repository }},workflow=main_build \
+            --value $value

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -123,5 +123,5 @@ jobs:
           value="${success}" == "true" && "0.0" || "1.0"
           aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
-            --dimensions repository=${{ github.repository }},workflow=main_build \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \
             --value $value

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "release/v*"
+      - "zhaez/*"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -120,8 +120,7 @@ jobs:
 
       - name: Publish main build status
         run: |
-          success="${{ needs.build.result == 'success' && needs.application-signals-e2e-test.result == 'success' }}"
-          value="${success}" == "true" && "0.0" || "1.0"
+          value="${{ needs.build.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0'}}"
           aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - "release/v*"
-      - "zhaez/*"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Emit a failure metric if main build fails. Since this workflow is triggered with pushes to main or a release branch, we want to be notified if there is a failure with the build process or e2e tests.

Tested by temporarily adding an `on: push:` trigger to my own branch in this repo and testing the updated workflow. Verified that failure metric was successfully published to cloudwatch.
https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/16764243839

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

