### PR TITLE
Add Image Scan to PR Build

### DIFF
--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -80,6 +80,15 @@ runs:
       env:
         AWS_REGION: ${{ inputs.aws-region }}
 
+    # Per https://docs.aws.amazon.com/AmazonECR/latest/public/docker-pull-ecr-image.html, it is possible to
+    # make unauthorized calls to get public ECR images (needed to build the ADOT Node docker image), but
+    # it can fail if you previously authenticated to a public repo. Adding this step to log out, so we
+    # ensure we can make unauthenticated call. This is important for making the pr_build workflow run on
+    # PRs created from forked repos.
+    - name: Logout of public AWS ECR
+      shell: bash
+      run: docker logout public.ecr.aws
+
     - name: Build and push image according to input
       uses: docker/build-push-action@v5
       with:

--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -80,15 +80,6 @@ runs:
       env:
         AWS_REGION: ${{ inputs.aws-region }}
 
-    # Per https://docs.aws.amazon.com/AmazonECR/latest/public/docker-pull-ecr-image.html, it is possible to
-    # make unauthorized calls to get public ECR images (needed to build the ADOT Node docker image), but
-    # it can fail if you previously authenticated to a public repo. Adding this step to log out, so we
-    # ensure we can make unauthenticated call. This is important for making the pr_build workflow run on
-    # PRs created from forked repos.
-    - name: Logout of public AWS ECR
-      shell: bash
-      run: docker logout public.ecr.aws
-
     - name: Build and push image according to input
       uses: docker/build-push-action@v5
       with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,6 +38,15 @@ jobs:
         run: npm ci
       - name: Compile all NPM projects
         run: npm run compile
+      - name: Build Tarball and Image Files
+        uses: ./.github/actions/artifacts_build
+        with:
+          image_uri_with_tag: pr-build/${{ matrix.node }}
+          push_image: false
+          load_image: true
+          node_version: ${{ matrix.node }}
+          package_name: aws-distro-opentelemetry-node-autoinstrumentation
+          os: ubuntu-latest
       - name: Build Lambda Layer
         run: npm run build-lambda
       - name: Unit tests (Full)


### PR DESCRIPTION
*Description of changes:*
- Adding `artifacts_build` step to `pr-build` workflow for JS images to get vulnerability scanning during PR builds. 
See the same for [Java](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/.github/workflows/pr-build.yml#L145) and [Python](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/.github/workflows/pr-build.yml#L23)

- Delete duplicate `docker logout` step in artifact_build. Doesn't effect PR builds from forked repos:
https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/16950181911/job/48040937542?pr=251

*Testing*
Successful run: https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/16949767942

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

