### PR TITLE
Pin AWS SDK version in lambda layer sample app to fix build

### DIFF
--- a/lambda-layer/sample-apps/aws-sdk/package.json
+++ b/lambda-layer/sample-apps/aws-sdk/package.json
@@ -51,6 +51,6 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.651.1"
+    "@aws-sdk/client-s3": "3.651.1"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fix failing build: https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/17474640162

*Description of changes:*
Pin AWS SDK version in lambda layer sample app

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

