### PR TITLE
Updating 3p actions from VID to CSHA

### DIFF
--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - name: Configure AWS Credentials
       if: ${{ inputs.push_image == true || inputs.push_image == 'true' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
       with:
         role-to-assume: ${{ inputs.snapshot-ecr-role }}
         aws-region: ${{ inputs.aws-region }}
@@ -67,14 +67,14 @@ runs:
         npm pack
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #3.6.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
 
     - name: Login to private AWS ECR
       if: ${{ inputs.push_image == true || inputs.push_image == 'true' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
       with:
         registry: ${{ inputs.image_registry }}
       env:
@@ -90,7 +90,7 @@ runs:
       run: docker logout public.ecr.aws
 
     - name: Build and push image according to input
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
       with:
         push: ${{ inputs.push_image }}
         context: .

--- a/.github/actions/lambda_artifacts_build/action.yml
+++ b/.github/actions/lambda_artifacts_build/action.yml
@@ -24,7 +24,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download Tarball to GitHub Actions
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
       with:
         name: ${{ inputs.staging_tarball}}
         path: ./aws-distro-opentelemetry-node-autoinstrumentation/

--- a/.github/actions/set_up/action.yml
+++ b/.github/actions/set_up/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
       with:
         node-version: ${{ inputs.node_version }}
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: arn:aws:iam::637423224110:role/${{ secrets.STAGING_ARTIFACTS_ACCESS_ROLE_NAME }}
           aws-region: us-east-1
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           name: ${{ inputs.staging-instrumentation-name }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,11 +55,11 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@16df4fbc19aea13d921737861d6c622bf3cefe23 #v3.30.3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@16df4fbc19aea13d921737861d6c622bf3cefe23 #v3.30.3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -26,23 +26,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo for dependency scan
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
         with:
           node-version: "20"
 
       - name: Configure AWS credentials for dependency scan
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Get NVD API key for dependency scan
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 #v2.0.10
         id: nvd_api_key
         with:
           secret-ids: ${{ secrets.NVD_API_KEY_SECRET_ARN }}
@@ -70,13 +70,13 @@ jobs:
         run: less dependency-check-report.html
       
       - name: Configure AWS credentials for image scan
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Login to Public ECR
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
         with:
           registry: public.ecr.aws
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Configure AWS Credentials for emitting metrics
         if: always()
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.MONITORING_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -33,7 +33,7 @@ jobs:
       staging_tarball_file: ${{ steps.staging_tarball_output.outputs.STAGING_TARBALL}}
     steps:
       - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Get Node Distro Output
         id: node_output
@@ -73,7 +73,7 @@ jobs:
           aws s3 cp aws-distro-opentelemetry-node-autoinstrumentation/${{ steps.staging_tarball_output.outputs.STAGING_TARBALL }} s3://${{ env.STAGING_S3_BUCKET }}
 
       - name: Upload Tarball to GitHub Actions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: ${{ steps.staging_tarball_output.outputs.STAGING_TARBALL}}
           path: aws-distro-opentelemetry-node-autoinstrumentation/${{ steps.staging_tarball_output.outputs.STAGING_TARBALL}}
@@ -112,7 +112,7 @@ jobs:
     if: always()
     steps:
       - name: Configure AWS Credentials for emitting metrics
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.MONITORING_ROLE_ARN }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,11 +23,11 @@ jobs:
       NPM_CONFIG_UNSAFE_PERM: true
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
         with:
           node-version: ${{ matrix.node }}
       - name: Update npm to a version that supports workspaces (v7 or later)
@@ -53,14 +53,14 @@ jobs:
         run: npm run test:coverage
       - name: Report Coverage
         if: ${{ matrix.code-coverage && !cancelled()}}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 #v5.5.1
         with:
           verbose: true
 
   contract-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
       - name: run contract tests
         run: |
           bash ./scripts/build_and_install_distro.sh
@@ -71,8 +71,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
         with:
           node-version: 18
           cache: 'npm'


### PR DESCRIPTION
This pr updates non-release workflows and actions 3p actions using version ID to use commit SHA.

References:
https://github.com/aws-actions/configure-aws-credentials     
https://github.com/actions/download-artifact
https://github.com/github/codeql-action
https://github.com/aws-actions/aws-secretsmanager-get-secrets
https://github.com/docker/login-action
https://github.com/actions/upload-artifact
https://github.com/docker/setup-buildx-action
https://github.com/docker/setup-qemu-action
https://github.com/actions/download-artifact
https://github.com/docker/build-push-action
https://github.com/github/codeql-action
https://github.com/docker/setup-buildx-action
https://github.com/codecov/codecov-action
https://github.com/actions/setup-node


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

