### PR TITLE
 feat: add self-validating workflow gate jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,3 +90,38 @@ jobs:
       uses: github/codeql-action/analyze@16df4fbc19aea13d921737861d6c622bf3cefe23 #v2.23.0
       with:
         category: "/language:${{matrix.language}}"
+
+  all-codeql-checks-pass:
+    runs-on: ubuntu-latest
+    needs: [analyze]
+    if: always()
+    steps:
+      - name: Checkout to get workflow file
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+
+      - name: Check all jobs succeeded and none missing
+        run: |
+          # Check if all needed jobs succeeded
+          results='${{ toJSON(needs) }}'
+          if echo "$results" | jq -r '.[] | .result' | grep -v success; then
+            echo "Some jobs failed"
+            exit 1
+          fi
+          
+          # Extract all job names from workflow (excluding this gate job)
+          all_jobs=$(yq eval '.jobs | keys | .[]' .github/workflows/codeql.yml | grep -v "all-codeql-checks-pass" | sort)
+          
+          # Extract job names from needs array
+          needed_jobs='${{ toJSON(needs) }}'
+          needs_list=$(echo "$needed_jobs" | jq -r 'keys[]' | sort)
+          
+          # Check if any jobs are missing from needs
+          missing_jobs=$(comm -23 <(echo "$all_jobs") <(echo "$needs_list"))
+          if [ -n "$missing_jobs" ]; then
+            echo "ERROR: Jobs missing from needs array in all-codeql-checks-pass:"
+            echo "$missing_jobs"
+            echo "Please add these jobs to the needs array of all-codeql-checks-pass"
+            exit 1
+          fi
+          
+          echo "All CodeQL checks passed and no jobs missing from gate!"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -143,3 +143,38 @@ jobs:
           npm run lint
           npm run lint:markdown
           npm run lint:readme
+
+  all-pr-checks-pass:
+    runs-on: ubuntu-latest
+    needs: [static-code-checks, contract-test, lint, build]
+    if: always()
+    steps:
+      - name: Checkout to get workflow file
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+
+      - name: Check all jobs succeeded and none missing
+        run: |
+          # Check if all needed jobs succeeded
+          results='${{ toJSON(needs) }}'
+          if echo "$results" | jq -r '.[] | .result' | grep -v success; then
+            echo "Some jobs failed"
+            exit 1
+          fi
+          
+          # Extract all job names from workflow (excluding this gate job)
+          all_jobs=$(yq eval '.jobs | keys | .[]' .github/workflows/pr-build.yml | grep -v "all-pr-checks-pass" | sort)
+          
+          # Extract job names from needs array
+          needed_jobs='${{ toJSON(needs) }}'
+          needs_list=$(echo "$needed_jobs" | jq -r 'keys[]' | sort)
+          
+          # Check if any jobs are missing from needs
+          missing_jobs=$(comm -23 <(echo "$all_jobs") <(echo "$needs_list"))
+          if [ -n "$missing_jobs" ]; then
+            echo "ERROR: Jobs missing from needs array in all-pr-checks-pass:"
+            echo "$missing_jobs"
+            echo "Please add these jobs to the needs array of all-pr-checks-pass"
+            exit 1
+          fi
+          
+          echo "All checks passed and no jobs missing from gate!"


### PR DESCRIPTION
Add gate jobs that fail if any workflow job fails OR if any job is missing from the gate's needs array. Prevents both job failures and configuration drift when adding new workflow jobs. Callout: I don't think it's possible to have one gate for both workflows, but it should not be the case that we add more over time.

### Testing:
See: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/477

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

