### PR TITLE
Add nightly dependency bump workflow

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "release/v*"
+      - nightly-dependency-updates
   workflow_dispatch:
 
 env:
@@ -109,7 +110,7 @@ jobs:
     name: "Publish Main Build Status"
     needs: [ build, application-signals-e2e-test ]
     runs-on: ubuntu-latest
-    if: always()
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
     steps:
       - name: Configure AWS Credentials for emitting metrics
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,70 @@
+name: Nightly Upstream Snapshot Build
+
+on:
+  schedule:
+    - cron: "21 3 * * *"
+  workflow_dispatch:
+
+env:
+  BRANCH_NAME: nightly-dependency-updates
+
+jobs:
+  update-and-create-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check_changes.outputs.has_changes }}
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Check if nightly branch already exists
+      run: |
+        if git ls-remote --exit-code --heads origin "$BRANCH_NAME"; then
+          echo "Branch $BRANCH_NAME already exists. Skipping run to avoid conflicts."
+          echo "Please merge or close the existing PR before the next nightly run."
+          exit 1
+        fi
+    
+    - name: Configure git and create branch
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git checkout -b "$BRANCH_NAME"
+    
+    - name: Set up Node.js
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
+      with:
+        node-version: '18'
+    
+    - name: Install dependencies
+      run: npm install
+    
+    - name: Update dependencies
+      run: node scripts/update_dependencies.js
+    
+    - name: Check for changes and create PR
+      id: check_changes
+      run: |
+        if git diff --quiet; then
+          echo "No dependency updates needed"
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+        else
+          echo "Dependencies were updated"
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+          
+          git add aws-distro-opentelemetry-node-autoinstrumentation/package.json
+          git commit -m "chore: update OpenTelemetry dependencies to latest versions"
+          git push origin "$BRANCH_NAME"
+          
+          gh pr create \
+            --title "Nightly dependency update: OpenTelemetry packages to latest versions" \
+            --body "Automated update of OpenTelemetry dependencies to their latest available versions." \
+            --base main \
+            --head "$BRANCH_NAME"
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/update_dependencies.js
+++ b/scripts/update_dependencies.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+async function getLatestVersion(packageName) {
+  const https = require('https');
+  
+  return new Promise((resolve, reject) => {
+    const url = `https://registry.npmjs.org/${packageName}/latest`;
+    const request = https.get(url, { timeout: 30000 }, (response) => {
+      let data = '';
+      response.on('data', (chunk) => data += chunk);
+      response.on('end', () => {
+        try {
+          if (response.statusCode === 200) {
+            const packageData = JSON.parse(data);
+            resolve(packageData.version);
+          } else {
+            console.warn(`Warning: Could not get latest version for ${packageName}: HTTP ${response.statusCode}`);
+            resolve(null);
+          }
+        } catch (parseError) {
+          console.warn(`Warning: Could not parse response for ${packageName}: ${parseError.message}`);
+          resolve(null);
+        }
+      });
+    });
+    
+    request.on('error', (requestError) => {
+      console.warn(`Warning: Could not get latest version for ${packageName}: ${requestError.message}`);
+      resolve(null);
+    });
+    
+    request.on('timeout', () => {
+      request.destroy();
+      console.warn(`Warning: Timeout getting latest version for ${packageName}`);
+      resolve(null);
+    });
+  });
+}
+
+async function main() {
+  const packageJsonPath = path.join('aws-distro-opentelemetry-node-autoinstrumentation', 'package.json');
+  
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    let updated = false;
+    
+    const dependencies = packageJson.dependencies || {};
+    const otelPackages = Object.keys(dependencies).filter(pkg => pkg.startsWith('@opentelemetry/'));
+    
+    for (const packageName of otelPackages) {
+      const latestVersion = await getLatestVersion(packageName);
+      if (latestVersion) {
+        const currentVersion = dependencies[packageName];
+        
+        if (currentVersion !== latestVersion) {
+          packageJson.dependencies[packageName] = latestVersion;
+          updated = true;
+          console.log(`Updated ${packageName}: ${currentVersion} → ${latestVersion}`);
+        } else {
+          console.log(`${packageName} already at latest version: ${latestVersion}`);
+        }
+      }
+    }
+    
+    if (updated) {
+      fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+      console.log('Dependencies updated successfully');
+    } else {
+      console.log('No OpenTelemetry dependencies needed updating');
+    }
+    
+  } catch (fileError) {
+    console.error(`Error updating dependencies: ${fileError.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a workflow nightly-build.yml that checks for newest versions of our OpenTelemetry dependencies, creates a PR if there are version bumps, and runs tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

