### PR TITLE
Update publishing UDP Exporter via npm, not npx

### DIFF
--- a/.github/workflows/release-udp-exporter.yml
+++ b/.github/workflows/release-udp-exporter.yml
@@ -52,13 +52,13 @@ jobs:
             exit 1
           fi
 
-      # Publish OTLP UDP Exporter to npm
+      # Publish X-Ray UDP Exporter to npm
       - name: Publish to npm
         working-directory: exporters/aws-distro-opentelemetry-exporter-xray-udp
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
-        run: npx publish
+        run: npm publish
 
       # Publish to GitHub releases
       - name: Create GH release


### PR DESCRIPTION
*Issue #, if available:*
`NPM_CONFIG_PROVENANCE` config setting doesn't apply to npx, but should apply for npm.

*Description of changes:*
- Use `npm` to publish, similar to how [ADOT Instrumentation is currently published](https://github.com/aws-observability/aws-otel-js-instrumentation/blob/v0.7.0/.github/workflows/release-build.yml#L122). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

