### PR TITLE
Update daily-scan.yml to run every 6 hours

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -8,10 +8,8 @@
 name: Daily scan
 
 on:
-  schedule: # scheduled to run at 14:00, 20:00, 02:00 UTC every day
-    - cron: '0 14 * * *' # 6:00/7:00   PST/PDT (14:00 UTC)
-    - cron: '0 20 * * *' # 12:00/13:00 PST/PDT (20:00 UTC)
-    - cron: '0 02 * * *' # 18:00/19:00 PST/PDT (02:00 UTC)
+  schedule: # scheduled to run every 6 hours
+    - cron: '0 */6 * * **' #  “At minute 0 past every 6th hour.” 
   workflow_dispatch: # be able to run the workflow on demand
 
 env:


### PR DESCRIPTION
We still see periodic failures in this workflow and sometimes 2 failures in a row is enough to cause an alarm (b/c of when the tests run and when the alarm is evaluated). Increase run rate to every 6 hours to reduce chance of 2 failures causing an alarm.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

