### PR TITLE
pin cargo-audit version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ARG TARGETARCH
 RUN if [ $TARGETARCH = "amd64" ]; then rustup component add rustfmt && cargo fmt --check ; fi
 
 # Audit dependencies
-RUN if [ $TARGETARCH = "amd64" ]; then cargo install cargo-audit && cargo audit ; fi
+RUN if [ $TARGETARCH = "amd64" ]; then cargo install cargo-audit --locked && cargo audit ; fi
 
 
 # Cross-compile based on the target platform.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[Release workflow](https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/18763231799/job/53532731909) failed with
```
4.633 error: failed to compile `cargo-audit v0.21.2`, intermediate artifacts can be found at `/tmp/cargo-installmLFMlZ`.
4.633 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
4.633 
4.633 Caused by:
4.633   rustc 1.87.0 is not supported by the following package:
4.633     smol_str@0.3.4 requires rustc 1.89
4.633   Try re-running `cargo install` with `--locked`
```

Fix by using `cargo install cargo-audit --locked` to resolve dependencies using the constraints defined in Cargo.lock.

Tested this locally by running `docker build --platform linux/amd64 -t test-adot-js .` without and with the change, confirmed that the latter works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

