### PR TITLE
Re-build SDK in publish step of release (#288)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -119,6 +119,16 @@ jobs:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
+      - name: Build Tarball and Image Files
+        uses: ./.github/actions/artifacts_build
+        with:
+          image_uri_with_tag: "adot-autoinstrumentation-node:test"
+          push_image: false
+          load_image: true
+          node_version: "20"
+          package_name: aws-distro-opentelemetry-node-autoinstrumentation
+          os: ubuntu-latest
+
       - name: Configure AWS credentials for private ECR
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cherry pick of #288 

The most recent Release build workflow failed:

```
ERROR: failed to build: Multi-platform build is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

Fix by first running
[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action?tab=readme-ov-file#about), which creates and starts a builder compatible with multi-platform images.

Tested by using the artifacts_build action, triggered by main build, to build/push a multi-platform image. Without this step, the action fails with the same error message as the Release workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

