### PR TITLE
feat: Add region build release workflow for Lambda layer

### DIFF
--- a/.github/workflows/region-build-release.yml
+++ b/.github/workflows/region-build-release.yml
@@ -1,0 +1,208 @@
+name: Region Build Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to tag the release with, e.g., 1.2.0'
+        required: true
+      aws_region:
+        description: 'Comma-separated list of AWS regions to deploy the Lambda layer to (e.g., ap-southeast-5, mx-central-1)'
+        required: true
+        default: ''
+
+env:
+  # Legacy list of commercial regions to deploy to. New regions should NOT be added here, and instead should be added to the `aws_region` input when triggering the workflow.
+  LEGACY_COMMERCIAL_REGIONS: us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1
+  LAYER_NAME: AWSOpenTelemetryDistroJs
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-layer:
+    runs-on: ubuntu-latest
+    outputs:
+      aws_regions_json: ${{ steps.set-matrix.outputs.aws_regions_json }}
+    steps:
+      - name: Set up regions matrix
+        id: set-matrix
+        env:
+          AWS_REGIONS: ${{ github.event.inputs.aws_region }}
+        run: |
+          IFS=',' read -ra REGIONS <<< "$AWS_REGIONS"
+          MATRIX="["
+          for region in "${REGIONS[@]}"; do
+            trimmed_region=$(echo "$region" | xargs)
+            MATRIX+="\"$trimmed_region\","
+          done
+          MATRIX="${MATRIX%,}]"
+          echo ${MATRIX}
+          echo "aws_regions_json=${MATRIX}" >> $GITHUB_OUTPUT
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  #v5.0.0
+        with:
+          node-version: 24
+      - name: NPM Clean Install
+        run: npm ci
+      - name: Compile all NPM projects
+        run: npm run compile
+      - name: Build Lambda Layer
+        run: npm run build-lambda
+      - name: upload layer
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: layer.zip
+          path: lambda-layer/packages/layer/build/layer.zip
+
+  publish-layer-prod:
+    runs-on: ubuntu-latest
+    needs: build-layer
+    strategy:
+      matrix:
+        aws_region: ${{ fromJson(needs.build-layer.outputs.aws_regions_json) }}
+    steps:
+      - name: role arn
+        env:
+          LEGACY_COMMERCIAL_REGIONS: ${{ env.LEGACY_COMMERCIAL_REGIONS }}
+        run: |
+          LEGACY_COMMERCIAL_REGIONS_ARRAY=(${LEGACY_COMMERCIAL_REGIONS//,/ })
+          FOUND=false
+          for REGION in "${LEGACY_COMMERCIAL_REGIONS_ARRAY[@]}"; do
+            if [[ "$REGION" == "${{ matrix.aws_region }}" ]]; then
+              FOUND=true
+              break
+            fi
+          done
+          if [ "$FOUND" = true ]; then
+            echo "Found ${{ matrix.aws_region }} in LEGACY_COMMERCIAL_REGIONS"
+            SECRET_KEY="LAMBDA_LAYER_RELEASE"
+          else
+            echo "Not found ${{ matrix.aws_region }} in LEGACY_COMMERCIAL_REGIONS"
+            SECRET_KEY="${{ matrix.aws_region }}_LAMBDA_LAYER_RELEASE"
+          fi
+          SECRET_KEY=${SECRET_KEY//-/_}
+          echo "SECRET_KEY=${SECRET_KEY}" >> $GITHUB_ENV
+      - uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
+        with:
+          role-to-assume: ${{ secrets[env.SECRET_KEY] }}
+          role-duration-seconds: 1200
+          aws-region: ${{ matrix.aws_region }}
+      - name: Get s3 bucket name for release 
+        run: |
+          echo BUCKET_NAME=nodejs-lambda-layer-${{ github.run_id }}-${{ matrix.aws_region }} | tee --append $GITHUB_ENV
+      - name: download layer.zip
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: layer.zip
+      - name: publish
+        run: |
+          aws s3 mb s3://${{ env.BUCKET_NAME }}
+          aws s3 cp layer.zip s3://${{ env.BUCKET_NAME }}
+          layerARN=$(
+            aws lambda publish-layer-version \
+              --layer-name ${{ env.LAYER_NAME }} \
+              --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=layer.zip \
+              --compatible-runtimes nodejs18.x nodejs20.x nodejs22.x nodejs24.x \
+              --compatible-architectures "arm64" "x86_64" \
+              --license-info "Apache-2.0" \
+              --description "AWS Distro of OpenTelemetry Lambda Layer for NodeJs Runtime" \
+              --query 'LayerVersionArn' \
+              --output text
+          )
+          echo $layerARN
+          echo "LAYER_ARN=${layerARN}" >> $GITHUB_ENV
+          mkdir ${{ env.LAYER_NAME }}
+          echo $layerARN > ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
+          cat ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
+      - name: public layer
+        run: |
+          layerVersion=$(
+            aws lambda list-layer-versions \
+              --layer-name ${{ env.LAYER_NAME }} \
+              --query 'max_by(LayerVersions, &Version).Version'
+          )
+          aws lambda add-layer-version-permission \
+            --layer-name ${{ env.LAYER_NAME }} \
+            --version-number $layerVersion \
+            --principal "*" \
+            --statement-id publish \
+            --action lambda:GetLayerVersion
+      - name: upload layer arn artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: ${{ env.LAYER_NAME }}-${{ matrix.aws_region }}
+          path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
+      - name: clean s3
+        if: always()
+        run: |
+          aws s3 rb --force s3://${{ env.BUCKET_NAME }}
+
+  generate-lambda-release-note:
+    runs-on: ubuntu-latest
+    needs: publish-layer-prod
+    outputs:
+      layer-note: ${{ steps.layer-note.outputs.layer-note }}
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd #v3.1.2
+      - name: download layerARNs
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          pattern: ${{ env.LAYER_NAME }}-*
+          path: ${{ env.LAYER_NAME }}
+          merge-multiple: true
+      - name: show layerARNs
+        run: |
+          for file in ${{ env.LAYER_NAME }}/*
+          do
+          echo $file
+          cat $file
+          done
+      - name: generate layer-note
+        id: layer-note
+        working-directory: ${{ env.LAYER_NAME }}
+        run: |
+          echo "| Region | Layer ARN |" >> ../layer-note
+          echo "|  ----  | ----  |" >> ../layer-note
+          for file in *
+          do
+          read arn < $file
+          echo "| " $file " | " $arn " |" >> ../layer-note
+          done
+          cd ..
+          {
+            echo "layer-note<<EOF"
+            cat layer-note
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+          cat layer-note
+      - name: generate tf layer
+        working-directory: ${{ env.LAYER_NAME }}
+        run: |
+          echo "locals {" >> ../layer_arns.tf
+          echo "  sdk_layer_arns = {" >> ../layer_arns.tf
+          for file in *
+          do
+          read arn < $file
+          echo "    \""$file"\" = \""$arn"\"" >> ../layer_arns.tf
+          done
+          cd ..
+          echo "  }" >> layer_arns.tf
+          echo "}" >> layer_arns.tf
+          terraform fmt layer_arns.tf
+          cat layer_arns.tf
+      - name: generate layer ARN constants for CDK
+        working-directory: ${{ env.LAYER_NAME }}
+        run: |
+          echo "{" > ../layer_cdk
+          for file in *; do
+            read arn < "$file"
+            echo "    \"$file\": \"$arn\"," >> ../layer_cdk
+          done
+          echo "}" >> ../layer_cdk
+          cat ../layer_cdk


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Extract Lambda layer regional deployment jobs (build-layer, publish-layer-prod, generate-lambda-release-note) from release-build.yml into a standalone region-build-release.yml workflow. This allows deploying Lambda layers to specific AWS regions on demand without triggering SDK publishing, ECR image builds, or GitHub release creation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

