### PR TITLE
feat: allow HTTP operations to be configurable via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- Support environment-configured endpoint visibility for HTTP operation names
+  ([#388](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/388))
 - Fix UnknownRemoteService/UnknownRemoteOperation for Next.js fetch by supporting new HTTP semantic conventions
   (`server.address`, `server.port`, `http.request.method`, `url.full`, `url.path`) as fallbacks
   ([#366](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/366))

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-metrics-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-metrics-processor.ts
@@ -6,7 +6,7 @@ import { Resource } from '@opentelemetry/resources';
 import { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { SEMATTRS_HTTP_STATUS_CODE } from '@opentelemetry/semantic-conventions';
 import { AttributeMap, MetricAttributeGenerator } from './metric-attribute-generator';
-import { ForceFlushFunction } from './aws-span-processing-util';
+import { AwsSpanProcessingUtil, ForceFlushFunction } from './aws-span-processing-util';
 import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
 
 /**
@@ -86,6 +86,10 @@ export class AwsSpanMetricsProcessor implements SpanProcessor {
   public onStart(span: Span, parentContext: Context): void {}
 
   public onEnd(span: ReadableSpan): void {
+    // If OTEL_AWS_HTTP_OPERATION_PATHS is configured, override the span name so that
+    // metrics use the configured operation path instead of the original span name.
+    span = AwsSpanProcessingUtil.applyOperationPathSpanName(span);
+
     const attributeMap: AttributeMap = this.generator.generateMetricAttributeMapFromSpan(span, this.resource);
 
     for (const attribute in attributeMap) {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
@@ -23,6 +23,7 @@ import {
 import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
 import { AWS_LAMBDA_FUNCTION_NAME_CONFIG, isLambdaEnvironment } from './aws-opentelemetry-configurator';
 import * as SQL_DIALECT_KEYWORDS_JSON from './configuration/sql_dialect_keywords.json';
+import { Mutable } from './utils';
 
 export type ForceFlushFunction = (options?: any) => Promise<void>;
 
@@ -49,6 +50,131 @@ export class AwsSpanProcessingUtil {
 
   // TODO: Use Semantic Conventions once upgraded
   static GEN_AI_REQUEST_MODEL: string = 'gen_ai.request.model';
+
+  // Environment variable for configurable operation name paths
+  static OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG: string = 'OTEL_AWS_HTTP_OPERATION_PATHS';
+
+  // Cached parsed operation paths (sorted longest first)
+  private static operationPaths: string[] | undefined;
+
+  /**
+   * Parse the OTEL_AWS_HTTP_OPERATION_PATHS env var into a sorted list of path templates
+   * (longest first by segment count). Returns an empty array if the env var is not set.
+   */
+  static getOperationPaths(): string[] {
+    if (AwsSpanProcessingUtil.operationPaths === undefined) {
+      const config = process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG];
+      if (config === undefined || config.trim() === '') {
+        AwsSpanProcessingUtil.operationPaths = [];
+      } else {
+        const paths = config
+          .split(',')
+          .map(p => p.trim())
+          .filter(p => p.length > 0);
+        // Sort longest first (by segment count) for longest-prefix-match.
+        // For patterns with the same number of segments, original config order is preserved (stable sort).
+        paths.sort((a, b) => b.split('/').length - a.split('/').length);
+        AwsSpanProcessingUtil.operationPaths = paths;
+      }
+    }
+    return AwsSpanProcessingUtil.operationPaths;
+  }
+
+  /** Reset cached operation paths (for testing). */
+  static resetOperationPaths(): void {
+    AwsSpanProcessingUtil.operationPaths = undefined;
+  }
+
+  /**
+   * If OTEL_AWS_HTTP_OPERATION_PATHS is configured and a pattern matches the span's URL path,
+   * mutates the span name to "METHOD /path/template". Returns the span unchanged if no config
+   * is set or no pattern matches.
+   */
+  static applyOperationPathSpanName(span: ReadableSpan): ReadableSpan {
+    const paths = AwsSpanProcessingUtil.getOperationPaths();
+    if (paths.length === 0) {
+      return span;
+    }
+
+    let urlPath = AwsSpanProcessingUtil.getUrlPath(span);
+    if (urlPath === undefined || urlPath === '') {
+      return span;
+    }
+
+    // Strip query string and fragment (relevant for http.target)
+    for (const sep of ['?', '#']) {
+      const idx = urlPath.indexOf(sep);
+      if (idx >= 0) {
+        urlPath = urlPath.substring(0, idx);
+      }
+    }
+
+    // Normalize trailing slashes
+    while (urlPath.endsWith('/') && urlPath.length > 1) {
+      urlPath = urlPath.substring(0, urlPath.length - 1);
+    }
+
+    const urlSegments = urlPath.split('/');
+    for (const pattern of paths) {
+      let normalizedPattern = pattern;
+      while (normalizedPattern.endsWith('/') && normalizedPattern.length > 1) {
+        normalizedPattern = normalizedPattern.substring(0, normalizedPattern.length - 1);
+      }
+      if (AwsSpanProcessingUtil.segmentsMatch(urlSegments, normalizedPattern.split('/'))) {
+        const httpMethod = AwsSpanProcessingUtil.getHttpMethod(span);
+        const newName = httpMethod !== undefined ? httpMethod + ' ' + pattern : pattern;
+        // Mutate the span name in place
+        const mutableSpan: Mutable<ReadableSpan> = span;
+        mutableSpan.name = newName;
+        return span;
+      }
+    }
+    return span;
+  }
+
+  /** Return the URL path from server span attributes, preferring url.path over http.target. */
+  private static getUrlPath(span: ReadableSpan): string | undefined {
+    const urlPath = span.attributes[ATTR_URL_PATH] ?? span.attributes[SEMATTRS_HTTP_TARGET];
+    return typeof urlPath === 'string' ? urlPath : undefined;
+  }
+
+  /** Get the HTTP method from the span, checking new and deprecated semconv attributes. */
+  private static getHttpMethod(span: ReadableSpan): string | undefined {
+    const method = span.attributes[ATTR_HTTP_REQUEST_METHOD] ?? span.attributes[SEMATTRS_HTTP_METHOD];
+    return typeof method === 'string' ? method : undefined;
+  }
+
+  /**
+   * Check if URL segments match a pattern's segments. Only pattern segments can be wildcards
+   * ({param}, :param, or *) — URL segments are always treated as literals. The pattern acts
+   * as a prefix — extra URL segments after the pattern are allowed.
+   */
+  private static segmentsMatch(urlSegments: string[], patternSegments: string[]): boolean {
+    for (let i = 0; i < patternSegments.length; i++) {
+      if (i >= urlSegments.length) {
+        return false;
+      }
+      const ps = patternSegments[i];
+      const us = urlSegments[i];
+
+      if (AwsSpanProcessingUtil.isWildcardSegment(ps)) {
+        if (us === '') {
+          return false;
+        }
+        continue;
+      }
+
+      if (ps !== us) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** A segment is a wildcard if it uses {param}, :param, or * format. */
+  private static isWildcardSegment(segment: string): boolean {
+    return (segment.startsWith('{') && segment.endsWith('}')) || segment.startsWith(':') || segment === '*';
+  }
   static GEN_AI_SYSTEM: string = 'gen_ai.system';
   static GEN_AI_REQUEST_MAX_TOKENS: string = 'gen_ai.request.max_tokens';
   static GEN_AI_REQUEST_TEMPERATURE: string = 'gen_ai.request.temperature';
@@ -222,12 +348,8 @@ export class AwsSpanProcessingUtil {
     if (operation == null || operation === AwsSpanProcessingUtil.UNKNOWN_OPERATION) {
       return false;
     }
-    if (
-      AwsSpanProcessingUtil.isKeyPresent(span, SEMATTRS_HTTP_METHOD) ||
-      AwsSpanProcessingUtil.isKeyPresent(span, ATTR_HTTP_REQUEST_METHOD)
-    ) {
-      const httpMethod: AttributeValue | undefined =
-        span.attributes[SEMATTRS_HTTP_METHOD] ?? span.attributes[ATTR_HTTP_REQUEST_METHOD];
+    const httpMethod = AwsSpanProcessingUtil.getHttpMethod(span);
+    if (httpMethod !== undefined) {
       return operation !== httpMethod;
     }
     return true;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-span-processing-util.ts
@@ -175,6 +175,7 @@ export class AwsSpanProcessingUtil {
   private static isWildcardSegment(segment: string): boolean {
     return (segment.startsWith('{') && segment.endsWith('}')) || segment.startsWith(':') || segment === '*';
   }
+
   static GEN_AI_SYSTEM: string = 'gen_ai.system';
   static GEN_AI_REQUEST_MAX_TOKENS: string = 'gen_ai.request.max_tokens';
   static GEN_AI_REQUEST_TEMPERATURE: string = 'gen_ai.request.temperature';

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
@@ -460,8 +460,7 @@ describe('AwsSpanProcessingUtilTest', () => {
     });
 
     it('same-length patterns: first in config order wins', () => {
-      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] =
-        '/api/v1/{userId},/api/{version}/user1';
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/v1/{userId},/api/{version}/user1';
       (spanDataMock as any).name = 'GET /api';
       attributesMock[ATTR_URL_PATH] = '/api/v1/user1';
       attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-span-processing-util.test.ts
@@ -13,6 +13,7 @@ import {
   SEMATTRS_MESSAGING_OPERATION,
   SEMATTRS_RPC_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
+import { ATTR_HTTP_REQUEST_METHOD, ATTR_URL_PATH } from '@opentelemetry/semantic-conventions';
 import { expect } from 'expect';
 import { AWS_ATTRIBUTE_KEYS } from '../src/aws-attribute-keys';
 import { AwsSpanProcessingUtil } from '../src/aws-span-processing-util';
@@ -406,6 +407,155 @@ describe('AwsSpanProcessingUtilTest', () => {
     spanDataMock.attributes[AwsSpanProcessingUtil.CLOUD_RESOURCE_ID] = 123; // Incorrect type
     const result = AwsSpanProcessingUtil.getResourceId(spanDataMock);
     expect(result).toBeUndefined();
+  });
+
+  // --- Tests for OTEL_AWS_HTTP_OPERATION_PATHS and applyOperationPathSpanName ---
+
+  describe('applyOperationPathSpanName', () => {
+    beforeEach(() => {
+      AwsSpanProcessingUtil.resetOperationPaths();
+    });
+
+    afterEach(() => {
+      AwsSpanProcessingUtil.resetOperationPaths();
+      delete process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG];
+    });
+
+    it('matches url.path and overrides span name', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] =
+        '/api/contests/{id}/leaderboard,/api/contests/{id},/api/contests';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api/contests/123/leaderboard';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api/contests/{id}/leaderboard');
+    });
+
+    it('falls back to http.target when url.path is absent', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/teams/{id},/api/teams';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[SEMATTRS_HTTP_TARGET] = '/api/teams/5?include=roster';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api/teams/{id}');
+    });
+
+    it('strips fragment from http.target', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/teams/{id}';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[SEMATTRS_HTTP_TARGET] = '/api/teams/5#section';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api/teams/{id}');
+    });
+
+    it('longest match wins', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] =
+        '/api/contests/{id}/leaderboard,/api/contests/{id},/api/contests,/api';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api/contests/42';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api/contests/{id}');
+    });
+
+    it('same-length patterns: first in config order wins', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] =
+        '/api/v1/{userId},/api/{version}/user1';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api/v1/user1';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api/v1/{userId}');
+    });
+
+    it('no match returns original span', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/contests/{id}';
+      (spanDataMock as any).name = 'GET /unknown';
+      attributesMock[ATTR_URL_PATH] = '/unknown/path';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result).toBe(spanDataMock);
+      expect(result.name).toEqual('GET /unknown');
+    });
+
+    it('empty config returns original span', () => {
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result).toBe(spanDataMock);
+    });
+
+    it('no http method omits method prefix', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/contests';
+      (spanDataMock as any).name = '/api';
+      attributesMock[ATTR_URL_PATH] = '/api/contests';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('/api/contests');
+    });
+
+    it('trailing slash in URL is normalized', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/contests';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api/contests/';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api/contests');
+    });
+
+    it('query string is stripped from url.path', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/contests';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api/contests?page=1&size=10';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api/contests');
+    });
+
+    it(':param wildcard in config matches literal URL segment', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/users/:userId/stats';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api/users/42/stats';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api/users/:userId/stats');
+    });
+
+    it('* wildcard in config matches literal URL segment', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/*/users/*';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api/v2/users/42';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api/*/users/*');
+    });
+
+    it('wildcard does not match empty segment', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/contests/{id}';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api/contests/';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      // Trailing slash normalized to /api/contests, which matches /api/contests as prefix
+      // but {id} requires a non-empty segment — so no match for {id} pattern
+      expect(result.name).not.toContain('{id}');
+    });
+
+    it('pattern longer than URL does not match', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/contests/{id}';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api';
+      attributesMock[ATTR_HTTP_REQUEST_METHOD] = 'GET';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('GET /api');
+    });
+
+    it('uses deprecated http.method when http.request.method is absent', () => {
+      process.env[AwsSpanProcessingUtil.OTEL_AWS_HTTP_OPERATION_PATHS_CONFIG] = '/api/contests';
+      (spanDataMock as any).name = 'GET /api';
+      attributesMock[ATTR_URL_PATH] = '/api/contests';
+      attributesMock[SEMATTRS_HTTP_METHOD] = 'POST';
+      const result = AwsSpanProcessingUtil.applyOperationPathSpanName(spanDataMock);
+      expect(result.name).toEqual('POST /api/contests');
+    });
   });
 });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Same as https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1352

When HTTP span names don't contain a URL path, we generate the HTTP operation by truncating the URL path to only the first trailing value to preserve low cardinality (i.e. /api/v1/users -> /api). This can result in overly broad operation groupings for services with endpoint paths of various depths.

This PR introduces an environment variable configuration, `OTEL_AWS_HTTP_OPERATION_PATHS`, which allows users to configure their own HTTP endpoint paths. If this variable is provided, the span name's URL path will resolve to the longest matching path. Wildcards are supported with the following syntaxes: `{version}`, `:version`, or simply `*`. This way, users can decide how their service endpoint are grouped into operation names shown in CloudWatch.

Added unit tests to verify behavior, and did some E2E testing with an instrumented HTTP server.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

