### PR TITLE
Lazy-load register.ts in tests to prevent TracerProvider conflicts

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -30,6 +30,7 @@ import {
 import * as assert from 'assert';
 import expect from 'expect';
 import * as sinon from 'sinon';
+import * as opentelemetry from '@opentelemetry/sdk-node';
 import { AlwaysRecordSampler } from '../src/always-record-sampler';
 import { AttributePropagatingSpanProcessor } from '../src/attribute-propagating-span-processor';
 import { AwsBatchUnsampledSpanProcessor } from '../src/aws-batch-unsampled-span-processor';
@@ -47,7 +48,7 @@ import {
 } from '../src/aws-opentelemetry-configurator';
 import { AwsSpanMetricsProcessor } from '../src/aws-span-metrics-processor';
 import { OTLPUdpSpanExporter } from '../src/otlp-udp-exporter';
-import { setAwsDefaultEnvironmentVariables } from '../src/register';
+let setAwsDefaultEnvironmentVariables: () => void;
 import { AwsXRayRemoteSampler } from '../src/sampler/aws-xray-remote-sampler';
 import { AwsXraySamplingClient } from '../src/sampler/aws-xray-sampling-client';
 import { GetSamplingRulesResponse } from '../src/sampler/remote-sampler.types';
@@ -72,6 +73,11 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
 
   // setUpClass
   before(() => {
+    const stub = sinon.stub(opentelemetry.NodeSDK.prototype, 'start');
+    const register = require('../src/register');
+    stub.restore();
+    setAwsDefaultEnvironmentVariables = register.setAwsDefaultEnvironmentVariables;
+
     // Run environment setup in register.ts, then validate expected env values.
     setAwsDefaultEnvironmentVariables();
     validateConfiguratorEnviron();

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/patches/instrumentation-patch.test.ts
@@ -40,7 +40,7 @@ import { Lambda } from '@aws-sdk/client-lambda';
 import * as nock from 'nock';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { getTestSpans } from '@opentelemetry/contrib-test-utils';
-import { instrumentationConfigs } from '../../src/register';
+import * as opentelemetry from '@opentelemetry/sdk-node';
 import { LoggerProvider } from '@opentelemetry/api-logs';
 import { STS } from '@aws-sdk/client-sts';
 import { getPropagator } from '@opentelemetry/auto-configuration-propagators';
@@ -77,12 +77,23 @@ const mockHeaders = {
   'content-type': 'application/json',
 };
 
-const UNPATCHED_INSTRUMENTATIONS: Instrumentation[] = getNodeAutoInstrumentations(instrumentationConfigs);
-
-const PATCHED_INSTRUMENTATIONS: Instrumentation[] = getNodeAutoInstrumentations(instrumentationConfigs);
-applyInstrumentationPatches(PATCHED_INSTRUMENTATIONS);
+let UNPATCHED_INSTRUMENTATIONS: Instrumentation[];
+let PATCHED_INSTRUMENTATIONS: Instrumentation[];
+let instrumentationConfigs: Record<string, any>;
 
 describe('InstrumentationPatchTest', () => {
+  before(() => {
+    const stub = sinon.stub(opentelemetry.NodeSDK.prototype, 'start');
+    const register = require('../../src/register');
+    stub.restore();
+    instrumentationConfigs = register.instrumentationConfigs;
+    UNPATCHED_INSTRUMENTATIONS = getNodeAutoInstrumentations(instrumentationConfigs);
+    PATCHED_INSTRUMENTATIONS = getNodeAutoInstrumentations(instrumentationConfigs);
+    applyInstrumentationPatches(PATCHED_INSTRUMENTATIONS);
+
+    propagation.disable();
+    propagation.setGlobalPropagator(getPropagator());
+  });
   it('SanityTestUnpatchedAwsSdkInstrumentation', () => {
     const awsSdkInstrumentation: AwsInstrumentation = extractAwsSdkInstrumentation(UNPATCHED_INSTRUMENTATIONS);
     const services: Map<string, any> = extractServicesFromAwsSdkInstrumentation(awsSdkInstrumentation);
@@ -1073,6 +1084,7 @@ describe('customExtractor', () => {
 
   before(() => {
     process.env.OTEL_PROPAGATORS = 'baggage,xray,tracecontext';
+    propagation.disable();
     propagation.setGlobalPropagator(getPropagator());
     delete process.env.OTEL_PROPAGATORS;
   });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -2,25 +2,42 @@
 // SPDX-License-Identifier: Apache-2.0
 // Modifications Copyright The OpenTelemetry Authors. Licensed under the Apache License 2.0 License.
 
-import { NodeSDK } from '@opentelemetry/sdk-node';
 import * as assert from 'assert';
 import { spawnSync, SpawnSyncReturns } from 'child_process';
 import expect from 'expect';
-import { setAwsDefaultEnvironmentVariables } from '../src/register';
+import * as opentelemetry from '@opentelemetry/sdk-node';
+import * as sinon from 'sinon';
 
 // The OpenTelemetry Authors code
 // Extend register.test.ts functionality to also test exported span with Application Signals enabled
 describe('Register', function () {
-  it('Requires without error', () => {
-    const originalPrototypeStart = NodeSDK.prototype.start;
-    NodeSDK.prototype.start = () => {};
-    try {
-      require('../src/register');
-    } catch (err: unknown) {
-      assert.fail(`require register unexpectedly failed: ${err}`);
-    }
+  let setAwsDefaultEnvironmentVariables: () => void;
 
-    NodeSDK.prototype.start = originalPrototypeStart;
+  before(() => {
+    const stub = sinon.stub(opentelemetry.NodeSDK.prototype, 'start');
+    const register = require('../src/register');
+    stub.restore();
+    setAwsDefaultEnvironmentVariables = register.setAwsDefaultEnvironmentVariables;
+  });
+
+  it('Requires without error', () => {
+    const proc: SpawnSyncReturns<Buffer> = spawnSync(
+      process.execPath,
+      ['--require', '../build/src/register.js', '-e', 'process.exit(0)'],
+      {
+        cwd: __dirname,
+        timeout: 10000,
+        killSignal: 'SIGKILL',
+        env: Object.assign({}, process.env, {
+          OTEL_NODE_RESOURCE_DETECTORS: 'none',
+          OTEL_TRACES_EXPORTER: 'none',
+          OTEL_METRICS_EXPORTER: 'none',
+          OTEL_LOGS_EXPORTER: 'none',
+        }),
+      }
+    );
+    assert.ifError(proc.error);
+    assert.equal(proc.status, 0, `proc.status (${proc.status})`);
   });
 
   describe('Tests AWS Default Environment Variables', () => {


### PR DESCRIPTION
### Description of changes
- Configurator, patch, and register tests statically imported `register.ts`, which calls `NodeSDK.start` at module load time, registering a global TracerProvider that conflicts with `contrib-test-utils` `registerInstrumentationTestingProvider`.
- Changed all three test files to lazy-load `register.ts` inside `before` hooks with `sinon.stub`.
- Added `propagation.disable` before `setGlobalPropagator` in patch tests so the XRay propagator registers correctly after `contrib-test-utils` sets a W3C-only propagator first.
- Fixes 2 pre-existing test failures in `customExtractor` and trace header injection tests.