### PR TITLE
Fix PR build test matrix and simplify unit tests

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -159,15 +159,15 @@ jobs:
           trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
       - name: Build Lambda Layer
         run: npm run build-lambda
-      - name: Unit tests (Node 18)
-        if: ${{ matrix.node == '18' }}
-        run: npm run test:node18
-      - name: Unit tests
-        if: ${{ !matrix.code-coverage && matrix.node != '18' }}
-        run: npm run test
-      - name: Unit tests with coverage
-        if: ${{ matrix.code-coverage }}
-        run: npm run test:coverage
+      - name: Run unit tests
+        run: |
+          if [ "${{ matrix.node }}" == "18" ]; then
+            npm run test:node18
+          elif [ "${{ matrix.code-coverage }}" == "true" ]; then
+            npm run test:coverage
+          else
+            npm run test
+          fi
       - name: Report Coverage
         if: ${{ matrix.code-coverage && !cancelled()}}
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 #v5.5.1

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -159,7 +159,7 @@ jobs:
           trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
       - name: Build Lambda Layer
         run: npm run build-lambda
-      - name: Unit tests (Node 18, excludes instrumentation)
+      - name: Unit tests (Node 18)
         if: ${{ matrix.node == '18' }}
         run: npm run test:node18
       - name: Unit tests

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -159,16 +159,12 @@ jobs:
           trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
       - name: Build Lambda Layer
         run: npm run build-lambda
-      # Some of instrumented packages require certain Node versions,
-      # so these tests are excluded from the main test script via --ignore
-      # and run here only on supported Node versions.
-      # Thus we exclude code coverage for Node 18.
-      - name: Unit tests without coverage
-        if: ${{ !matrix.code-coverage }}
+      - name: Unit tests (Node 18, excludes instrumentation)
+        if: ${{ matrix.node == '18' }}
         run: npm run test:node18
-      - name: Run instrumentation tests
+      - name: Unit tests
         if: ${{ !matrix.code-coverage && matrix.node != '18' }}
-        run: npm run test:instrumentation:langchain
+        run: npm run test
       - name: Unit tests with coverage
         if: ${{ matrix.code-coverage }}
         run: npm run test:coverage

--- a/aws-distro-opentelemetry-node-autoinstrumentation/package.json
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/package.json
@@ -32,7 +32,6 @@
     "tdd": "yarn test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha --timeout 15000 -p tsconfig.json --require '@opentelemetry/contrib-test-utils' 'test/**/*.ts'",
     "test:node18": "nyc ts-mocha --timeout 10000 -p tsconfig.json --require '@opentelemetry/contrib-test-utils' --ignore 'test/instrumentation/instrumentation-langchain/**' 'test/**/*.ts'",
-    "test:instrumentation:langchain": "ts-mocha --timeout 15000 -p tsconfig.json --require '@opentelemetry/contrib-test-utils' 'test/instrumentation/instrumentation-langchain/**/*.ts'",
     "test:coverage": "nyc --check-coverage --functions 95 --lines 95 ts-mocha --timeout 15000 -p tsconfig.json --require '@opentelemetry/contrib-test-utils' 'test/**/*.ts'",
     "watch": "tsc -w"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test": "lerna run test",
     "test:node18": "lerna run test:node18",
     "test:coverage": "lerna run test:coverage",
-    "test:instrumentation:langchain": "lerna run test:instrumentation:langchain",
     "test:ci:changed": "lerna run test --since origin/main",
     "test:browser": "lerna run test:browser --concurrency 1",
     "test-all-versions": "npm run --if-present --workspaces test-all-versions",


### PR DESCRIPTION
*Description of changes:*
- Node 22 and 24 were running test:node18  then running instrumentation tests separately. Now they just run npm run test which includes everything.

- Removed individual instrumentation tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

