### PR TITLE
Fix flaky xray sampler tests with nock persist

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
@@ -112,7 +112,6 @@ describe('AwsXrayRemoteSampler', () => {
   });
 
   it('testLargeReservoir', done => {
-    nock.cleanAll();
     nock(TEST_URL).post('/GetSamplingRules').reply(200, require(DATA_DIR_SAMPLING_RULES)).persist();
     nock(TEST_URL).post('/SamplingTargets').reply(200, require(DATA_DIR_SAMPLING_TARGETS)).persist();
     const resource = resourceFromAttributes({
@@ -156,7 +155,6 @@ describe('AwsXrayRemoteSampler', () => {
   });
 
   it('testSomeReservoir', done => {
-    nock.cleanAll();
     nock(TEST_URL).post('/GetSamplingRules').reply(200, require(DATA_DIR_SAMPLING_RULES)).persist();
     nock(TEST_URL).post('/SamplingTargets').reply(200, require(DATA_DIR_SAMPLING_TARGETS)).persist();
     const resource = resourceFromAttributes({

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/sampler/aws-xray-remote-sampler.test.ts
@@ -21,6 +21,7 @@ export const testTraceId = '0af7651916cd43dd8448eb211c80319c';
 describe('AwsXrayRemoteSampler', () => {
   afterEach(() => {
     sinon.restore();
+    nock.cleanAll();
   });
 
   it('testCreateRemoteSamplerWithEmptyResource', () => {
@@ -111,8 +112,9 @@ describe('AwsXrayRemoteSampler', () => {
   });
 
   it('testLargeReservoir', done => {
-    nock(TEST_URL).post('/GetSamplingRules').reply(200, require(DATA_DIR_SAMPLING_RULES));
-    nock(TEST_URL).post('/SamplingTargets').reply(200, require(DATA_DIR_SAMPLING_TARGETS));
+    nock.cleanAll();
+    nock(TEST_URL).post('/GetSamplingRules').reply(200, require(DATA_DIR_SAMPLING_RULES)).persist();
+    nock(TEST_URL).post('/SamplingTargets').reply(200, require(DATA_DIR_SAMPLING_TARGETS)).persist();
     const resource = resourceFromAttributes({
       [SEMRESATTRS_SERVICE_NAME]: 'test-service-name',
       [SEMRESATTRS_CLOUD_PLATFORM]: 'test-cloud-platform',
@@ -154,8 +156,9 @@ describe('AwsXrayRemoteSampler', () => {
   });
 
   it('testSomeReservoir', done => {
-    nock(TEST_URL).post('/GetSamplingRules').reply(200, require(DATA_DIR_SAMPLING_RULES));
-    nock(TEST_URL).post('/SamplingTargets').reply(200, require(DATA_DIR_SAMPLING_TARGETS));
+    nock.cleanAll();
+    nock(TEST_URL).post('/GetSamplingRules').reply(200, require(DATA_DIR_SAMPLING_RULES)).persist();
+    nock(TEST_URL).post('/SamplingTargets').reply(200, require(DATA_DIR_SAMPLING_TARGETS)).persist();
     const resource = resourceFromAttributes({
       [SEMRESATTRS_SERVICE_NAME]: 'test-service-name',
       [SEMRESATTRS_CLOUD_PLATFORM]: 'test-cloud-platform',


### PR DESCRIPTION
The `testUpdateSamplingRulesAndTargetsWithPollersAndShouldSampled` test creates a sampler with a 200ms target polling interval but never cleans it up. Its poller keeps running and consumes the one-shot nock interceptors set up by testLargeReservoir and testSomeReservoir, causing them to fail when they try to fetch sampling targets.

add `nock.cleanAll()` to clear stale interceptors before each test, use `.persist()` so interceptors survive multiple hits, and clean up in afterEach.
