### PR TITLE
Respect OTEL_EXPORTER_OTLP_ENDPOINT in agent observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix: Respect OTEL_EXPORTER_OTLP_ENDPOINT in agent observability endpoint configuration
+  ([#411](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/411))
 - feat(instrumentation-vercel-ai): Add native Vercel AI instrumentation support
   ([#394](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/394))
 - feat(instrumentation-langchain): Add native LangChain instrumentation support

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -100,20 +100,21 @@ export function setAwsDefaultEnvironmentVariables() {
       process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED = 'false';
     }
 
-    // Set OTLP endpoints with AWS region if not already set
-    const region = getAwsRegionFromEnvironment();
-    if (region) {
-      if (!process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) {
-        process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = `https://xray.${region}.amazonaws.com/v1/traces`;
-      }
+    if (!process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+      const region = getAwsRegionFromEnvironment();
+      if (region) {
+        if (!process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) {
+          process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = `https://xray.${region}.amazonaws.com/v1/traces`;
+        }
 
-      if (!process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) {
-        process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = `https://logs.${region}.amazonaws.com/v1/logs`;
+        if (!process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) {
+          process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = `https://logs.${region}.amazonaws.com/v1/logs`;
+        }
+      } else {
+        diag.error(
+          'AWS region could not be determined. OTLP endpoints will not be automatically configured. Please set AWS_REGION environment variable or configure OTLP endpoints manually.'
+        );
       }
-    } else {
-      diag.error(
-        'AWS region could not be determined. OTLP endpoints will not be automatically configured. Please set AWS_REGION environment variable or configure OTLP endpoints manually.'
-      );
     }
   }
 }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -152,6 +152,7 @@ describe('Register', function () {
       delete process.env.AWS_REGION;
       delete process.env.AWS_DEFAULT_REGION;
       delete process.env.AGENT_OBSERVABILITY_ENABLED;
+      delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
       delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
       delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
       delete process.env.OTEL_TRACES_EXPORTER;
@@ -207,6 +208,17 @@ describe('Register', function () {
 
       expect(process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).toEqual('https://xray.us-east-2.amazonaws.com/v1/traces');
       expect(process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toEqual('https://logs.us-east-2.amazonaws.com/v1/logs');
+    });
+
+    it('Does not set signal-specific endpoints when OTEL_EXPORTER_OTLP_ENDPOINT is set', () => {
+      process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+      process.env.AWS_REGION = 'us-west-2';
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://my-collector:4318';
+
+      setAwsDefaultEnvironmentVariables();
+
+      expect(process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).toBeUndefined();
+      expect(process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toBeUndefined();
     });
 
     it('Configures defaults when AgentObservabilityEnabled is true', () => {


### PR DESCRIPTION
*Description of changes*
- When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, skip setting signal-specific endpoints derives them from the base URL
- Aligns with the Python distro behavior (aws-observability/aws-otel-python-instrumentation#732)