### PR TITLE
feat(llo-handler): add gen_ai.input.messages, gen_ai.output.messages, and gen_ai.system_instructions support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(llo-handler): add gen_ai.input.messages, gen_ai.output.messages, and gen_ai.system_instructions support
 - feat(instrumentation-openai-agents): Add native OpenAI Agents instrumentation support
   ([#401](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/401))
 - feat(instrumentation-vercel-ai): Add native Vercel AI instrumentation support

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/llo-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/llo-handler.ts
@@ -132,6 +132,21 @@ export const LLO_PATTERNS: { [key: string]: PatternConfig } = {
     role: ROLE_USER,
     source: 'prompt',
   },
+  'gen_ai.input.messages': {
+    type: PatternType.DIRECT,
+    role: ROLE_USER,
+    source: 'input',
+  },
+  'gen_ai.output.messages': {
+    type: PatternType.DIRECT,
+    role: ROLE_ASSISTANT,
+    source: 'output',
+  },
+  'gen_ai.system_instructions': {
+    type: PatternType.DIRECT,
+    role: ROLE_SYSTEM,
+    source: 'prompt',
+  },
 };
 
 /**

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.collection.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.collection.test.ts
@@ -255,6 +255,9 @@ describe('TestLLOHandlerCollection', () => {
       'traceloop.entity.input': 'input',
       'gen_ai.prompt': 'direct prompt',
       'input.value': 'inference input',
+      'gen_ai.input.messages': 'structured input',
+      'gen_ai.output.messages': 'structured output',
+      'gen_ai.system_instructions': 'system instructions',
     };
 
     const span = testBase.createMockSpan(attributes);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.events.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.events.test.ts
@@ -40,6 +40,9 @@ describe('TestLLOHandlerEvents', () => {
       'gen_ai.agent.actual_output': 'agent output',
       'crewai.crew.tasks_output': 'tasks output',
       'crewai.crew.result': 'crew result',
+      'gen_ai.input.messages': 'structured input',
+      'gen_ai.output.messages': 'structured output',
+      'gen_ai.system_instructions': 'system instructions',
     };
 
     const span = testBase.createMockSpan(attributes);
@@ -66,7 +69,7 @@ describe('TestLLOHandlerEvents', () => {
     expect(eventBody.output.messages).toBeDefined();
 
     const inputMessages = eventBody.input.messages;
-    expect(inputMessages.length).toBe(2);
+    expect(inputMessages.length).toBe(4);
 
     const userPrompt = inputMessages.find((msg: any) => msg.content === 'prompt content');
     expect(userPrompt).toBeDefined();
@@ -76,8 +79,16 @@ describe('TestLLOHandlerEvents', () => {
     expect(traceloopInput).toBeDefined();
     expect(traceloopInput.role).toBe('user');
 
+    const structuredInput = inputMessages.find((msg: any) => msg.content === 'structured input');
+    expect(structuredInput).toBeDefined();
+    expect(structuredInput.role).toBe('user');
+
+    const systemInstructions = inputMessages.find((msg: any) => msg.content === 'system instructions');
+    expect(systemInstructions).toBeDefined();
+    expect(systemInstructions.role).toBe('system');
+
     const outputMessages = eventBody.output.messages;
-    expect(outputMessages.length).toBeGreaterThanOrEqual(3);
+    expect(outputMessages.length).toBeGreaterThanOrEqual(5);
 
     const completion = outputMessages.find((msg: any) => msg.content === 'completion content');
     expect(completion).toBeDefined();
@@ -86,6 +97,10 @@ describe('TestLLOHandlerEvents', () => {
     const agentOutput = outputMessages.find((msg: any) => msg.content === 'agent output');
     expect(agentOutput).toBeDefined();
     expect(agentOutput.role).toBe('assistant');
+
+    const structuredOutput = outputMessages.find((msg: any) => msg.content === 'structured output');
+    expect(structuredOutput).toBeDefined();
+    expect(structuredOutput.role).toBe('assistant');
   });
 
   /**
@@ -105,6 +120,9 @@ describe('TestLLOHandlerEvents', () => {
       'input.value': 'How do transformers work?',
       'output.value': 'Transformers are a type of neural network architecture...',
       'crewai.crew.result': 'Task completed successfully',
+      'gen_ai.input.messages': 'OTel input messages',
+      'gen_ai.output.messages': 'OTel output messages',
+      'gen_ai.system_instructions': 'OTel system instructions',
     };
 
     const span = testBase.createMockSpan(attributes);
@@ -130,6 +148,8 @@ describe('TestLLOHandlerEvents', () => {
     expect(inputContents).toContain('What is machine learning?');
     expect(inputContents).toContain('Explain neural networks');
     expect(inputContents).toContain('How do transformers work?');
+    expect(inputContents).toContain('OTel input messages');
+    expect(inputContents).toContain('OTel system instructions');
 
     // Verify output messages from all frameworks
     const outputMessages = eventBody.output.messages;
@@ -139,6 +159,7 @@ describe('TestLLOHandlerEvents', () => {
     expect(outputContents).toContain('Neural networks are computing systems...');
     expect(outputContents).toContain('Transformers are a type of neural network architecture...');
     expect(outputContents).toContain('Task completed successfully');
+    expect(outputContents).toContain('OTel output messages');
 
     inputMessages.forEach((msg: any) => {
       expect(['user', 'system']).toContain(msg.role);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.framework.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.framework.test.ts
@@ -474,7 +474,6 @@ describe('TestLLOHandlerFrameworks', () => {
     const completionMsg = messages.find(m => m.content === 'Assistant response');
     expect(completionMsg).toBeDefined();
 
-    // Check OTel GenAI semantic convention messages
     const inputMsg = messages.find(m => m.content === 'OTel input messages');
     expect(inputMsg).toBeDefined();
     expect(inputMsg!.role).toBe('user');

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.framework.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.framework.test.ts
@@ -451,12 +451,15 @@ describe('TestLLOHandlerFrameworks', () => {
       'llm.prompts': "[{'role': 'system', 'content': 'System prompt'}]",
       'gen_ai.prompt': 'Direct prompt',
       'gen_ai.completion': 'Assistant response',
+      'gen_ai.input.messages': 'OTel input messages',
+      'gen_ai.output.messages': 'OTel output messages',
+      'gen_ai.system_instructions': 'OTel system instructions',
     };
 
     const span = testBase.createMockSpan(attributes);
     const messages = testBase.lloHandler['collectAllLloMessages'](span, attributes);
 
-    expect(messages.length).toBe(3);
+    expect(messages.length).toBe(6);
 
     // Check llm.prompts message
     const llmPromptsMsg = messages.find(m => m.content === attributes['llm.prompts']);
@@ -470,5 +473,21 @@ describe('TestLLOHandlerFrameworks', () => {
 
     const completionMsg = messages.find(m => m.content === 'Assistant response');
     expect(completionMsg).toBeDefined();
+
+    // Check OTel GenAI semantic convention messages
+    const inputMsg = messages.find(m => m.content === 'OTel input messages');
+    expect(inputMsg).toBeDefined();
+    expect(inputMsg!.role).toBe('user');
+    expect(inputMsg!.source).toBe('input');
+
+    const outputMsg = messages.find(m => m.content === 'OTel output messages');
+    expect(outputMsg).toBeDefined();
+    expect(outputMsg!.role).toBe('assistant');
+    expect(outputMsg!.source).toBe('output');
+
+    const systemMsg = messages.find(m => m.content === 'OTel system instructions');
+    expect(systemMsg).toBeDefined();
+    expect(systemMsg!.role).toBe('system');
+    expect(systemMsg!.source).toBe('prompt');
   });
 });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.patterns.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/llo-handler.patterns.test.ts
@@ -102,6 +102,26 @@ describe('TestLLOHandlerPatterns', () => {
   });
 
   /**
+   * Verify isLloAttribute recognizes OTel GenAI semantic convention patterns.
+   */
+  it('should test isLloAttribute otel genai patterns match', () => {
+    expect(testBase.lloHandler['isLloAttribute']('gen_ai.input.messages')).toBeTruthy();
+    expect(testBase.lloHandler['isLloAttribute']('gen_ai.output.messages')).toBeTruthy();
+    expect(testBase.lloHandler['isLloAttribute']('gen_ai.system_instructions')).toBeTruthy();
+  });
+
+  /**
+   * Verify isLloAttribute correctly rejects similar but incorrect OTel GenAI patterns.
+   */
+  it('should test isLloAttribute otel genai patterns no match', () => {
+    expect(testBase.lloHandler['isLloAttribute']('gen_ai.input')).toBeFalsy();
+    expect(testBase.lloHandler['isLloAttribute']('gen_ai.output')).toBeFalsy();
+    expect(testBase.lloHandler['isLloAttribute']('gen_ai.input.message')).toBeFalsy();
+    expect(testBase.lloHandler['isLloAttribute']('gen_ai.output.message')).toBeFalsy();
+    expect(testBase.lloHandler['isLloAttribute']('gen_ai.system_instruction')).toBeFalsy();
+  });
+
+  /**
    * Test buildPatternMatchers handles patterns with missing regex gracefully.
    */
   it('should test build pattern matchers with missing regex', () => {


### PR DESCRIPTION
Parities https://github.com/aws-observability/aws-otel-python-instrumentation/pull/699