### PR TITLE
feat(agent-observability): add GenAiNestedClientSpanProcessor to deduplicate nested CLIENT spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat: add GenAiNestedClientSpanProcessor to deduplicate nested CLIENT spans
+- feat(agent-observability): add GenAiNestedClientSpanProcessor to deduplicate nested CLIENT spans
   ([#413](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/413))
 - fix: Respect OTEL_EXPORTER_OTLP_ENDPOINT in agent observability endpoint configuration
   ([#411](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/411))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat(llo-handler): add gen_ai.input.messages, gen_ai.output.messages, and gen_ai.system_instructions support
+- feat: add GenAiNestedClientSpanProcessor to deduplicate nested CLIENT spans
 - feat(instrumentation-openai-agents): Add native OpenAI Agents instrumentation support
   ([#401](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/401))
 - feat(instrumentation-vercel-ai): Add native Vercel AI instrumentation support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat(agent-observability): register custom instrumentations in OTEL_NODE_ENABLED_INSTRUMENTATIONS default
-  ([#414](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/414))
 - feat: add GenAiNestedClientSpanProcessor to deduplicate nested CLIENT spans
   ([#413](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/413))
 - fix: Respect OTEL_EXPORTER_OTLP_ENDPOINT in agent observability endpoint configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 ## Unreleased
 
 - feat: add GenAiNestedClientSpanProcessor to deduplicate nested CLIENT spans
+  ([#413](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/413))
 - feat(instrumentation-openai-agents): Add native OpenAI Agents instrumentation support
   ([#401](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/401))
 - feat(instrumentation-vercel-ai): Add native Vercel AI instrumentation support

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -74,6 +74,7 @@ import { LIB_VERSION } from './version';
 import { AWSCloudWatchEMFExporter } from './exporter/aws/metrics/aws-cloudwatch-emf-exporter';
 import { OTLPAwsLogExporter } from './exporter/otlp/aws/logs/otlp-aws-log-exporter';
 import { isAgentObservabilityEnabled } from './utils';
+import { GenAiNestedClientSpanProcessor } from './gen-ai-nested-client-span-processor';
 import { BaggageSpanProcessor } from '@opentelemetry/baggage-span-processor';
 import { logs } from '@opentelemetry/api-logs';
 import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
@@ -325,6 +326,7 @@ export class AwsOpentelemetryConfigurator {
       // comprehensive monitoring to catch subtle failure modes like hallucinations
       // and quality degradation that sampling could miss.
       this.exportUnsampledSpanForAgentObservability(spanProcessors, resource);
+      spanProcessors.push(new GenAiNestedClientSpanProcessor());
 
       // Add session.id baggage attribute to span attributes to support AI Agent use cases
       // enabling session ID tracking in spans.

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/gen-ai-nested-client-span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/gen-ai-nested-client-span-processor.ts
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Context, SpanKind } from '@opentelemetry/api';
+import { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import {
+  ATTR_GEN_AI_OPERATION_NAME,
+  GEN_AI_OPERATION_NAME_VALUE_CHAT,
+  GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS,
+  GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT,
+  GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
+} from './instrumentation/common/semconv';
+
+export class GenAiNestedClientSpanProcessor implements SpanProcessor {
+  // OTel GenAI semantic conventions require outgoing LLM calls to be CLIENT spans.
+  // However, the same call can be instrumented by both the agentic framework
+  // and the underlying LLM client SDK, producing nested CLIENT spans for a single request.
+  // This processor converts the outer span to INTERNAL so only the innermost
+  // SDK span remains CLIENT, avoiding the nested CLIENT anti-pattern.
+
+  private _hasGenAiClientChild: Map<string, boolean> = new Map();
+
+  onStart(_span: Span, _parentContext: Context): void {}
+
+  onEnd(span: ReadableSpan): void {
+    if (span.kind !== SpanKind.CLIENT) {
+      return;
+    }
+
+    const parentSpanId = span.parentSpanContext?.spanId;
+    if (parentSpanId) {
+      this._hasGenAiClientChild.set(parentSpanId, true);
+    }
+
+    const operationName = (span.attributes || {})[ATTR_GEN_AI_OPERATION_NAME] as string | undefined;
+    const isLlmSpan =
+      operationName === GEN_AI_OPERATION_NAME_VALUE_CHAT ||
+      operationName === GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION ||
+      operationName === GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT ||
+      operationName === GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS;
+
+    if (isLlmSpan && span.spanContext() && this._hasGenAiClientChild.delete(span.spanContext().spanId)) {
+      (span as any).kind = SpanKind.INTERNAL;
+    }
+  }
+
+  shutdown(): Promise<void> {
+    this._hasGenAiClientChild.clear();
+    return Promise.resolve();
+  }
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -66,6 +66,7 @@ import { OTLPAwsSpanExporter } from '../src/exporter/otlp/aws/traces/otlp-aws-sp
 import { AwsCloudWatchOtlpBatchLogRecordProcessor } from '../src/exporter/otlp/aws/logs/aws-cw-otlp-batch-log-record-processor';
 import { TRACE_PARENT_HEADER } from '@opentelemetry/core';
 import { ConsoleEMFExporter } from '../src/exporter/aws/metrics/console-emf-exporter';
+import { GenAiNestedClientSpanProcessor } from '../src/gen-ai-nested-client-span-processor';
 
 // Tests AwsOpenTelemetryConfigurator after running Environment Variable setup in register.ts
 describe('AwsOpenTelemetryConfiguratorTest', () => {
@@ -507,12 +508,13 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
     process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED = 'True';
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, emptyResource());
-    expect(spanProcessors.length).toEqual(3);
+    expect(spanProcessors.length).toEqual(4);
 
     // Verify processors are added in the expected order
-    expect(spanProcessors[0]).toBeInstanceOf(BaggageSpanProcessor);
-    expect(spanProcessors[1]).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    expect(spanProcessors[2]).toBeInstanceOf(AwsSpanMetricsProcessor);
+    expect(spanProcessors[0]).toBeInstanceOf(GenAiNestedClientSpanProcessor);
+    expect(spanProcessors[1]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(spanProcessors[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect(spanProcessors[3]).toBeInstanceOf(AwsSpanMetricsProcessor);
 
     // shut down exporters for test cleanup
     spanProcessors.forEach(spanProcessor => {
@@ -533,11 +535,11 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     // Test that BaggageSpanProcessor is added when agent observability is enabled
     process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
-    expect(spanProcessorsToTest.length).toEqual(1);
+    expect(spanProcessorsToTest.length).toEqual(2);
 
-    // Verify the added processor is BaggageSpanProcessor
-    const addedProcessor = spanProcessorsToTest[0];
-    expect(addedProcessor).toBeInstanceOf(BaggageSpanProcessor);
+    // Verify the added processors
+    expect(spanProcessorsToTest[0]).toBeInstanceOf(GenAiNestedClientSpanProcessor);
+    expect(spanProcessorsToTest[1]).toBeInstanceOf(BaggageSpanProcessor);
 
     // Clean up
     delete process.env.AGENT_OBSERVABILITY_ENABLED;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/gen-ai-nested-client-span-processor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/gen-ai-nested-client-span-processor.test.ts
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { context, SpanKind, trace } from '@opentelemetry/api';
+import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import { expect } from 'expect';
+import { GenAiNestedClientSpanProcessor } from '../src/gen-ai-nested-client-span-processor';
+import {
+  ATTR_GEN_AI_OPERATION_NAME,
+  GEN_AI_OPERATION_NAME_VALUE_CHAT,
+  GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS,
+  GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT,
+  GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT,
+  GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
+} from '../src/instrumentation/common/semconv';
+
+describe('TestGenAiNestedClientSpanProcessor', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  let tracer: ReturnType<NodeTracerProvider['getTracer']>;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider({
+      spanProcessors: [new GenAiNestedClientSpanProcessor(), new SimpleSpanProcessor(exporter)],
+    });
+    tracer = provider.getTracer('test');
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+  });
+
+  function makeLlmSpan(
+    name: string = 'chat model',
+    op: string = GEN_AI_OPERATION_NAME_VALUE_CHAT,
+    kind: SpanKind = SpanKind.CLIENT,
+    ctx?: ReturnType<typeof context.active>
+  ) {
+    const span = tracer.startSpan(name, { kind }, ctx);
+    span.setAttribute(ATTR_GEN_AI_OPERATION_NAME, op);
+    return span;
+  }
+
+  it('should convert parent to INTERNAL when nested LLM CLIENT child exists', () => {
+    const parent = makeLlmSpan();
+    const ctx = trace.setSpan(context.active(), parent);
+    const child = makeLlmSpan('chat model', GEN_AI_OPERATION_NAME_VALUE_CHAT, SpanKind.CLIENT, ctx);
+    child.end();
+    parent.end();
+
+    const spans = exporter.getFinishedSpans();
+    const childSpan = spans[0];
+    const parentSpan = spans[1];
+    expect(childSpan.kind).toBe(SpanKind.CLIENT);
+    expect(parentSpan.kind).toBe(SpanKind.INTERNAL);
+  });
+
+  it('should convert parent when HTTP child span exists', () => {
+    const parent = makeLlmSpan();
+    const ctx = trace.setSpan(context.active(), parent);
+    const child = tracer.startSpan('POST', { kind: SpanKind.CLIENT }, ctx);
+    child.end();
+    parent.end();
+
+    const spans = exporter.getFinishedSpans();
+    const parentSpan = spans.find(s => s.name === 'chat model')!;
+    expect(parentSpan.kind).toBe(SpanKind.INTERNAL);
+  });
+
+  it('should keep CLIENT when no child exists', () => {
+    const span = makeLlmSpan();
+    span.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    expect(spans[0].kind).toBe(SpanKind.CLIENT);
+  });
+
+  it('should convert text_completion parent by child', () => {
+    const parent = makeLlmSpan('chat model', GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION);
+    const ctx = trace.setSpan(context.active(), parent);
+    const child = makeLlmSpan('chat model', GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION, SpanKind.CLIENT, ctx);
+    child.end();
+    parent.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].kind).toBe(SpanKind.CLIENT);
+    expect(spans[1].kind).toBe(SpanKind.INTERNAL);
+  });
+
+  it('should convert embeddings parent by child', () => {
+    const parent = makeLlmSpan('chat model', GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS);
+    const ctx = trace.setSpan(context.active(), parent);
+    const child = makeLlmSpan('chat model', GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS, SpanKind.CLIENT, ctx);
+    child.end();
+    parent.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].kind).toBe(SpanKind.CLIENT);
+    expect(spans[1].kind).toBe(SpanKind.INTERNAL);
+  });
+
+  it('should convert generate_content parent by child', () => {
+    const parent = makeLlmSpan('chat model', GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT);
+    const ctx = trace.setSpan(context.active(), parent);
+    const child = makeLlmSpan('chat model', GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT, SpanKind.CLIENT, ctx);
+    child.end();
+    parent.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].kind).toBe(SpanKind.CLIENT);
+    expect(spans[1].kind).toBe(SpanKind.INTERNAL);
+  });
+
+  it('should not convert non-LLM operation', () => {
+    const span = tracer.startSpan('invoke_agent MyAgent', { kind: SpanKind.CLIENT });
+    span.setAttribute(ATTR_GEN_AI_OPERATION_NAME, GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT);
+    span.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].kind).toBe(SpanKind.CLIENT);
+  });
+
+  it('should not modify INTERNAL span', () => {
+    const span = tracer.startSpan('chat model', { kind: SpanKind.INTERNAL });
+    span.setAttribute(ATTR_GEN_AI_OPERATION_NAME, GEN_AI_OPERATION_NAME_VALUE_CHAT);
+    span.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].kind).toBe(SpanKind.INTERNAL);
+  });
+
+  it('should not modify span without gen_ai attribute', () => {
+    const span = tracer.startSpan('some-span', { kind: SpanKind.CLIENT });
+    span.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].kind).toBe(SpanKind.CLIENT);
+  });
+
+  it('should keep CLIENT when no parent', () => {
+    const span = makeLlmSpan();
+    span.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].kind).toBe(SpanKind.CLIENT);
+  });
+
+  it('should clear state on shutdown', async () => {
+    const processor = new GenAiNestedClientSpanProcessor();
+    (processor as any)._hasGenAiClientChild.set('123', true);
+    expect((processor as any)._hasGenAiClientChild.size).toBe(1);
+    await processor.shutdown();
+    expect((processor as any)._hasGenAiClientChild.size).toBe(0);
+  });
+
+  it('should return resolved promise from forceFlush', async () => {
+    const processor = new GenAiNestedClientSpanProcessor();
+    await processor.forceFlush();
+  });
+});


### PR DESCRIPTION
Parities: https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py