### PR TITLE
feat(agent-observability): register custom instrumentations in OTEL_NODE_ENABLED_INSTRUMENTATIONS default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix: register custom instrumentations in OTEL_NODE_ENABLED_INSTRUMENTATIONS default
 - feat(instrumentation-openai-agents): Add native OpenAI Agents instrumentation support
   ([#401](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/401))
 - feat(instrumentation-vercel-ai): Add native Vercel AI instrumentation support

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -73,8 +73,6 @@ export function setAwsDefaultEnvironmentVariables() {
     if (!process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS) {
       // Assume users only need aws-sdk, aws-lambda, and our custom GenAI instrumentations,
       // as well as instrumentations that are manually set-up outside of OpenTelemetry.
-      // Our custom instrumentation short names are added after getNodeAutoInstrumentations()
-      // to avoid upstream logging "Provided instrumentation name not found" warnings.
       process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS = `aws-lambda,aws-sdk,http,${LANGCHAIN_SHORT_NAME},${OPENAI_AGENTS_SHORT_NAME},${VERCEL_AI_SHORT_NAME}`;
     }
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -75,7 +75,7 @@ export function setAwsDefaultEnvironmentVariables() {
       // instrumentations that are manually set-up outside of OpenTelemetry.
       // Our custom instrumentation short names are added after getNodeAutoInstrumentations()
       // to avoid upstream logging "Provided instrumentation name not found" warnings.
-      process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS = 'aws-lambda,aws-sdk,http';
+      process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS = `aws-lambda,aws-sdk,http,${LANGCHAIN_SHORT_NAME},${OPENAI_AGENTS_SHORT_NAME},${VERCEL_AI_SHORT_NAME}`;
     }
 
     // Set exporter defaults

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -71,8 +71,8 @@ export function setAwsDefaultEnvironmentVariables() {
 
   if (isAgentObservabilityEnabled()) {
     if (!process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS) {
-      // Assume users only need aws-sdk and aws-lambda instrumentations, as well as
-      // instrumentations that are manually set-up outside of OpenTelemetry.
+      // Assume users only need aws-sdk, aws-lambda, and our custom GenAI instrumentations,
+      // as well as instrumentations that are manually set-up outside of OpenTelemetry.
       // Our custom instrumentation short names are added after getNodeAutoInstrumentations()
       // to avoid upstream logging "Provided instrumentation name not found" warnings.
       process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS = `aws-lambda,aws-sdk,http,${LANGCHAIN_SHORT_NAME},${OPENAI_AGENTS_SHORT_NAME},${VERCEL_AI_SHORT_NAME}`;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -227,7 +227,9 @@ describe('Register', function () {
       expect(process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT).toEqual('true');
       expect(process.env.OTEL_TRACES_SAMPLER).toEqual('parentbased_always_on');
       expect(process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS).toEqual('fs,dns');
-      expect(process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS).toEqual('aws-lambda,aws-sdk,http');
+      expect(process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS).toEqual(
+        'aws-lambda,aws-sdk,http,aws_langchain,aws_openai_agents,aws_vercel_ai'
+      );
       expect(process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED).toEqual('false');
       expect(process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).toEqual('https://xray.us-east-1.amazonaws.com/v1/traces');
       expect(process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).toEqual('https://logs.us-east-1.amazonaws.com/v1/logs');


### PR DESCRIPTION
When `AGENT_OBSERVABILITY_ENABLED=true` and `OTEL_NODE_ENABLED_INSTRUMENTATIONS` is not set, the default value only included `aws-lambda,aws-sdk,http`. This caused our custom instrumentations (`aws_langchain`, `aws_openai_agents`, `aws_vercel_ai`) to be filtered out by `isInstrumentationDisabled()` since they were not in the enabled list.

This adds the three custom instrumentation short names to the default enabled list.