### PR TITLE
feat: add env var BaggageSpanProcessor by default in ADOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: add BaggageSpanProcessor by default with OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS support
+  ([#415](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/415))
 - fix: Respect OTEL_EXPORTER_OTLP_ENDPOINT in agent observability endpoint configuration
   ([#411](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/411))
 - feat(llo-handler): add gen_ai.input.messages, gen_ai.output.messages, and gen_ai.system_instructions support

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -73,7 +73,7 @@ import { AwsXRayRemoteSampler } from './sampler/aws-xray-remote-sampler';
 import { LIB_VERSION } from './version';
 import { AWSCloudWatchEMFExporter } from './exporter/aws/metrics/aws-cloudwatch-emf-exporter';
 import { OTLPAwsLogExporter } from './exporter/otlp/aws/logs/otlp-aws-log-exporter';
-import { isAgentObservabilityEnabled } from './utils';
+import { isAgentObservabilityEnabled, parseOtelBaggageKeysEnvVar } from './utils';
 import { BaggageSpanProcessor } from '@opentelemetry/baggage-span-processor';
 import { logs } from '@opentelemetry/api-logs';
 import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
@@ -319,20 +319,19 @@ export class AwsOpentelemetryConfigurator {
   }
 
   static customizeSpanProcessors(spanProcessors: SpanProcessor[], resource: Resource): void {
+    // Propagates baggage entries matching OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS into span attributes.
+    const baggageKeys: Set<string> = parseOtelBaggageKeysEnvVar();
+
     if (isAgentObservabilityEnabled()) {
       // We always send 100% spans to Genesis platform for agent observability because
       // AI applications typically have low throughput traffic patterns and require
       // comprehensive monitoring to catch subtle failure modes like hallucinations
       // and quality degradation that sampling could miss.
       this.exportUnsampledSpanForAgentObservability(spanProcessors, resource);
-
-      // Add session.id baggage attribute to span attributes to support AI Agent use cases
-      // enabling session ID tracking in spans.
-      const sessionIdPredicate = (baggageKey: string) => {
-        return baggageKey === 'session.id';
-      };
-      spanProcessors.push(new BaggageSpanProcessor(sessionIdPredicate));
+      baggageKeys.add('session.id');
     }
+
+    spanProcessors.push(new BaggageSpanProcessor((key: string) => baggageKeys.has(key)));
 
     if (!AwsOpentelemetryConfigurator.isApplicationSignalsEnabled()) {
       return;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -319,15 +319,17 @@ export class AwsOpentelemetryConfigurator {
   }
 
   static customizeSpanProcessors(spanProcessors: SpanProcessor[], resource: Resource): void {
-    // Propagates baggage entries matching OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS into span attributes.
     const baggageKeys: Set<string> = parseOtelBaggageKeysEnvVar();
 
     if (isAgentObservabilityEnabled()) {
-      // We always send 100% spans to Genesis platform for agent observability because
+      // We always send 100% spans to Bedrock AgentCore platform for agent observability because
       // AI applications typically have low throughput traffic patterns and require
       // comprehensive monitoring to catch subtle failure modes like hallucinations
       // and quality degradation that sampling could miss.
       this.exportUnsampledSpanForAgentObservability(spanProcessors, resource);
+
+      // Add session.id baggage attribute to span attributes to support AI Agent use cases
+      // enabling session ID tracking in spans.
       baggageKeys.add('session.id');
     }
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
@@ -4,6 +4,7 @@
 import { diag } from '@opentelemetry/api';
 
 const AGENT_OBSERVABILITY_ENABLED = 'AGENT_OBSERVABILITY_ENABLED';
+export const OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS = 'OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS';
 
 // Bypass `readonly` restriction of a Type.
 // Workaround provided from official TypeScript docs:
@@ -55,8 +56,6 @@ export const getAwsRegionFromEnvironment = (): string | undefined => {
 
   return undefined;
 };
-
-export const OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS = 'OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS';
 
 export const parseOtelBaggageKeysEnvVar = (): Set<string> => {
   const raw = (process.env[OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS] || '').trim();

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
@@ -56,6 +56,20 @@ export const getAwsRegionFromEnvironment = (): string | undefined => {
   return undefined;
 };
 
+export const OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS = 'OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS';
+
+export const parseOtelBaggageKeysEnvVar = (): Set<string> => {
+  const raw = (process.env[OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS] || '').trim();
+  const keys = new Set<string>();
+  for (const k of raw.split(',')) {
+    const trimmed = k.trim();
+    if (trimmed) {
+      keys.add(trimmed);
+    }
+  }
+  return keys;
+};
+
 export const isInstrumentationDisabled = (shortName: string): boolean => {
   const disabledEnv = process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS;
   if (disabledEnv) {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
@@ -58,7 +58,7 @@ export const getAwsRegionFromEnvironment = (): string | undefined => {
 };
 
 export const parseOtelBaggageKeysEnvVar = (): Set<string> => {
-  const raw = (process.env[OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS] || '').trim();
+  const raw = process.env[OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS] ?? '';
   const keys = new Set<string>();
   for (const k of raw.split(',')) {
     const trimmed = k.trim();

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -474,6 +474,7 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED = 'True';
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, emptyResource());
     expect(spanProcessors.length).toEqual(4);
+    expect(spanProcessors[0]).toBeInstanceOf(BaggageSpanProcessor);
     expect(spanProcessors[1]).toBeInstanceOf(BaggageSpanProcessor);
     expect(spanProcessors[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
     expect(spanProcessors[3]).toBeInstanceOf(AwsSpanMetricsProcessor);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -468,15 +468,15 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     // Test application signals only
     let spanProcessors: SpanProcessor[] = [];
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, emptyResource());
-    expect(spanProcessors.length).toEqual(0);
+    expect(spanProcessors.length).toEqual(1);
+    expect(spanProcessors[0]).toBeInstanceOf(BaggageSpanProcessor);
 
     process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED = 'True';
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, emptyResource());
-    expect(spanProcessors.length).toEqual(2);
-    const firstProcessor: SpanProcessor = spanProcessors[0];
-    expect(firstProcessor).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    const secondProcessor: SpanProcessor = spanProcessors[1];
-    expect(secondProcessor).toBeInstanceOf(AwsSpanMetricsProcessor);
+    expect(spanProcessors.length).toEqual(4);
+    expect(spanProcessors[1]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(spanProcessors[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect(spanProcessors[3]).toBeInstanceOf(AwsSpanMetricsProcessor);
     delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;
 
     try {
@@ -525,56 +525,90 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
   it('CustomizeSpanProcessorsWithAgentObservabilityTest', () => {
     const spanProcessorsToTest: SpanProcessor[] = [];
 
-    // Test that BaggageSpanProcessor is not added when agent observability is disabled
+    // BaggageSpanProcessor is always added, even when agent observability is disabled
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
-    expect(spanProcessorsToTest).toEqual([]);
-
-    // Test that BaggageSpanProcessor is added when agent observability is enabled
-    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
-    AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
     expect(spanProcessorsToTest.length).toEqual(1);
-
-    // Verify the added processor is BaggageSpanProcessor
-    const addedProcessor = spanProcessorsToTest[0];
-    expect(addedProcessor).toBeInstanceOf(BaggageSpanProcessor);
+    expect(spanProcessorsToTest[0]).toBeInstanceOf(BaggageSpanProcessor);
 
     // Clean up
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
   });
 
   it('BaggageSpanProcessorSessionIdFilteringTest', () => {
-    // Set up agent observability
     process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    delete process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS;
 
-    // Create a SpanProcessor list for this test
     const spanProcessorsToTest: SpanProcessor[] = [];
-
-    // Add our span processors
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
 
-    // Verify that the BaggageSpanProcessor was added
-    const baggageProcessors = spanProcessorsToTest.filter(
-      processor => processor.constructor.name === 'BaggageSpanProcessor'
-    );
-    expect(baggageProcessors.length).toBe(1);
-
-    // Verify the predicate function only accepts session.id
-    const baggageProcessor = baggageProcessors[0];
+    const baggageProcessor = spanProcessorsToTest.find(p => p instanceof BaggageSpanProcessor)!;
     expect(baggageProcessor).toBeInstanceOf(BaggageSpanProcessor);
     const predicate = (baggageProcessor as BaggageSpanProcessor)['_keyPredicate'].bind(baggageProcessor);
 
-    // Test the predicate function directly
     expect(predicate('session.id')).toBeTruthy();
     expect(predicate('user.id')).toBeFalsy();
-    expect(predicate('request.id')).toBeFalsy();
-    expect(predicate('other.key')).toBeFalsy();
-    expect(predicate('')).toBeFalsy();
-    expect(predicate('session')).toBeFalsy();
-    expect(predicate('id')).toBeFalsy();
 
-    // Clean up
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    delete process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS;
+  });
+
+  it('BaggageSpanProcessorCustomKeysTest', () => {
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS = 'user.id, request.id';
+
+    const spanProcessorsToTest: SpanProcessor[] = [];
+    AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
+
+    const baggageProcessor = spanProcessorsToTest.find(p => p instanceof BaggageSpanProcessor)!;
+    const predicate = (baggageProcessor as BaggageSpanProcessor)['_keyPredicate'].bind(baggageProcessor);
+
+    expect(predicate('user.id')).toBeTruthy();
+    expect(predicate('request.id')).toBeTruthy();
+    expect(predicate('session.id')).toBeTruthy();
+
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    delete process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS;
+  });
+
+  it('BaggageSpanProcessorRejectsKeysWithoutCustomConfigTest', () => {
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    delete process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS;
+
+    const spanProcessorsToTest: SpanProcessor[] = [];
+    AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
+
+    const baggageProcessor = spanProcessorsToTest.find(p => p instanceof BaggageSpanProcessor)!;
+    const predicate = (baggageProcessor as BaggageSpanProcessor)['_keyPredicate'].bind(baggageProcessor);
+
+    expect(predicate('any.key')).toBeFalsy();
+
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    delete process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS;
+  });
+
+  it('SessionIdAlwaysAddedWhenAgentObservabilityEnabledTest', () => {
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+
+    // Without custom baggage keys
+    delete process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS;
+    let spanProcessorsToTest: SpanProcessor[] = [];
+    AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
+    let baggageProcessor = spanProcessorsToTest.find(p => p instanceof BaggageSpanProcessor)!;
+    let predicate = (baggageProcessor as BaggageSpanProcessor)['_keyPredicate'].bind(baggageProcessor);
+    expect(predicate('session.id')).toBeTruthy();
+
+    // With custom baggage keys
+    process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS = 'custom.key';
+    spanProcessorsToTest = [];
+    AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
+    baggageProcessor = spanProcessorsToTest.find(p => p instanceof BaggageSpanProcessor)!;
+    predicate = (baggageProcessor as BaggageSpanProcessor)['_keyPredicate'].bind(baggageProcessor);
+    expect(predicate('session.id')).toBeTruthy();
+    expect(predicate('custom.key')).toBeTruthy();
+
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    delete process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS;
   });
 
   it('ApplicationSignalsExporterProviderTest', () => {
@@ -747,7 +781,8 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     expect((config.spanProcessors as any)[0]).toBeInstanceOf(BatchSpanProcessor);
     expect((config.spanProcessors as any)[0]._exporter).toBeInstanceOf(OTLPUdpSpanExporter);
     expect((config.spanProcessors as any)[0]._exporter._endpoint).toBe('www.test.com:2222');
-    expect(config.spanProcessors?.length).toEqual(1);
+    expect((config.spanProcessors as any)[1]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(config.spanProcessors?.length).toEqual(2);
 
     delete process.env.AWS_LAMBDA_FUNCTION_NAME;
     delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;
@@ -760,11 +795,10 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     process.env.AWS_LAMBDA_FUNCTION_NAME = 'TestFunction';
     const spanProcessors: SpanProcessor[] = [];
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, emptyResource());
-    expect(spanProcessors.length).toEqual(2);
-    const firstProcessor: SpanProcessor = spanProcessors[0];
-    expect(firstProcessor).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    const secondProcessor: SpanProcessor = spanProcessors[1];
-    expect(secondProcessor).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
+    expect(spanProcessors.length).toEqual(3);
+    expect(spanProcessors[0]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(spanProcessors[1]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect(spanProcessors[2]).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
     delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;
     delete process.env.AWS_LAMBDA_FUNCTION_NAME;
   });
@@ -847,24 +881,27 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     // Default scenario where no trace exporter is specified
     process.env.OTEL_TRACES_EXPORTER = 'none';
     config = new AwsOpentelemetryConfigurator([]).configure();
-    expect((config.spanProcessors as any)[0]).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    expect((config.spanProcessors as any)[1]).toBeInstanceOf(AwsSpanMetricsProcessor);
-    expect(config.spanProcessors?.length).toEqual(2);
+    expect((config.spanProcessors as any)[0]).toBeInstanceOf(BaggageSpanProcessor);
+    expect((config.spanProcessors as any)[1]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect((config.spanProcessors as any)[2]).toBeInstanceOf(AwsSpanMetricsProcessor);
+    expect(config.spanProcessors?.length).toEqual(3);
 
     // Scenario where otlp trace exporter is specified, adds one more exporter compared to default case
     process.env.OTEL_TRACES_EXPORTER = 'otlp';
     config = new AwsOpentelemetryConfigurator([]).configure();
     expect((config.spanProcessors as any)[0]._exporter.delegate).toBeInstanceOf(OTLPProtoTraceExporter);
-    expect((config.spanProcessors as any)[1]).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    expect((config.spanProcessors as any)[2]).toBeInstanceOf(AwsSpanMetricsProcessor);
-    expect(config.spanProcessors?.length).toEqual(3);
+    expect((config.spanProcessors as any)[1]).toBeInstanceOf(BaggageSpanProcessor);
+    expect((config.spanProcessors as any)[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect((config.spanProcessors as any)[3]).toBeInstanceOf(AwsSpanMetricsProcessor);
+    expect(config.spanProcessors?.length).toEqual(4);
 
     // Specify invalid exporter, same result as default scenario where no trace exporter is specified
     process.env.OTEL_TRACES_EXPORTER = 'invalid_exporter_name';
     config = new AwsOpentelemetryConfigurator([]).configure();
-    expect((config.spanProcessors as any)[0]).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    expect((config.spanProcessors as any)[1]).toBeInstanceOf(AwsSpanMetricsProcessor);
-    expect(config.spanProcessors?.length).toEqual(2);
+    expect((config.spanProcessors as any)[0]).toBeInstanceOf(BaggageSpanProcessor);
+    expect((config.spanProcessors as any)[1]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect((config.spanProcessors as any)[2]).toBeInstanceOf(AwsSpanMetricsProcessor);
+    expect(config.spanProcessors?.length).toEqual(3);
 
     // Cleanup
     delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -525,30 +525,51 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
   it('CustomizeSpanProcessorsWithAgentObservabilityTest', () => {
     const spanProcessorsToTest: SpanProcessor[] = [];
 
-    // BaggageSpanProcessor is always added, even when agent observability is disabled
+    // Test that only BaggageSpanProcessor is added when agent observability is disabled
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
     expect(spanProcessorsToTest.length).toEqual(1);
-    expect(spanProcessorsToTest[0]).toBeInstanceOf(BaggageSpanProcessor);
+
+    // Verify the added processor is BaggageSpanProcessor
+    const addedProcessor = spanProcessorsToTest[0];
+    expect(addedProcessor).toBeInstanceOf(BaggageSpanProcessor);
 
     // Clean up
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
   });
 
   it('BaggageSpanProcessorSessionIdFilteringTest', () => {
+    // Set up agent observability
     process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
     delete process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS;
 
+    // Create a SpanProcessor list for this test
     const spanProcessorsToTest: SpanProcessor[] = [];
+
+    // Add our span processors
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
 
-    const baggageProcessor = spanProcessorsToTest.find(p => p instanceof BaggageSpanProcessor)!;
+    // Verify that the BaggageSpanProcessor was added
+    const baggageProcessors = spanProcessorsToTest.filter(
+      processor => processor.constructor.name === 'BaggageSpanProcessor'
+    );
+    expect(baggageProcessors.length).toBe(1);
+
+    // Verify the predicate function only accepts session.id
+    const baggageProcessor = baggageProcessors[0];
     expect(baggageProcessor).toBeInstanceOf(BaggageSpanProcessor);
     const predicate = (baggageProcessor as BaggageSpanProcessor)['_keyPredicate'].bind(baggageProcessor);
 
+    // Test the predicate function directly
     expect(predicate('session.id')).toBeTruthy();
     expect(predicate('user.id')).toBeFalsy();
+    expect(predicate('request.id')).toBeFalsy();
+    expect(predicate('other.key')).toBeFalsy();
+    expect(predicate('')).toBeFalsy();
+    expect(predicate('session')).toBeFalsy();
+    expect(predicate('id')).toBeFalsy();
 
+    // Clean up
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
     delete process.env.OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS;
   });


### PR DESCRIPTION
## Summary

Parities: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/687