### PR TITLE
fix: fall back to OTEL_EXPORTER_OTLP_ENDPOINT for unsampled spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: auto-detect and mutually exclude native vs third-party agentic instrumentors
+  ([#417](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/417))
 - feat(agent-observability): add GenAiNestedClientSpanProcessor to deduplicate nested CLIENT spans
   ([#413](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/413))
 - feat: add BaggageSpanProcessor by default with OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS support

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -298,11 +298,10 @@ export class AwsOpentelemetryConfigurator {
       return;
     }
 
-    // Get the traces endpoint from environment
-    const tracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    const tracesEndpoint =
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 
     if (!tracesEndpoint) {
-      // No traces endpoint configured, skip unsampled span export
       diag.warn('No traces endpoint configured for agent observability unsampled spans');
       return;
     }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/instrumentation.ts
@@ -11,7 +11,11 @@ import {
 } from '@opentelemetry/instrumentation';
 import { LIB_VERSION } from '../../version';
 import { LangChainInstrumentationConfig } from './types';
-import { isAgenticInstrumentationOptIn, isInstrumentationDisabled, findInstrumentation } from '../../utils';
+import {
+  isAgenticInstrumentationOptIn,
+  isInstrumentationDisabled,
+  detectConflictingInstrumentation,
+} from '../../utils';
 
 export const INSTRUMENTATION_NAME = '@aws/aws-distro-opentelemetry-instrumentation-langchain';
 export const INSTRUMENTATION_SHORT_NAME = 'aws_langchain';
@@ -41,7 +45,7 @@ export class LangChainInstrumentation extends InstrumentationBase<LangChainInstr
     }
 
     if (!isAgenticInstrumentationOptIn()) {
-      const conflict = findInstrumentation([['langchain'], ['langgraph']]);
+      const conflict = detectConflictingInstrumentation(INSTRUMENTATION_SHORT_NAME);
       if (conflict) {
         this._diag.info(
           `Skipping ${INSTRUMENTATION_NAME}: third-party '${conflict}' detected. ` +

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/instrumentation.ts
@@ -11,6 +11,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { LIB_VERSION } from '../../version';
 import { LangChainInstrumentationConfig } from './types';
+import { isAgenticInstrumentationOptIn, isInstrumentationDisabled, findInstrumentation } from '../../utils';
 
 export const INSTRUMENTATION_NAME = '@aws/aws-distro-opentelemetry-instrumentation-langchain';
 export const INSTRUMENTATION_SHORT_NAME = 'aws_langchain';
@@ -31,6 +32,25 @@ export class LangChainInstrumentation extends InstrumentationBase<LangChainInstr
   override setConfig(config: LangChainInstrumentationConfig = {}) {
     super.setConfig({ ...config, captureMessageContent: !!config.captureMessageContent });
     this._handler = undefined;
+  }
+
+  override enable() {
+    if (isInstrumentationDisabled(INSTRUMENTATION_SHORT_NAME)) {
+      this._diag.debug(`${INSTRUMENTATION_NAME} is disabled`);
+      return;
+    }
+
+    if (!isAgenticInstrumentationOptIn()) {
+      const conflict = findInstrumentation([['langchain'], ['langgraph']]);
+      if (conflict) {
+        this._diag.info(
+          `Skipping ${INSTRUMENTATION_NAME}: third-party '${conflict}' detected. ` +
+            'Set AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true to override.'
+        );
+        return;
+      }
+    }
+    super.enable();
   }
 
   protected init() {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/instrumentation.ts
@@ -12,7 +12,11 @@ import {
 import { LIB_VERSION } from '../../version';
 import { OpenAIAgentsInstrumentationConfig } from './types';
 import { OpenTelemetryTracingProcessor } from './tracing-processor';
-import { isAgenticInstrumentationOptIn, isInstrumentationDisabled, findInstrumentation } from '../../utils';
+import {
+  isAgenticInstrumentationOptIn,
+  isInstrumentationDisabled,
+  detectConflictingInstrumentation,
+} from '../../utils';
 
 export const INSTRUMENTATION_NAME = '@aws/aws-distro-opentelemetry-instrumentation-openai-agents';
 export const INSTRUMENTATION_SHORT_NAME = 'aws_openai_agents';
@@ -42,7 +46,7 @@ export class OpenAIAgentsInstrumentation extends InstrumentationBase<OpenAIAgent
     }
 
     if (!isAgenticInstrumentationOptIn()) {
-      const conflict = findInstrumentation([['openai', 'agents']]);
+      const conflict = detectConflictingInstrumentation(INSTRUMENTATION_SHORT_NAME);
       if (conflict) {
         this._diag.info(
           `Skipping ${INSTRUMENTATION_NAME}: third-party '${conflict}' detected. ` +

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/instrumentation.ts
@@ -12,6 +12,7 @@ import {
 import { LIB_VERSION } from '../../version';
 import { OpenAIAgentsInstrumentationConfig } from './types';
 import { OpenTelemetryTracingProcessor } from './tracing-processor';
+import { isAgenticInstrumentationOptIn, isInstrumentationDisabled, findInstrumentation } from '../../utils';
 
 export const INSTRUMENTATION_NAME = '@aws/aws-distro-opentelemetry-instrumentation-openai-agents';
 export const INSTRUMENTATION_SHORT_NAME = 'aws_openai_agents';
@@ -32,6 +33,25 @@ export class OpenAIAgentsInstrumentation extends InstrumentationBase<OpenAIAgent
 
   override setConfig(config: OpenAIAgentsInstrumentationConfig = {}) {
     super.setConfig({ ...config, captureMessageContent: !!config.captureMessageContent });
+  }
+
+  override enable() {
+    if (isInstrumentationDisabled(INSTRUMENTATION_SHORT_NAME)) {
+      this._diag.debug(`${INSTRUMENTATION_NAME} is disabled`);
+      return;
+    }
+
+    if (!isAgenticInstrumentationOptIn()) {
+      const conflict = findInstrumentation([['openai', 'agents']]);
+      if (conflict) {
+        this._diag.info(
+          `Skipping ${INSTRUMENTATION_NAME}: third-party '${conflict}' detected. ` +
+            'Set AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true to override.'
+        );
+        return;
+      }
+    }
+    super.enable();
   }
 
   override _updateMetricInstruments() {}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/instrumentation.ts
@@ -8,7 +8,11 @@ import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opent
 import { LIB_VERSION } from '../../version';
 import { VercelAIInstrumentationConfig } from './types';
 import { VercelAISpanProcessor } from './span-processor';
-import { isAgenticInstrumentationOptIn, isInstrumentationDisabled, findInstrumentation } from '../../utils';
+import {
+  isAgenticInstrumentationOptIn,
+  isInstrumentationDisabled,
+  detectConflictingInstrumentation,
+} from '../../utils';
 
 export const INSTRUMENTATION_NAME = '@aws/aws-distro-opentelemetry-instrumentation-vercel-ai';
 export const INSTRUMENTATION_SHORT_NAME = 'aws_vercel_ai';
@@ -50,7 +54,7 @@ export class VercelAIInstrumentation extends InstrumentationBase<VercelAIInstrum
     }
 
     if (!isAgenticInstrumentationOptIn()) {
-      const conflict = findInstrumentation([['vercel']]);
+      const conflict = detectConflictingInstrumentation(INSTRUMENTATION_SHORT_NAME);
       if (conflict) {
         this._diag.info(
           `Skipping ${INSTRUMENTATION_NAME}: third-party '${conflict}' detected. ` +

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/instrumentation.ts
@@ -8,6 +8,7 @@ import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opent
 import { LIB_VERSION } from '../../version';
 import { VercelAIInstrumentationConfig } from './types';
 import { VercelAISpanProcessor } from './span-processor';
+import { isAgenticInstrumentationOptIn, isInstrumentationDisabled, findInstrumentation } from '../../utils';
 
 export const INSTRUMENTATION_NAME = '@aws/aws-distro-opentelemetry-instrumentation-vercel-ai';
 export const INSTRUMENTATION_SHORT_NAME = 'aws_vercel_ai';
@@ -40,6 +41,25 @@ export class VercelAIInstrumentation extends InstrumentationBase<VercelAIInstrum
 
   override setConfig(config: VercelAIInstrumentationConfig = {}) {
     super.setConfig({ ...config, captureMessageContent: !!config.captureMessageContent });
+  }
+
+  override enable() {
+    if (isInstrumentationDisabled(INSTRUMENTATION_SHORT_NAME)) {
+      this._diag.debug(`${INSTRUMENTATION_NAME} is disabled`);
+      return;
+    }
+
+    if (!isAgenticInstrumentationOptIn()) {
+      const conflict = findInstrumentation([['vercel']]);
+      if (conflict) {
+        this._diag.info(
+          `Skipping ${INSTRUMENTATION_NAME}: third-party '${conflict}' detected. ` +
+            'Set AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true to override.'
+        );
+        return;
+      }
+    }
+    super.enable();
   }
 
   override setTracerProvider(provider: any): void {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -73,7 +73,7 @@ export function setAwsDefaultEnvironmentVariables() {
     if (!process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS) {
       // Assume users only need aws-sdk, aws-lambda, and our custom GenAI instrumentations,
       // as well as instrumentations that are manually set-up outside of OpenTelemetry.
-      process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS = `aws-lambda,aws-sdk,http,${LANGCHAIN_SHORT_NAME},${OPENAI_AGENTS_SHORT_NAME},${VERCEL_AI_SHORT_NAME}`;
+      process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS = `aws-lambda,aws-sdk,http,undici,${LANGCHAIN_SHORT_NAME},${OPENAI_AGENTS_SHORT_NAME},${VERCEL_AI_SHORT_NAME}`;
     }
 
     // Set exporter defaults

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -33,7 +33,7 @@ import {
   INSTRUMENTATION_SHORT_NAME as VERCEL_AI_SHORT_NAME,
 } from './instrumentation/instrumentation-vercel-ai/instrumentation';
 import { applyInstrumentationPatches, customExtractor } from './patches/instrumentation-patch';
-import { getAwsRegionFromEnvironment, isAgentObservabilityEnabled, isInstrumentationDisabled } from './utils';
+import { getAwsRegionFromEnvironment, isAgentObservabilityEnabled } from './utils';
 
 const logLevelEnv = getStringFromEnv('OTEL_LOG_LEVEL');
 const logLevel = logLevelEnv ? diagLogLevelFromString(logLevelEnv) : undefined;
@@ -136,15 +136,9 @@ export const instrumentationConfigs: InstrumentationConfigMap = {
 export const instrumentations: Instrumentation[] = getNodeAutoInstrumentations(instrumentationConfigs);
 
 const captureMessageContent = process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT !== 'false';
-if (!isInstrumentationDisabled(LANGCHAIN_SHORT_NAME)) {
-  instrumentations.push(new LangChainInstrumentation({ captureMessageContent }));
-}
-if (!isInstrumentationDisabled(OPENAI_AGENTS_SHORT_NAME)) {
-  instrumentations.push(new OpenAIAgentsInstrumentation({ captureMessageContent }));
-}
-if (!isInstrumentationDisabled(VERCEL_AI_SHORT_NAME)) {
-  instrumentations.push(new VercelAIInstrumentation({ captureMessageContent }));
-}
+instrumentations.push(new LangChainInstrumentation({ captureMessageContent }));
+instrumentations.push(new OpenAIAgentsInstrumentation({ captureMessageContent }));
+instrumentations.push(new VercelAIInstrumentation({ captureMessageContent }));
 
 // Apply instrumentation patches
 applyInstrumentationPatches(instrumentations);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { diag } from '@opentelemetry/api';
+import { INSTRUMENTATION_SHORT_NAME as LANGCHAIN_SHORT_NAME } from './instrumentation/instrumentation-langchain/instrumentation';
+import { INSTRUMENTATION_SHORT_NAME as OPENAI_AGENTS_SHORT_NAME } from './instrumentation/instrumentation-openai-agents/instrumentation';
+import { INSTRUMENTATION_SHORT_NAME as VERCEL_AI_SHORT_NAME } from './instrumentation/instrumentation-vercel-ai/instrumentation';
 
 const AGENT_OBSERVABILITY_ENABLED = 'AGENT_OBSERVABILITY_ENABLED';
 const AWS_AGENTIC_INSTRUMENTATION_OPT_IN = 'AWS_AGENTIC_INSTRUMENTATION_OPT_IN';
@@ -96,18 +99,18 @@ export const isInstrumentationDisabled = (shortName: string): boolean => {
 };
 
 const CONFLICTING_INSTRUMENTATIONS: Record<string, string[]> = {
-  aws_langchain: [
+  [LANGCHAIN_SHORT_NAME]: [
     '@traceloop/instrumentation-langchain',
     '@arizeai/openinference-instrumentation-langchain',
     '@arizeai/openinference-instrumentation-langchain-v0',
     '@microsoft/agents-a365-observability-extensions-langchain',
     '@langfuse/langchain',
   ],
-  aws_openai_agents: [
+  [OPENAI_AGENTS_SHORT_NAME]: [
     '@respan/instrumentation-openai-agents',
     '@microsoft/agents-a365-observability-extensions-openai',
   ],
-  aws_vercel_ai: ['@monocle.sh/instrumentation-vercel-ai', '@respan/instrumentation-vercel'],
+  [VERCEL_AI_SHORT_NAME]: ['@monocle.sh/instrumentation-vercel-ai', '@respan/instrumentation-vercel'],
 };
 
 export const detectConflictingInstrumentation = (shortName: string): string | undefined => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
@@ -1,9 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import * as fs from 'fs';
+import * as path from 'path';
 import { diag } from '@opentelemetry/api';
 
 const AGENT_OBSERVABILITY_ENABLED = 'AGENT_OBSERVABILITY_ENABLED';
+const AWS_AGENTIC_INSTRUMENTATION_OPT_IN = 'AWS_AGENTIC_INSTRUMENTATION_OPT_IN';
 export const OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS = 'OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS';
 
 // Bypass `readonly` restriction of a Type.
@@ -35,6 +38,11 @@ export const isAgentObservabilityEnabled = () => {
   }
 
   return agentObservabilityEnabled.toLowerCase() === 'true';
+};
+
+export const isAgenticInstrumentationOptIn = (): boolean => {
+  const v = process.env[AWS_AGENTIC_INSTRUMENTATION_OPT_IN];
+  return v !== undefined && v.toLowerCase() === 'true';
 };
 
 /**
@@ -87,6 +95,37 @@ export const isInstrumentationDisabled = (shortName: string): boolean => {
   }
 
   return false;
+};
+
+export const findInstrumentation = (keywordGroups: string[][], lookupPaths?: string[]): string | undefined => {
+  const matches = (name: string) =>
+    name.includes('instrumentation') && keywordGroups.some(group => group.every(k => name.includes(k)));
+
+  for (const nmDir of lookupPaths || require.resolve.paths('_') || []) {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(nmDir);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (entry.startsWith('@')) {
+        if (entry === '@aws' || entry === '@opentelemetry') continue;
+        let pkgs: string[];
+        try {
+          pkgs = fs.readdirSync(path.join(nmDir, entry));
+        } catch {
+          continue;
+        }
+        const match = pkgs.find(matches);
+        if (match) return `${entry}/${match}`;
+      } else if (matches(entry)) {
+        return entry;
+      }
+    }
+  }
+  return undefined;
 };
 
 export const checkDigits = (str: string): boolean => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import * as fs from 'fs';
-import * as path from 'path';
 import { diag } from '@opentelemetry/api';
 
 const AGENT_OBSERVABILITY_ENABLED = 'AGENT_OBSERVABILITY_ENABLED';
@@ -97,32 +95,31 @@ export const isInstrumentationDisabled = (shortName: string): boolean => {
   return false;
 };
 
-export const findInstrumentation = (keywordGroups: string[][], lookupPaths?: string[]): string | undefined => {
-  const matches = (name: string) =>
-    name.includes('instrumentation') && keywordGroups.some(group => group.every(k => name.includes(k)));
+const CONFLICTING_INSTRUMENTATIONS: Record<string, string[]> = {
+  aws_langchain: [
+    '@traceloop/instrumentation-langchain',
+    '@arizeai/openinference-instrumentation-langchain',
+    '@arizeai/openinference-instrumentation-langchain-v0',
+    '@microsoft/agents-a365-observability-extensions-langchain',
+    '@langfuse/langchain',
+  ],
+  aws_openai_agents: [
+    '@respan/instrumentation-openai-agents',
+    '@microsoft/agents-a365-observability-extensions-openai',
+  ],
+  aws_vercel_ai: ['@monocle.sh/instrumentation-vercel-ai', '@respan/instrumentation-vercel'],
+};
 
-  for (const nmDir of lookupPaths || require.resolve.paths('_') || []) {
-    let entries: string[];
+export const detectConflictingInstrumentation = (shortName: string): string | undefined => {
+  const conflicts = CONFLICTING_INSTRUMENTATIONS[shortName];
+  if (!conflicts) return undefined;
+
+  for (const pkg of conflicts) {
     try {
-      entries = fs.readdirSync(nmDir);
+      require.resolve(pkg);
+      return pkg;
     } catch {
       continue;
-    }
-
-    for (const entry of entries) {
-      if (entry.startsWith('@')) {
-        if (entry === '@aws' || entry === '@opentelemetry') continue;
-        let pkgs: string[];
-        try {
-          pkgs = fs.readdirSync(path.join(nmDir, entry));
-        } catch {
-          continue;
-        }
-        const match = pkgs.find(matches);
-        if (match) return `${entry}/${match}`;
-      } else if (matches(entry)) {
-        return entry;
-      }
     }
   }
   return undefined;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -1336,6 +1336,18 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     // Cleanup
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+
+    // Test fallback to OTEL_EXPORTER_OTLP_ENDPOINT
+    const fallbackProcessors: SpanProcessor[] = [];
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318';
+
+    AwsOpentelemetryConfigurator.exportUnsampledSpanForAgentObservability(fallbackProcessors, emptyResource());
+    expect(fallbackProcessors.length).toEqual(1);
+    expect(fallbackProcessors[0]).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
+
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
   });
 
   it('ExportUnsampledSpanForAgentObservabilityUsesOtlpAwsSpanExporterTest', () => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
@@ -305,6 +305,9 @@ describe('patch and unpatch lifecycle', function () {
   let originalCall: any;
 
   before(function () {
+    contentCaptureInstrumentation._unpatchCallbackManager(CallbackManager);
+    contentCaptureInstrumentation._unpatchChatModelsModule(chatExports);
+    contentCaptureInstrumentation._unpatchToolsModule(toolExports);
     instrumentation._unpatchCallbackManager(CallbackManager);
     instrumentation._unpatchChatModelsModule(chatExports);
     instrumentation._unpatchToolsModule(toolExports);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -135,6 +135,24 @@ describe('Register', function () {
           expectedDisabled: true,
         },
         {
+          name: 'disables LangChain when @arizeai/openinference-instrumentation-langchain-v0 is installed',
+          fakePackage: '@arizeai/openinference-instrumentation-langchain-v0',
+          instrumentationName: LANGCHAIN_NAME,
+          expectedDisabled: true,
+        },
+        {
+          name: 'disables LangChain when @microsoft/agents-a365-observability-extensions-langchain is installed',
+          fakePackage: '@microsoft/agents-a365-observability-extensions-langchain',
+          instrumentationName: LANGCHAIN_NAME,
+          expectedDisabled: true,
+        },
+        {
+          name: 'disables LangChain when @langfuse/langchain is installed',
+          fakePackage: '@langfuse/langchain',
+          instrumentationName: LANGCHAIN_NAME,
+          expectedDisabled: true,
+        },
+        {
           name: 'enables LangChain with @traceloop/instrumentation-langchain when opt-in',
           fakePackage: '@traceloop/instrumentation-langchain',
           instrumentationName: LANGCHAIN_NAME,
@@ -142,11 +160,29 @@ describe('Register', function () {
           optIn: true,
         },
         {
-          name: 'enables LangChain with @arizeai/openinference-instrumentation-langchain when opt-in',
-          fakePackage: '@arizeai/openinference-instrumentation-langchain',
-          instrumentationName: LANGCHAIN_NAME,
+          name: 'disables OpenAI Agents when @respan/instrumentation-openai-agents is installed',
+          fakePackage: '@respan/instrumentation-openai-agents',
+          instrumentationName: OPENAI_AGENTS_NAME,
+          expectedDisabled: true,
+        },
+        {
+          name: 'disables OpenAI Agents when @microsoft/agents-a365-observability-extensions-openai is installed',
+          fakePackage: '@microsoft/agents-a365-observability-extensions-openai',
+          instrumentationName: OPENAI_AGENTS_NAME,
+          expectedDisabled: true,
+        },
+        {
+          name: 'enables OpenAI Agents with @respan/instrumentation-openai-agents when opt-in',
+          fakePackage: '@respan/instrumentation-openai-agents',
+          instrumentationName: OPENAI_AGENTS_NAME,
           expectedDisabled: false,
           optIn: true,
+        },
+        {
+          name: 'does not disable OpenAI Agents when @traceloop/instrumentation-openai is installed',
+          fakePackage: '@traceloop/instrumentation-openai',
+          instrumentationName: OPENAI_AGENTS_NAME,
+          expectedDisabled: false,
         },
         {
           name: 'disables Vercel AI when @monocle.sh/instrumentation-vercel-ai is installed',
@@ -167,25 +203,6 @@ describe('Register', function () {
           expectedDisabled: false,
           optIn: true,
         },
-        {
-          name: 'enables Vercel AI with @respan/instrumentation-vercel when opt-in',
-          fakePackage: '@respan/instrumentation-vercel',
-          instrumentationName: VERCEL_AI_NAME,
-          expectedDisabled: false,
-          optIn: true,
-        },
-        {
-          name: 'does not disable OpenAI Agents when @traceloop/instrumentation-openai is installed',
-          fakePackage: '@traceloop/instrumentation-openai',
-          instrumentationName: OPENAI_AGENTS_NAME,
-          expectedDisabled: false,
-        },
-        {
-          name: 'does not disable OpenAI Agents when @arizeai/openinference-instrumentation-openai is installed',
-          fakePackage: '@arizeai/openinference-instrumentation-openai',
-          instrumentationName: OPENAI_AGENTS_NAME,
-          expectedDisabled: false,
-        },
       ];
 
       for (const tc of conflictTestCases) {
@@ -196,7 +213,9 @@ describe('Register', function () {
             const path = require('path');
             const os = require('os');
             const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'otel-conflict-'));
-            fs.mkdirSync(path.join(tmpDir, '${tc.fakePackage}'), { recursive: true });
+            const pkgDir = path.join(tmpDir, '${tc.fakePackage}');
+            fs.mkdirSync(pkgDir, { recursive: true });
+            fs.writeFileSync(path.join(pkgDir, 'index.js'), '');
             process.env.NODE_PATH = tmpDir;
             require('module').Module._initPaths();
             const register = require('../build/src/register.js');

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -377,7 +377,7 @@ describe('Register', function () {
       expect(process.env.OTEL_TRACES_SAMPLER).toEqual('parentbased_always_on');
       expect(process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS).toEqual('fs,dns');
       expect(process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS).toEqual(
-        'aws-lambda,aws-sdk,http,aws_langchain,aws_openai_agents,aws_vercel_ai'
+        'aws-lambda,aws-sdk,http,undici,aws_langchain,aws_openai_agents,aws_vercel_ai'
       );
       expect(process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED).toEqual('false');
       expect(process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).toEqual('https://xray.us-east-1.amazonaws.com/v1/traces');

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -135,6 +135,20 @@ describe('Register', function () {
           expectedDisabled: true,
         },
         {
+          name: 'enables LangChain with @traceloop/instrumentation-langchain when opt-in',
+          fakePackage: '@traceloop/instrumentation-langchain',
+          instrumentationName: LANGCHAIN_NAME,
+          expectedDisabled: false,
+          optIn: true,
+        },
+        {
+          name: 'enables LangChain with @arizeai/openinference-instrumentation-langchain when opt-in',
+          fakePackage: '@arizeai/openinference-instrumentation-langchain',
+          instrumentationName: LANGCHAIN_NAME,
+          expectedDisabled: false,
+          optIn: true,
+        },
+        {
           name: 'disables Vercel AI when @monocle.sh/instrumentation-vercel-ai is installed',
           fakePackage: '@monocle.sh/instrumentation-vercel-ai',
           instrumentationName: VERCEL_AI_NAME,
@@ -147,17 +161,30 @@ describe('Register', function () {
           expectedDisabled: true,
         },
         {
-          name: 'does not disable OpenAI Agents when base @traceloop/instrumentation-openai is installed',
+          name: 'enables Vercel AI with @monocle.sh/instrumentation-vercel-ai when opt-in',
+          fakePackage: '@monocle.sh/instrumentation-vercel-ai',
+          instrumentationName: VERCEL_AI_NAME,
+          expectedDisabled: false,
+          optIn: true,
+        },
+        {
+          name: 'enables Vercel AI with @respan/instrumentation-vercel when opt-in',
+          fakePackage: '@respan/instrumentation-vercel',
+          instrumentationName: VERCEL_AI_NAME,
+          expectedDisabled: false,
+          optIn: true,
+        },
+        {
+          name: 'does not disable OpenAI Agents when @traceloop/instrumentation-openai is installed',
           fakePackage: '@traceloop/instrumentation-openai',
           instrumentationName: OPENAI_AGENTS_NAME,
           expectedDisabled: false,
         },
         {
-          name: 'overrides conflict when AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true',
-          fakePackage: '@traceloop/instrumentation-langchain',
-          instrumentationName: LANGCHAIN_NAME,
+          name: 'does not disable OpenAI Agents when @arizeai/openinference-instrumentation-openai is installed',
+          fakePackage: '@arizeai/openinference-instrumentation-openai',
+          instrumentationName: OPENAI_AGENTS_NAME,
           expectedDisabled: false,
-          optIn: true,
         },
       ];
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -56,7 +56,8 @@ describe('Register', function () {
       const script = `
         const assert = require('assert');
         const register = require('../build/src/register.js');
-        const names = register.instrumentations.map(i => i.instrumentationName);
+        const instrumentations = register.instrumentations;
+        const names = instrumentations.map(i => i.instrumentationName);
         ${assertion}
         process.exit(0);
       `;
@@ -79,7 +80,9 @@ describe('Register', function () {
         it('is disabled via OTEL_NODE_DISABLED_INSTRUMENTATIONS', () => {
           const proc = spawnWithAssertion(
             { OTEL_NODE_DISABLED_INSTRUMENTATIONS: shortName },
-            `assert.ok(!names.includes('${fullName}'));`
+            `const instr = instrumentations.find(i => i.instrumentationName === '${fullName}');
+             assert.ok(instr, '${fullName} should be registered');
+             assert.ok(!instr.isEnabled(), '${fullName} should be disabled');`
           );
           assert.ifError(proc.error);
           assert.equal(proc.status, 0, proc.stderr?.toString());
@@ -88,7 +91,9 @@ describe('Register', function () {
         it('is disabled when OTEL_NODE_ENABLED_INSTRUMENTATIONS is set without it', () => {
           const proc = spawnWithAssertion(
             { OTEL_NODE_ENABLED_INSTRUMENTATIONS: 'http' },
-            `assert.ok(!names.includes('${fullName}'));`
+            `const instr = instrumentations.find(i => i.instrumentationName === '${fullName}');
+             assert.ok(instr, '${fullName} should be registered');
+             assert.ok(!instr.isEnabled(), '${fullName} should be disabled');`
           );
           assert.ifError(proc.error);
           assert.equal(proc.status, 0, proc.stderr?.toString());
@@ -108,6 +113,92 @@ describe('Register', function () {
     testInstrumentation(LangChainInstrumentation, LANGCHAIN_NAME, LANGCHAIN_SHORT_NAME);
     testInstrumentation(OpenAIAgentsInstrumentation, OPENAI_AGENTS_NAME, OPENAI_AGENTS_SHORT_NAME);
     testInstrumentation(VercelAIInstrumentation, VERCEL_AI_NAME, VERCEL_AI_SHORT_NAME);
+
+    describe('third-party conflict detection', () => {
+      const conflictTestCases: {
+        name: string;
+        fakePackage: string;
+        instrumentationName: string;
+        expectedDisabled: boolean;
+        optIn?: boolean;
+      }[] = [
+        {
+          name: 'disables LangChain when @traceloop/instrumentation-langchain is installed',
+          fakePackage: '@traceloop/instrumentation-langchain',
+          instrumentationName: LANGCHAIN_NAME,
+          expectedDisabled: true,
+        },
+        {
+          name: 'disables LangChain when @arizeai/openinference-instrumentation-langchain is installed',
+          fakePackage: '@arizeai/openinference-instrumentation-langchain',
+          instrumentationName: LANGCHAIN_NAME,
+          expectedDisabled: true,
+        },
+        {
+          name: 'disables Vercel AI when @monocle.sh/instrumentation-vercel-ai is installed',
+          fakePackage: '@monocle.sh/instrumentation-vercel-ai',
+          instrumentationName: VERCEL_AI_NAME,
+          expectedDisabled: true,
+        },
+        {
+          name: 'disables Vercel AI when @respan/instrumentation-vercel is installed',
+          fakePackage: '@respan/instrumentation-vercel',
+          instrumentationName: VERCEL_AI_NAME,
+          expectedDisabled: true,
+        },
+        {
+          name: 'does not disable OpenAI Agents when base @traceloop/instrumentation-openai is installed',
+          fakePackage: '@traceloop/instrumentation-openai',
+          instrumentationName: OPENAI_AGENTS_NAME,
+          expectedDisabled: false,
+        },
+        {
+          name: 'overrides conflict when AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true',
+          fakePackage: '@traceloop/instrumentation-langchain',
+          instrumentationName: LANGCHAIN_NAME,
+          expectedDisabled: false,
+          optIn: true,
+        },
+      ];
+
+      for (const tc of conflictTestCases) {
+        it(tc.name, () => {
+          const script = `
+            const assert = require('assert');
+            const fs = require('fs');
+            const path = require('path');
+            const os = require('os');
+            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'otel-conflict-'));
+            fs.mkdirSync(path.join(tmpDir, '${tc.fakePackage}'), { recursive: true });
+            process.env.NODE_PATH = tmpDir;
+            require('module').Module._initPaths();
+            const register = require('../build/src/register.js');
+            const instr = register.instrumentations.find(
+              i => i.instrumentationName === '${tc.instrumentationName}'
+            );
+            assert.ok(instr, '${tc.instrumentationName} should be registered');
+            assert.strictEqual(
+              instr.isEnabled(), ${!tc.expectedDisabled},
+              '${tc.instrumentationName} should be ${tc.expectedDisabled ? 'disabled' : 'enabled'}'
+            );
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+            process.exit(0);
+          `;
+          const env: Record<string, string | undefined> = {};
+          if (tc.optIn) {
+            env.AWS_AGENTIC_INSTRUMENTATION_OPT_IN = 'true';
+          }
+          const proc = spawnSync(process.execPath, ['-e', script], {
+            cwd: __dirname,
+            timeout: 10000,
+            killSignal: 'SIGKILL',
+            env: { ...baseEnv, ...env },
+          });
+          assert.ifError(proc.error);
+          assert.equal(proc.status, 0, proc.stderr?.toString());
+        });
+      }
+    });
 
     it('Vercel AI auto-registers VercelAISpanProcessor', () => {
       const provider = new BasicTracerProvider();

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/utils.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/utils.test.ts
@@ -101,7 +101,6 @@ describe('Utils', function () {
       keywords: string[][];
       expected: string | undefined;
     }[] = [
-      // LangChain detections
       {
         name: 'detects @traceloop/instrumentation-langchain',
         packagePath: '@traceloop/instrumentation-langchain',
@@ -120,8 +119,6 @@ describe('Utils', function () {
         keywords: [['langchain'], ['langgraph']],
         expected: undefined,
       },
-
-      // OpenAI Agents detections
       {
         name: 'does not false-positive on base openai instrumentation',
         packagePath: '@traceloop/instrumentation-openai',
@@ -134,8 +131,6 @@ describe('Utils', function () {
         keywords: [['openai', 'agents']],
         expected: '@traceloop/instrumentation-openai-agents',
       },
-
-      // Vercel AI detections
       {
         name: 'detects @monocle.sh/instrumentation-vercel-ai',
         packagePath: '@monocle.sh/instrumentation-vercel-ai',
@@ -154,8 +149,6 @@ describe('Utils', function () {
         keywords: [['vercel']],
         expected: 'opentelemetry-instrumentation-vercel',
       },
-
-      // Skipped scopes
       {
         name: 'skips @aws scoped packages',
         packagePath: '@aws/instrumentation-langchain',

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/utils.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/utils.test.ts
@@ -1,12 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import expect from 'expect';
-import { getAwsRegionFromEnvironment, isAgentObservabilityEnabled } from '../src/utils';
+import {
+  getAwsRegionFromEnvironment,
+  isAgentObservabilityEnabled,
+  isAgenticInstrumentationOptIn,
+  findInstrumentation,
+} from '../src/utils';
 
 describe('Utils', function () {
   beforeEach(() => {
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    delete process.env.AWS_AGENTIC_INSTRUMENTATION_OPT_IN;
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
     delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
     delete process.env.AWS_REGION;
@@ -51,5 +60,131 @@ describe('Utils', function () {
     delete process.env.AWS_REGION;
     process.env.AWS_DEFAULT_REGION = 'eu-west-1';
     expect(getAwsRegionFromEnvironment()).toEqual('eu-west-1');
+  });
+
+  it('Test isAgenticInstrumentationOptIn to be True', () => {
+    process.env.AWS_AGENTIC_INSTRUMENTATION_OPT_IN = 'true';
+    expect(isAgenticInstrumentationOptIn()).toBeTruthy();
+
+    process.env.AWS_AGENTIC_INSTRUMENTATION_OPT_IN = 'True';
+    expect(isAgenticInstrumentationOptIn()).toBeTruthy();
+
+    process.env.AWS_AGENTIC_INSTRUMENTATION_OPT_IN = 'TRUE';
+    expect(isAgenticInstrumentationOptIn()).toBeTruthy();
+  });
+
+  it('Test isAgenticInstrumentationOptIn to be False', () => {
+    process.env.AWS_AGENTIC_INSTRUMENTATION_OPT_IN = 'false';
+    expect(isAgenticInstrumentationOptIn()).toBeFalsy();
+
+    process.env.AWS_AGENTIC_INSTRUMENTATION_OPT_IN = 'anything else';
+    expect(isAgenticInstrumentationOptIn()).toBeFalsy();
+
+    delete process.env.AWS_AGENTIC_INSTRUMENTATION_OPT_IN;
+    expect(isAgenticInstrumentationOptIn()).toBeFalsy();
+  });
+
+  describe('findInstrumentation', function () {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'otel-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    const testCases: {
+      name: string;
+      packagePath: string;
+      keywords: string[][];
+      expected: string | undefined;
+    }[] = [
+      // LangChain detections
+      {
+        name: 'detects @traceloop/instrumentation-langchain',
+        packagePath: '@traceloop/instrumentation-langchain',
+        keywords: [['langchain'], ['langgraph']],
+        expected: '@traceloop/instrumentation-langchain',
+      },
+      {
+        name: 'detects @arizeai/openinference-instrumentation-langchain',
+        packagePath: '@arizeai/openinference-instrumentation-langchain',
+        keywords: [['langchain'], ['langgraph']],
+        expected: '@arizeai/openinference-instrumentation-langchain',
+      },
+      {
+        name: 'langchain keywords do not false-positive on openai package',
+        packagePath: '@traceloop/instrumentation-openai',
+        keywords: [['langchain'], ['langgraph']],
+        expected: undefined,
+      },
+
+      // OpenAI Agents detections
+      {
+        name: 'does not false-positive on base openai instrumentation',
+        packagePath: '@traceloop/instrumentation-openai',
+        keywords: [['openai', 'agents']],
+        expected: undefined,
+      },
+      {
+        name: 'detects hypothetical @traceloop/instrumentation-openai-agents',
+        packagePath: '@traceloop/instrumentation-openai-agents',
+        keywords: [['openai', 'agents']],
+        expected: '@traceloop/instrumentation-openai-agents',
+      },
+
+      // Vercel AI detections
+      {
+        name: 'detects @monocle.sh/instrumentation-vercel-ai',
+        packagePath: '@monocle.sh/instrumentation-vercel-ai',
+        keywords: [['vercel']],
+        expected: '@monocle.sh/instrumentation-vercel-ai',
+      },
+      {
+        name: 'detects @respan/instrumentation-vercel',
+        packagePath: '@respan/instrumentation-vercel',
+        keywords: [['vercel']],
+        expected: '@respan/instrumentation-vercel',
+      },
+      {
+        name: 'detects unscoped opentelemetry-instrumentation-vercel',
+        packagePath: 'opentelemetry-instrumentation-vercel',
+        keywords: [['vercel']],
+        expected: 'opentelemetry-instrumentation-vercel',
+      },
+
+      // Skipped scopes
+      {
+        name: 'skips @aws scoped packages',
+        packagePath: '@aws/instrumentation-langchain',
+        keywords: [['langchain']],
+        expected: undefined,
+      },
+      {
+        name: 'skips @opentelemetry scoped packages',
+        packagePath: '@opentelemetry/instrumentation-langchain',
+        keywords: [['langchain']],
+        expected: undefined,
+      },
+    ];
+
+    for (const tc of testCases) {
+      it(tc.name, () => {
+        fs.mkdirSync(path.join(tmpDir, tc.packagePath), { recursive: true });
+        const result = findInstrumentation(tc.keywords, [tmpDir]);
+        if (tc.expected === undefined) {
+          expect(result).toBeUndefined();
+        } else {
+          expect(result).toBe(tc.expected);
+        }
+      });
+    }
+
+    it('returns undefined when node_modules directory does not exist', () => {
+      const result = findInstrumentation([['langchain']], [path.join(tmpDir, 'nonexistent')]);
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/utils.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/utils.test.ts
@@ -1,16 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
 import expect from 'expect';
-import {
-  getAwsRegionFromEnvironment,
-  isAgentObservabilityEnabled,
-  isAgenticInstrumentationOptIn,
-  findInstrumentation,
-} from '../src/utils';
+import { getAwsRegionFromEnvironment, isAgentObservabilityEnabled, isAgenticInstrumentationOptIn } from '../src/utils';
 
 describe('Utils', function () {
   beforeEach(() => {
@@ -82,102 +74,5 @@ describe('Utils', function () {
 
     delete process.env.AWS_AGENTIC_INSTRUMENTATION_OPT_IN;
     expect(isAgenticInstrumentationOptIn()).toBeFalsy();
-  });
-
-  describe('findInstrumentation', function () {
-    let tmpDir: string;
-
-    beforeEach(() => {
-      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'otel-test-'));
-    });
-
-    afterEach(() => {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    });
-
-    const testCases: {
-      name: string;
-      packagePath: string;
-      keywords: string[][];
-      expected: string | undefined;
-    }[] = [
-      {
-        name: 'detects @traceloop/instrumentation-langchain',
-        packagePath: '@traceloop/instrumentation-langchain',
-        keywords: [['langchain'], ['langgraph']],
-        expected: '@traceloop/instrumentation-langchain',
-      },
-      {
-        name: 'detects @arizeai/openinference-instrumentation-langchain',
-        packagePath: '@arizeai/openinference-instrumentation-langchain',
-        keywords: [['langchain'], ['langgraph']],
-        expected: '@arizeai/openinference-instrumentation-langchain',
-      },
-      {
-        name: 'langchain keywords do not false-positive on openai package',
-        packagePath: '@traceloop/instrumentation-openai',
-        keywords: [['langchain'], ['langgraph']],
-        expected: undefined,
-      },
-      {
-        name: 'does not false-positive on base openai instrumentation',
-        packagePath: '@traceloop/instrumentation-openai',
-        keywords: [['openai', 'agents']],
-        expected: undefined,
-      },
-      {
-        name: 'detects hypothetical @traceloop/instrumentation-openai-agents',
-        packagePath: '@traceloop/instrumentation-openai-agents',
-        keywords: [['openai', 'agents']],
-        expected: '@traceloop/instrumentation-openai-agents',
-      },
-      {
-        name: 'detects @monocle.sh/instrumentation-vercel-ai',
-        packagePath: '@monocle.sh/instrumentation-vercel-ai',
-        keywords: [['vercel']],
-        expected: '@monocle.sh/instrumentation-vercel-ai',
-      },
-      {
-        name: 'detects @respan/instrumentation-vercel',
-        packagePath: '@respan/instrumentation-vercel',
-        keywords: [['vercel']],
-        expected: '@respan/instrumentation-vercel',
-      },
-      {
-        name: 'detects unscoped opentelemetry-instrumentation-vercel',
-        packagePath: 'opentelemetry-instrumentation-vercel',
-        keywords: [['vercel']],
-        expected: 'opentelemetry-instrumentation-vercel',
-      },
-      {
-        name: 'skips @aws scoped packages',
-        packagePath: '@aws/instrumentation-langchain',
-        keywords: [['langchain']],
-        expected: undefined,
-      },
-      {
-        name: 'skips @opentelemetry scoped packages',
-        packagePath: '@opentelemetry/instrumentation-langchain',
-        keywords: [['langchain']],
-        expected: undefined,
-      },
-    ];
-
-    for (const tc of testCases) {
-      it(tc.name, () => {
-        fs.mkdirSync(path.join(tmpDir, tc.packagePath), { recursive: true });
-        const result = findInstrumentation(tc.keywords, [tmpDir]);
-        if (tc.expected === undefined) {
-          expect(result).toBeUndefined();
-        } else {
-          expect(result).toBe(tc.expected);
-        }
-      });
-    }
-
-    it('returns undefined when node_modules directory does not exist', () => {
-      const result = findInstrumentation([['langchain']], [path.join(tmpDir, 'nonexistent')]);
-      expect(result).toBeUndefined();
-    });
   });
 });


### PR DESCRIPTION
- When `OTEL_EXPORTER_OTLP_ENDPOINT` is set but `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is not, `exportUnsampledSpanForAgentObservability` now correctly falls back to the base endpoint instead of warning and skipping