### PR TITLE
fix(agent-observability): fall back to OTEL_EXPORTER_OTLP_ENDPOINT for unsampled spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(agent-observability): fall back to OTEL_EXPORTER_OTLP_ENDPOINT for unsampled spans
+  ([#420](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/420))
 - feat(agent-observability): add GenAiNestedClientSpanProcessor to deduplicate nested CLIENT spans
   ([#413](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/413))
 - feat: add BaggageSpanProcessor by default with OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS support

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -298,7 +298,10 @@ export class AwsOpentelemetryConfigurator {
       return;
     }
 
-    const tracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    let tracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    if (!tracesEndpoint && process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+      tracesEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT.replace(/\/+$/, '') + '/v1/traces';
+    }
 
     if (!tracesEndpoint) {
       diag.warn('No traces endpoint configured for agent observability unsampled spans');

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -298,11 +298,10 @@ export class AwsOpentelemetryConfigurator {
       return;
     }
 
-    // Get the traces endpoint from environment
-    const tracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    const tracesEndpoint =
+      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 
     if (!tracesEndpoint) {
-      // No traces endpoint configured, skip unsampled span export
       diag.warn('No traces endpoint configured for agent observability unsampled spans');
       return;
     }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -298,8 +298,7 @@ export class AwsOpentelemetryConfigurator {
       return;
     }
 
-    const tracesEndpoint =
-      process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    const tracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 
     if (!tracesEndpoint) {
       diag.warn('No traces endpoint configured for agent observability unsampled spans');

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -1350,6 +1350,38 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
 
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
     delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+
+    // Test AWS endpoint via base OTEL_EXPORTER_OTLP_ENDPOINT fallback
+    const awsFallbackProcessors: SpanProcessor[] = [];
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'https://xray.us-west-2.amazonaws.com';
+
+    AwsOpentelemetryConfigurator.exportUnsampledSpanForAgentObservability(awsFallbackProcessors, emptyResource());
+    expect(awsFallbackProcessors.length).toEqual(1);
+    expect(awsFallbackProcessors[0]).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
+    const awsFallbackExporter = (awsFallbackProcessors[0] as AwsBatchUnsampledSpanProcessor)['_exporter'];
+    expect(awsFallbackExporter).toBeInstanceOf(OTLPAwsSpanExporter);
+    expect(awsFallbackExporter['endpoint']).toEqual('https://xray.us-west-2.amazonaws.com/v1/traces');
+
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+
+    // Test precedence: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT wins over OTEL_EXPORTER_OTLP_ENDPOINT
+    const precedenceProcessors: SpanProcessor[] = [];
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = 'https://xray.us-east-1.amazonaws.com/v1/traces';
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318';
+
+    AwsOpentelemetryConfigurator.exportUnsampledSpanForAgentObservability(precedenceProcessors, emptyResource());
+    expect(precedenceProcessors.length).toEqual(1);
+    expect(precedenceProcessors[0]).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
+    const precedenceExporter = (precedenceProcessors[0] as AwsBatchUnsampledSpanProcessor)['_exporter'];
+    expect(precedenceExporter).toBeInstanceOf(OTLPAwsSpanExporter);
+    expect(precedenceExporter['endpoint']).toEqual('https://xray.us-east-1.amazonaws.com/v1/traces');
+
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
   });
 
   it('ExportUnsampledSpanForAgentObservabilityUsesOtlpAwsSpanExporterTest', () => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -1336,6 +1336,18 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     // Cleanup
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+
+    // Test fallback to OTEL_EXPORTER_OTLP_ENDPOINT
+    const fallbackProcessors: SpanProcessor[] = [];
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318';
+
+    AwsOpentelemetryConfigurator.exportUnsampledSpanForAgentObservability(fallbackProcessors, emptyResource());
+    expect(fallbackProcessors.length).toEqual(1);
+    expect(fallbackProcessors[0]).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
+
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
   });
 
   it('ExportUnsampledSpanForAgentObservabilityUsesOtlpAwsSpanExporterTest', () => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -1345,6 +1345,8 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     AwsOpentelemetryConfigurator.exportUnsampledSpanForAgentObservability(fallbackProcessors, emptyResource());
     expect(fallbackProcessors.length).toEqual(1);
     expect(fallbackProcessors[0]).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
+    const fallbackExporter = (fallbackProcessors[0] as AwsBatchUnsampledSpanProcessor)['_exporter'];
+    expect(fallbackExporter['endpoint']).toEqual('http://localhost:4318/v1/traces');
 
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
     delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;


### PR DESCRIPTION
- When `OTEL_EXPORTER_OTLP_ENDPOINT` is set but `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is not, `exportUnsampledSpanForAgentObservability` now correctly falls back to the base endpoint instead of warning and skipping