### PR TITLE
enhancement(agent-observability): add undici to agent observability enabled instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat(agent-observability): add undici to default enabled instrumentations
-  ([#418](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/418))
+- enhancement(agent-observability): add undici to default enabled instrumentations
+  ([#421](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/421))
 - feat: auto-detect and mutually exclude native vs third-party agentic instrumentors
   ([#417](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/417))
 - fix(agent-observability): fall back to OTEL_EXPORTER_OTLP_ENDPOINT for unsampled spans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(agent-observability): add undici to default enabled instrumentations
+  ([#418](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/418))
 - feat: auto-detect and mutually exclude native vs third-party agentic instrumentors
   ([#417](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/417))
 - fix(agent-observability): fall back to OTEL_EXPORTER_OTLP_ENDPOINT for unsampled spans

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -73,7 +73,7 @@ export function setAwsDefaultEnvironmentVariables() {
     if (!process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS) {
       // Assume users only need aws-sdk, aws-lambda, and our custom GenAI instrumentations,
       // as well as instrumentations that are manually set-up outside of OpenTelemetry.
-      process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS = `aws-lambda,aws-sdk,http,${LANGCHAIN_SHORT_NAME},${OPENAI_AGENTS_SHORT_NAME},${VERCEL_AI_SHORT_NAME}`;
+      process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS = `aws-lambda,aws-sdk,http,undici,${LANGCHAIN_SHORT_NAME},${OPENAI_AGENTS_SHORT_NAME},${VERCEL_AI_SHORT_NAME}`;
     }
 
     // Set exporter defaults

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -377,7 +377,7 @@ describe('Register', function () {
       expect(process.env.OTEL_TRACES_SAMPLER).toEqual('parentbased_always_on');
       expect(process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS).toEqual('fs,dns');
       expect(process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS).toEqual(
-        'aws-lambda,aws-sdk,http,aws_langchain,aws_openai_agents,aws_vercel_ai'
+        'aws-lambda,aws-sdk,http,undici,aws_langchain,aws_openai_agents,aws_vercel_ai'
       );
       expect(process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED).toEqual('false');
       expect(process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).toEqual('https://xray.us-east-1.amazonaws.com/v1/traces');


### PR DESCRIPTION
## Summary
- Adds `undici` to the default `OTEL_NODE_ENABLED_INSTRUMENTATIONS` list when agent observability is enabled. `undici` is the default HTTP client in Node.js 18+ and is used by most agentic libraries for LLM API calls