### PR TITLE
pin @smithy/client to 4.12.13

### DIFF
--- a/contract-tests/images/applications/aws-sdk/package.json
+++ b/contract-tests/images/applications/aws-sdk/package.json
@@ -24,6 +24,7 @@
     "@aws-sdk/client-sns": "^3.750.0",
     "@aws-sdk/client-sqs": "^3.750.0",
     "@smithy/node-http-handler": "^4.0.0",
+    "@smithy/client": "4.12.13",
     "jszip": "^3.10.1",
     "node-fetch": "^2.7.0"
   }

--- a/contract-tests/images/applications/aws-sdk/package.json
+++ b/contract-tests/images/applications/aws-sdk/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/client-sns": "^3.750.0",
     "@aws-sdk/client-sqs": "^3.750.0",
     "@smithy/node-http-handler": "^4.0.0",
-    "@smithy/client": "4.12.13",
+    "@smithy/smithy-client": "4.12.13",
     "jszip": "^3.10.1",
     "node-fetch": "^2.7.0"
   }

--- a/contract-tests/images/applications/aws-sdk/package.json
+++ b/contract-tests/images/applications/aws-sdk/package.json
@@ -24,8 +24,10 @@
     "@aws-sdk/client-sns": "^3.750.0",
     "@aws-sdk/client-sqs": "^3.750.0",
     "@smithy/node-http-handler": "^4.0.0",
-    "@smithy/smithy-client": "4.12.13",
     "jszip": "^3.10.1",
     "node-fetch": "^2.7.0"
+  },
+  "overrides": {
+    "@smithy/smithy-client": "4.12.13"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/smithy-lang/smithy-typescript/releases/tag/@smithy/smithy-client@4.13.0 breaks contract tests. Pin to previous version until upstream instrumentation changes entry hook.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

