### PR TITLE
chore: Fix CHANGELOG format in release notes

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -387,7 +387,9 @@ jobs:
           if version_match:
               entries = version_match.group(1).strip()
               if entries:
-                  print(entries)
+                  # Join continuation lines (indented lines) with the previous line
+                  joined = re.sub(r'\n  +', ' ', entries)
+                  print(joined)
           ")
 
           # Create release notes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove next-line indentation of PR link in CHANGELOG entries in release notes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

