### PR TITLE
chore: suppress CVE-2026-44902

### DIFF
--- a/.github/trivy/daily-scan.trivyignore.yaml
+++ b/.github/trivy/daily-scan.trivyignore.yaml
@@ -12,9 +12,13 @@
 
 vulnerabilities:
   - id: CVE-2026-33036
-    statement: "fast-xml-parser numeric entity expansion DoS. Low risk for ADOT JS: XML parsing only occurs on trusted AWS API responses, not user-supplied input. Fix in PR #369, will ship with next scheduled release. Ticket: V2145663734"
+    statement: "fast-xml-parser numeric entity expansion DoS. Low risk for ADOT JS: XML parsing only occurs on trusted AWS API responses, not user-supplied input. Fix in PR #369, will ship with next scheduled release."
     expired_at: 2026-06-22
 
   - id: CVE-2026-44665
     statement: "fast-xml-builder attribute value quote bypass. Low risk for ADOT JS: XML building only occurs for trusted AWS API request payloads, not user-supplied input. Fix available in 1.1.7."
+    expired_at: 2026-06-22
+
+  - id: CVE-2026-44902
+    statement: "Prometheus exporter process crash via malformed HTTP request. Will be fixed in #425 and released in next scheduled release."
     expired_at: 2026-06-22

--- a/.github/trivy/pr-build.trivyignore.yaml
+++ b/.github/trivy/pr-build.trivyignore.yaml
@@ -16,3 +16,7 @@ vulnerabilities:
   - id: CVE-2026-44665
     statement: "fast-xml-builder attribute value quote bypass. Low risk for ADOT JS: XML building only occurs for trusted AWS API request payloads, not user-supplied input. Fix available in 1.1.7."
     expired_at: 2026-06-22
+
+  - id: CVE-2026-44902
+    statement: "Prometheus exporter process crash via malformed HTTP request. Will be fixed in #425 and released in next scheduled release."
+    expired_at: 2026-06-22


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CVE-2026-44902 was recently reported in our daily scans. This will be patched by #425 and released in our next scheduled ADOT JS release. Suppress until week of planned release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

