### PR TITLE
test: add coverage for OTLPAwsSpanExporter LLO handler initialization

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/exporter/otlp/aws/traces/otlp-aws-span-exporter.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/exporter/otlp/aws/traces/otlp-aws-span-exporter.test.ts
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import { OTLPAwsBaseExporterTest } from '../common/otlp-aws-base-exporter.test';
 import { OTLPAwsSpanExporter } from '../../../../../src/exporter/otlp/aws/traces/otlp-aws-span-exporter';
+import expect from 'expect';
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
+import { LoggerProvider } from '@opentelemetry/sdk-logs';
 
 class OTLPAwsSpanExporterTest extends OTLPAwsBaseExporterTest {
   protected override getExporter() {
@@ -25,11 +28,60 @@ describe('OTLPAwsSpanExporter', () => {
 
   afterEach(() => {
     test.afterEach();
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
   });
 
   test.testCommon().forEach(testCase => {
     it(testCase.description, done => {
       testCase.test(done);
+    });
+  });
+
+  it('ensureLloHandler returns false when agent observability is disabled', () => {
+    const exporter = new OTLPAwsSpanExporter('https://xray.us-east-1.amazonaws.com/v1/traces');
+    const result = (exporter as any).ensureLloHandler();
+    expect(result).toBe(false);
+    expect((exporter as any).lloHandler).toBeUndefined();
+  });
+
+  it('ensureLloHandler initializes handler when agent observability is enabled with LoggerProvider', () => {
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    const loggerProvider = new LoggerProvider();
+    const exporter = new OTLPAwsSpanExporter(
+      'https://xray.us-east-1.amazonaws.com/v1/traces',
+      undefined,
+      loggerProvider
+    );
+
+    const result = (exporter as any).ensureLloHandler();
+    expect(result).toBe(true);
+    expect((exporter as any).lloHandler).toBeDefined();
+    loggerProvider.shutdown();
+  });
+
+  it('ensureLloHandler returns false when loggerProvider is not an SDK LoggerProvider', () => {
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    const exporter = new OTLPAwsSpanExporter('https://xray.us-east-1.amazonaws.com/v1/traces');
+
+    const result = (exporter as any).ensureLloHandler();
+    expect(result).toBe(false);
+    expect((exporter as any).lloHandler).toBeUndefined();
+  });
+
+  it('export succeeds with LLO processing when agent observability is enabled', done => {
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    const loggerProvider = new LoggerProvider();
+    const exporter = new OTLPAwsSpanExporter(
+      'https://xray.us-east-1.amazonaws.com/v1/traces',
+      undefined,
+      loggerProvider
+    );
+
+    exporter.export([], (result: ExportResult) => {
+      expect(result.code).toBe(ExportResultCode.SUCCESS);
+      expect((exporter as any).lloHandler).toBeDefined();
+      loggerProvider.shutdown();
+      done();
     });
   });
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Test coverage for otlp-aws-span-exporter.ts was at 60%. This PR enhances the LLO handler test coverage across all paths, validating handler initialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

