### PR TITLE
suppress /ping spans in AgentCore environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 - refactor: remove BedrockRuntime, SecretsManager, StepFunction, SNS instrumentation patches.
   ([#446](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/446))
 
+### Bug Fixes
+
+- suppress /ping endpoint instrumentation for HTTP libraries in AgentCore
+  ([#453](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/453))
+
 ## v0.11.0 - 2026-04-30
 
 - Support environment-configured endpoint visibility for HTTP operation names

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -132,6 +132,19 @@ export const instrumentationConfigs: InstrumentationConfigMap = {
   '@opentelemetry/instrumentation-mongoose': {
     suppressInternalInstrumentation: true,
   },
+  // Suppress healthcheck (/ping) traces in AgentCore environments to reduce noise
+  ...(isAgentObservabilityEnabled() && {
+    '@opentelemetry/instrumentation-http': {
+      ignoreIncomingRequestHook: (request: { url?: string }) => {
+        return request.url === '/ping';
+      },
+    },
+    '@opentelemetry/instrumentation-undici': {
+      ignoreRequestHook: (request: { path: string }) => {
+        return request.path === '/ping';
+      },
+    },
+  }),
 };
 export const instrumentations: Instrumentation[] = getNodeAutoInstrumentations(instrumentationConfigs);
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -122,6 +122,9 @@ export function setAwsDefaultEnvironmentVariables() {
 }
 setAwsDefaultEnvironmentVariables();
 
+export const isHttpPingRequest = (request: { url?: string }) => request.url === '/ping';
+export const isUndicPingRequest = (request: { path: string }) => request.path === '/ping';
+
 export const instrumentationConfigs: InstrumentationConfigMap = {
   '@opentelemetry/instrumentation-aws-lambda': {
     eventContextExtractor: customExtractor,
@@ -134,14 +137,10 @@ export const instrumentationConfigs: InstrumentationConfigMap = {
   },
   ...(isAgentObservabilityEnabled() && {
     '@opentelemetry/instrumentation-http': {
-      ignoreIncomingRequestHook: (request: { url?: string }) => {
-        return request.url === '/ping';
-      },
+      ignoreIncomingRequestHook: isHttpPingRequest,
     },
     '@opentelemetry/instrumentation-undici': {
-      ignoreRequestHook: (request: { path: string }) => {
-        return request.path === '/ping';
-      },
+      ignoreRequestHook: isUndicPingRequest,
     },
   }),
 };

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -132,7 +132,6 @@ export const instrumentationConfigs: InstrumentationConfigMap = {
   '@opentelemetry/instrumentation-mongoose': {
     suppressInternalInstrumentation: true,
   },
-  // Suppress healthcheck (/ping) traces in AgentCore environments to reduce noise
   ...(isAgentObservabilityEnabled() && {
     '@opentelemetry/instrumentation-http': {
       ignoreIncomingRequestHook: (request: { url?: string }) => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -123,7 +123,7 @@ export function setAwsDefaultEnvironmentVariables() {
 setAwsDefaultEnvironmentVariables();
 
 export const isHttpPingRequest = (request: { url?: string }) => request.url === '/ping';
-export const isUndicPingRequest = (request: { path: string }) => request.path === '/ping';
+export const isUndiciPingRequest = (request: { path: string }) => request.path === '/ping';
 
 export const instrumentationConfigs: InstrumentationConfigMap = {
   '@opentelemetry/instrumentation-aws-lambda': {
@@ -140,7 +140,7 @@ export const instrumentationConfigs: InstrumentationConfigMap = {
       ignoreIncomingRequestHook: isHttpPingRequest,
     },
     '@opentelemetry/instrumentation-undici': {
-      ignoreRequestHook: isUndicPingRequest,
+      ignoreRequestHook: isUndiciPingRequest,
     },
   }),
 };

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -413,9 +413,8 @@ describe('Register', function () {
   });
 
   describe('Healthcheck suppression', () => {
-    const { isHttpPingRequest, isUndicPingRequest } = require('../src/register');
-
     it('suppresses /ping for incoming HTTP requests', () => {
+      const { isHttpPingRequest } = require('../src/register');
       assert.strictEqual(isHttpPingRequest({ url: '/ping' }), true);
       assert.strictEqual(isHttpPingRequest({ url: '/invocations' }), false);
       assert.strictEqual(isHttpPingRequest({ url: '/' }), false);
@@ -423,9 +422,10 @@ describe('Register', function () {
     });
 
     it('suppresses /ping for undici requests', () => {
-      assert.strictEqual(isUndicPingRequest({ path: '/ping' }), true);
-      assert.strictEqual(isUndicPingRequest({ path: '/invocations' }), false);
-      assert.strictEqual(isUndicPingRequest({ path: '/' }), false);
+      const { isUndiciPingRequest } = require('../src/register');
+      assert.strictEqual(isUndiciPingRequest({ path: '/ping' }), true);
+      assert.strictEqual(isUndiciPingRequest({ path: '/invocations' }), false);
+      assert.strictEqual(isUndiciPingRequest({ path: '/' }), false);
     });
   });
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -412,6 +412,67 @@ describe('Register', function () {
     });
   });
 
+  describe('Healthcheck suppression', () => {
+    const baseEnv = {
+      ...process.env,
+      OTEL_NODE_RESOURCE_DETECTORS: 'none',
+      OTEL_TRACES_EXPORTER: 'none',
+      OTEL_METRICS_EXPORTER: 'none',
+      OTEL_LOGS_EXPORTER: 'none',
+      OTEL_LOG_LEVEL: 'NONE',
+    };
+
+    const loadConfigsInChildProcess = (env: Record<string, string | undefined>): SpawnSyncReturns<Buffer> => {
+      const script = `
+        const register = require('../build/src/register.js');
+        // Output configs as JSON for the parent to assert on
+        const configs = register.instrumentationConfigs;
+        const httpHook = configs['@opentelemetry/instrumentation-http']?.ignoreIncomingRequestHook;
+        const undiciHook = configs['@opentelemetry/instrumentation-undici']?.ignoreRequestHook;
+        const result = {
+          hasHttpConfig: !!httpHook,
+          hasUndiciConfig: !!undiciHook,
+          httpIgnoresPing: httpHook ? httpHook({ url: '/ping' }) : null,
+          httpIgnoresInvocations: httpHook ? httpHook({ url: '/invocations' }) : null,
+          undiciIgnoresPing: undiciHook ? undiciHook({ path: '/ping' }) : null,
+          undiciIgnoresInvocations: undiciHook ? undiciHook({ path: '/invocations' }) : null,
+        };
+        process.stdout.write(JSON.stringify(result));
+        process.exit(0);
+      `;
+      return spawnSync(process.execPath, ['-e', script], {
+        cwd: __dirname,
+        timeout: 10000,
+        killSignal: 'SIGKILL',
+        env: { ...baseEnv, ...env },
+      });
+    };
+
+    it('configures /ping suppression when AGENT_OBSERVABILITY_ENABLED is true', () => {
+      const proc = loadConfigsInChildProcess({ AGENT_OBSERVABILITY_ENABLED: 'true' });
+      assert.ifError(proc.error);
+      assert.equal(proc.status, 0, proc.stderr?.toString());
+
+      const result = JSON.parse(proc.stdout.toString());
+      expect(result.hasHttpConfig).toBe(true);
+      expect(result.hasUndiciConfig).toBe(true);
+      expect(result.httpIgnoresPing).toBe(true);
+      expect(result.httpIgnoresInvocations).toBe(false);
+      expect(result.undiciIgnoresPing).toBe(true);
+      expect(result.undiciIgnoresInvocations).toBe(false);
+    });
+
+    it('does not configure /ping suppression when AGENT_OBSERVABILITY_ENABLED is not set', () => {
+      const proc = loadConfigsInChildProcess({});
+      assert.ifError(proc.error);
+      assert.equal(proc.status, 0, proc.stderr?.toString());
+
+      const result = JSON.parse(proc.stdout.toString());
+      expect(result.hasHttpConfig).toBe(false);
+      expect(result.hasUndiciConfig).toBe(false);
+    });
+  });
+
   it('can load auto instrumentation from command line', () => {
     const proc: SpawnSyncReturns<Buffer> = spawnSync(
       process.execPath,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -30,13 +30,17 @@ import {
 describe('Register', function () {
   let instrumentations: any[];
   let setAwsDefaultEnvironmentVariables: () => void;
+  let instrumentationConfigs: any;
 
   before(() => {
+    // Set AGENT_OBSERVABILITY_ENABLED so instrumentationConfigs includes the /ping hooks
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
     const stub = sinon.stub(opentelemetry.NodeSDK.prototype, 'start');
     const register = require('../src/register');
     stub.restore();
     instrumentations = register.instrumentations;
     setAwsDefaultEnvironmentVariables = register.setAwsDefaultEnvironmentVariables;
+    instrumentationConfigs = register.instrumentationConfigs;
     for (const instr of instrumentations) {
       instr.disable();
     }
@@ -413,63 +417,22 @@ describe('Register', function () {
   });
 
   describe('Healthcheck suppression', () => {
-    const baseEnv = {
-      ...process.env,
-      OTEL_NODE_RESOURCE_DETECTORS: 'none',
-      OTEL_TRACES_EXPORTER: 'none',
-      OTEL_METRICS_EXPORTER: 'none',
-      OTEL_LOGS_EXPORTER: 'none',
-      OTEL_LOG_LEVEL: 'NONE',
-    };
-
-    const loadConfigsInChildProcess = (env: Record<string, string | undefined>): SpawnSyncReturns<Buffer> => {
-      const script = `
-        const register = require('../build/src/register.js');
-        // Output configs as JSON for the parent to assert on
-        const configs = register.instrumentationConfigs;
-        const httpHook = configs['@opentelemetry/instrumentation-http']?.ignoreIncomingRequestHook;
-        const undiciHook = configs['@opentelemetry/instrumentation-undici']?.ignoreRequestHook;
-        const result = {
-          hasHttpConfig: !!httpHook,
-          hasUndiciConfig: !!undiciHook,
-          httpIgnoresPing: httpHook ? httpHook({ url: '/ping' }) : null,
-          httpIgnoresInvocations: httpHook ? httpHook({ url: '/invocations' }) : null,
-          undiciIgnoresPing: undiciHook ? undiciHook({ path: '/ping' }) : null,
-          undiciIgnoresInvocations: undiciHook ? undiciHook({ path: '/invocations' }) : null,
-        };
-        process.stdout.write(JSON.stringify(result));
-        process.exit(0);
-      `;
-      return spawnSync(process.execPath, ['-e', script], {
-        cwd: __dirname,
-        timeout: 10000,
-        killSignal: 'SIGKILL',
-        env: { ...baseEnv, ...env },
-      });
-    };
-
-    it('configures /ping suppression when AGENT_OBSERVABILITY_ENABLED is true', () => {
-      const proc = loadConfigsInChildProcess({ AGENT_OBSERVABILITY_ENABLED: 'true' });
-      assert.ifError(proc.error);
-      assert.equal(proc.status, 0, proc.stderr?.toString());
-
-      const result = JSON.parse(proc.stdout.toString());
-      expect(result.hasHttpConfig).toBe(true);
-      expect(result.hasUndiciConfig).toBe(true);
-      expect(result.httpIgnoresPing).toBe(true);
-      expect(result.httpIgnoresInvocations).toBe(false);
-      expect(result.undiciIgnoresPing).toBe(true);
-      expect(result.undiciIgnoresInvocations).toBe(false);
+    it('configures ignoreIncomingRequestHook for http when AGENT_OBSERVABILITY_ENABLED is true', () => {
+      const httpConfig = instrumentationConfigs['@opentelemetry/instrumentation-http'];
+      assert.ok(httpConfig, 'http config should exist');
+      assert.ok(httpConfig.ignoreIncomingRequestHook, 'ignoreIncomingRequestHook should be set');
+      assert.strictEqual(httpConfig.ignoreIncomingRequestHook({ url: '/ping' }), true);
+      assert.strictEqual(httpConfig.ignoreIncomingRequestHook({ url: '/invocations' }), false);
+      assert.strictEqual(httpConfig.ignoreIncomingRequestHook({ url: '/' }), false);
     });
 
-    it('does not configure /ping suppression when AGENT_OBSERVABILITY_ENABLED is not set', () => {
-      const proc = loadConfigsInChildProcess({});
-      assert.ifError(proc.error);
-      assert.equal(proc.status, 0, proc.stderr?.toString());
-
-      const result = JSON.parse(proc.stdout.toString());
-      expect(result.hasHttpConfig).toBe(false);
-      expect(result.hasUndiciConfig).toBe(false);
+    it('configures ignoreRequestHook for undici when AGENT_OBSERVABILITY_ENABLED is true', () => {
+      const undiciConfig = instrumentationConfigs['@opentelemetry/instrumentation-undici'];
+      assert.ok(undiciConfig, 'undici config should exist');
+      assert.ok(undiciConfig.ignoreRequestHook, 'ignoreRequestHook should be set');
+      assert.strictEqual(undiciConfig.ignoreRequestHook({ path: '/ping' }), true);
+      assert.strictEqual(undiciConfig.ignoreRequestHook({ path: '/invocations' }), false);
+      assert.strictEqual(undiciConfig.ignoreRequestHook({ path: '/' }), false);
     });
   });
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -30,17 +30,13 @@ import {
 describe('Register', function () {
   let instrumentations: any[];
   let setAwsDefaultEnvironmentVariables: () => void;
-  let instrumentationConfigs: any;
 
   before(() => {
-    // Set AGENT_OBSERVABILITY_ENABLED so instrumentationConfigs includes the /ping hooks
-    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
     const stub = sinon.stub(opentelemetry.NodeSDK.prototype, 'start');
     const register = require('../src/register');
     stub.restore();
     instrumentations = register.instrumentations;
     setAwsDefaultEnvironmentVariables = register.setAwsDefaultEnvironmentVariables;
-    instrumentationConfigs = register.instrumentationConfigs;
     for (const instr of instrumentations) {
       instr.disable();
     }
@@ -417,22 +413,19 @@ describe('Register', function () {
   });
 
   describe('Healthcheck suppression', () => {
-    it('configures ignoreIncomingRequestHook for http when AGENT_OBSERVABILITY_ENABLED is true', () => {
-      const httpConfig = instrumentationConfigs['@opentelemetry/instrumentation-http'];
-      assert.ok(httpConfig, 'http config should exist');
-      assert.ok(httpConfig.ignoreIncomingRequestHook, 'ignoreIncomingRequestHook should be set');
-      assert.strictEqual(httpConfig.ignoreIncomingRequestHook({ url: '/ping' }), true);
-      assert.strictEqual(httpConfig.ignoreIncomingRequestHook({ url: '/invocations' }), false);
-      assert.strictEqual(httpConfig.ignoreIncomingRequestHook({ url: '/' }), false);
+    const { isHttpPingRequest, isUndicPingRequest } = require('../src/register');
+
+    it('suppresses /ping for incoming HTTP requests', () => {
+      assert.strictEqual(isHttpPingRequest({ url: '/ping' }), true);
+      assert.strictEqual(isHttpPingRequest({ url: '/invocations' }), false);
+      assert.strictEqual(isHttpPingRequest({ url: '/' }), false);
+      assert.strictEqual(isHttpPingRequest({}), false);
     });
 
-    it('configures ignoreRequestHook for undici when AGENT_OBSERVABILITY_ENABLED is true', () => {
-      const undiciConfig = instrumentationConfigs['@opentelemetry/instrumentation-undici'];
-      assert.ok(undiciConfig, 'undici config should exist');
-      assert.ok(undiciConfig.ignoreRequestHook, 'ignoreRequestHook should be set');
-      assert.strictEqual(undiciConfig.ignoreRequestHook({ path: '/ping' }), true);
-      assert.strictEqual(undiciConfig.ignoreRequestHook({ path: '/invocations' }), false);
-      assert.strictEqual(undiciConfig.ignoreRequestHook({ path: '/' }), false);
+    it('suppresses /ping for undici requests', () => {
+      assert.strictEqual(isUndicPingRequest({ path: '/ping' }), true);
+      assert.strictEqual(isUndicPingRequest({ path: '/invocations' }), false);
+      assert.strictEqual(isUndicPingRequest({ path: '/' }), false);
     });
   });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In AWS Bedrock AgentCore environments, hosted agent runtimes receive an steady rate of healthcheck pings that would be excessive to trace. Python fixes this by setting `OTEL_PYTHON_EXCLUDED_URLS` in its AgentCore runtime environment, but NodeJS does not provide a similar configuration in upstream. Instead, we manually configure suppression of this endpoint for the http and undici instrumentation libraries for AgentCore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

