### PR TITLE
fix(ci): pin floating build dependencies that break PR builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,9 @@ ARG TARGETARCH
 RUN if [ $TARGETARCH = "amd64" ]; then rustup component add rustfmt && cargo fmt --check ; fi
 
 # Audit dependencies
-RUN if [ $TARGETARCH = "amd64" ]; then cargo install cargo-audit --locked && cargo audit ; fi
+# Pin cargo-audit: newer releases (>=0.22.2) require a rustc newer than the pinned
+# rust base image above, which breaks the build when cargo-audit floats to latest.
+RUN if [ $TARGETARCH = "amd64" ]; then cargo install cargo-audit --locked --version 0.22.1 && cargo audit ; fi
 
 
 # Cross-compile based on the target platform.

--- a/lambda-layer/sample-apps/aws-sdk/package.json
+++ b/lambda-layer/sample-apps/aws-sdk/package.json
@@ -51,7 +51,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.750.0",
+    "@aws-sdk/client-s3": "3.982.0",
     "@opentelemetry/winston-transport": "^0.13.0",
     "winston": "^3.17.0"
   }


### PR DESCRIPTION
## Description

Two unpinned build dependencies float to "latest" on every PR build and have started failing as new upstream releases land. Neither is related to any feature change — they break **all** PR builds until pinned (observed on #466, and reproducible on any PR built after the upstream releases landed).

### 1. `cargo-audit` vs pinned rustc (root `Dockerfile`)
The image pins `rust:1.87` but runs `cargo install cargo-audit --locked` (unpinned). `cargo-audit` recently published `0.22.2`, which requires `rustc >= 1.88`:

```
error: cannot install package `cargo-audit 0.22.2`, it requires rustc 1.88 or newer,
       while the currently active rustc version is 1.87.0
```

This fails the **"Build Tarball and Image Files"** step. Fixed by pinning `cargo-audit` to `0.22.1` (compatible with rustc 1.87, per cargo's own message).

### 2. `@aws-sdk/client-s3` vs pinned TypeScript (`lambda-layer/sample-apps/aws-sdk`)
The sample app floats `@aws-sdk/client-s3` from `^3.750.0`, which now resolves to `3.1062.0`. Its generated `S3Client.d.ts` imports the `@aws-sdk/middleware-sdk-s3/s3` **subpath export**, which the sample's pinned **TypeScript 4.9.5** cannot resolve:

```
node_modules/@aws-sdk/client-s3/dist-types/S3Client.d.ts:3:59 - error TS2307:
Cannot find module '@aws-sdk/middleware-sdk-s3/s3'
```

This fails the **"Build Lambda Layer"** step on Node 20/22/24. Fixed by pinning to `3.982.0` — the version the main package already pins; its `.d.ts` imports the package root (`@aws-sdk/middleware-sdk-s3`), not the subpath.

## Testing

- **Lambda sample (Fix 2)**: verified locally — fresh install resolves `3.982.0`, `S3Client.d.ts` no longer uses the breaking subpath, and `npm run compile` (the failing CI step: `tsc -p .` + package) succeeds.
- **cargo-audit (Fix 1)**: the pin to `0.22.1` is the version cargo's own error message identifies as supporting rustc 1.85+ (and thus the pinned 1.87). Validated by CI on this PR.

## Notes

Both are pinned (exact / safe range) so future floating releases can't reintroduce the break. A follow-up could add lockfiles to the sample apps for stronger reproducibility, but that's out of scope here.
