### PR TITLE
ci(claude-review): widen allowedTools so large PRs can be reviewed

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,6 +45,6 @@ jobs:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
+            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Read,Grep,Glob,Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*),Bash(git diff *),Bash(git log *),Bash(git show *)"
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in this repository for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines of this PR only. Do not modify, comment on, or interact with any other PR.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `claude-review` GitHub Action's `--allowedTools` only permits PR-scoped `gh pr diff/view` and `gh api .../comments|reviews` — it has no tools to read repo files or grep the tree, so the reviewer can only see the raw diff. We suspect this is why it struggles on large PRs: run #467 (the large ServiceEvents PR) logged 256 permission denials, ran ~19 min, and posted no review, whereas the small #466 ran clean (14 denials, ~5 min). The job log hides per-turn tool output, so the exact denied calls aren't recorded — but a diff-only reviewer has no way to gather cross-file context on a big change, which is the most likely cause.

The potential fix is to add read-only context-gathering tools — `Read`, `Grep`, `Glob`, and `git diff/log/show` — so the reviewer can inspect changed files. This stays strictly read-only: no write tools and no build/test execution (important under `pull_request_target`, which runs with repo secrets against the PR author's code), and the existing PR-scoped `gh` rules are unchanged.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

