### PR TITLE
refactor(debugger): remove unused instrumentation_name field from DI

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/model/instrumentation-configuration.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/model/instrumentation-configuration.ts
@@ -31,7 +31,6 @@ export interface InstrumentationConfiguration {
   captureConfig: CaptureConfiguration;
   locationHash: string;
   instrumentationType: InstrumentationType;
-  instrumentationName: string;
   expiresAt: number | null; // epoch milliseconds
   maxHits: number;
   attributeFilters: Array<Record<string, string>>;
@@ -117,7 +116,6 @@ export function isPermanent(config: InstrumentationConfiguration): boolean {
  *   "LocationHash": "abc123",
  *   "CaptureConfiguration": { "CodeCapture": {...} },
  *   "ExpiresAt": "2026-01-23T10:36:51Z",
- *   "InstrumentationName": "my-probe",
  *   "AttributeFilters": [{"key": "value"}],
  *   "ARN": "arn:...",
  *   "CreatedAt": "2026-01-23T10:00:00Z"
@@ -176,15 +174,6 @@ export function parseInstrumentationConfiguration(
         diag.warn(`DI: Invalid InstrumentationType '${typeStr}'. Defaulting to BREAKPOINT.`);
         instrumentationType = InstrumentationType.BREAKPOINT;
       }
-    }
-
-    // Parse instrumentation name
-    const instrumentationName = (apiConfig.InstrumentationName as string) ?? '';
-
-    // PROBE requires InstrumentationName
-    if (instrumentationType === InstrumentationType.PROBE && !instrumentationName) {
-      diag.warn(`DI: PROBE instrumentation for ${filePath}:${methodName} missing InstrumentationName. Skipping.`);
-      return null;
     }
 
     // Parse line number
@@ -262,7 +251,6 @@ export function parseInstrumentationConfiguration(
       captureConfig,
       locationHash,
       instrumentationType,
-      instrumentationName,
       expiresAt,
       maxHits,
       attributeFilters,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/configuration-poller.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/configuration-poller.test.ts
@@ -34,7 +34,6 @@ function makeApiConfigItem(attributeFilters: Array<Record<string, string>> | und
   return {
     InstrumentationType: 'BREAKPOINT',
     SignalType: 'SNAPSHOT',
-    InstrumentationName: 'test-bp',
     Location: {
       CodeLocation: {
         Language: 'javascript',
@@ -249,13 +248,11 @@ describe('ConfigurationPoller attribute filter matching', function () {
         {
           ...makeApiConfigItem([{ 'service.name': 'payment-service' }]),
           LocationHash: 'hash456',
-          InstrumentationName: 'test-bp-2',
         },
         // Config 3: OR-across — second filter matches
         {
           ...makeApiConfigItem([{ 'service.name': 'payment-service' }, { 'instance.id': 'i-abc123' }]),
           LocationHash: 'hash789',
-          InstrumentationName: 'test-bp-3',
         },
       ],
       NextToken: null,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/model/instrumentation-configuration.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/model/instrumentation-configuration.test.ts
@@ -14,7 +14,6 @@ function makeConfig(overrides: Record<string, unknown> = {}): Record<string, unk
   return {
     InstrumentationType: 'BREAKPOINT',
     SignalType: 'SNAPSHOT',
-    InstrumentationName: 'test',
     Location: {
       CodeLocation: {
         Language: 'javascript',
@@ -46,7 +45,6 @@ describe('parseInstrumentationConfiguration', function () {
     const config = parseInstrumentationConfiguration(
       makeConfig({
         InstrumentationType: 'PROBE',
-        InstrumentationName: 'my-probe',
         Location: {
           CodeLocation: { Language: 'javascript', MethodName: 'myFunc', FilePath: 'app.js', LineNumber: 5 },
         },
@@ -56,13 +54,6 @@ describe('parseInstrumentationConfiguration', function () {
     expect(config!.instrumentationType).toBe(InstrumentationType.PROBE);
     expect(config!.lineNumber).toBe(0); // PROBE forces lineNumber to 0
     expect(config!.maxHits).toBe(Number.MAX_SAFE_INTEGER); // PROBE = unlimited
-  });
-
-  it('should reject PROBE without InstrumentationName', function () {
-    const config = parseInstrumentationConfiguration(
-      makeConfig({ InstrumentationType: 'PROBE', InstrumentationName: undefined })
-    );
-    expect(config).toBeNull();
   });
 
   it('should reject config without FilePath', function () {
@@ -143,7 +134,6 @@ describe('parseInstrumentationConfiguration', function () {
     const config = parseInstrumentationConfiguration(
       makeConfig({
         InstrumentationType: 'PROBE',
-        InstrumentationName: 'test-probe',
         ExpiresAt: '2026-01-01T00:00:00Z',
       })
     );
@@ -180,7 +170,6 @@ describe('isLineLevel', function () {
     const config = parseInstrumentationConfiguration(
       makeConfig({
         InstrumentationType: 'PROBE',
-        InstrumentationName: 'probe',
         Location: { CodeLocation: { Language: 'javascript', MethodName: 'fn', FilePath: 'a.js', LineNumber: 0 } },
       })
     )!;
@@ -193,7 +182,6 @@ describe('isPermanent', function () {
     const config = parseInstrumentationConfiguration(
       makeConfig({
         InstrumentationType: 'PROBE',
-        InstrumentationName: 'probe',
       })
     )!;
     expect(isPermanent(config)).toBe(true);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/registry/instrumentation-registry.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/registry/instrumentation-registry.test.ts
@@ -17,7 +17,6 @@ function makeTestConfig(overrides: Partial<InstrumentationConfiguration> = {}): 
     captureConfig: CAPTURE_DEFAULTS as any,
     locationHash: 'hash123',
     instrumentationType: InstrumentationType.BREAKPOINT,
-    instrumentationName: 'test',
     expiresAt: null,
     maxHits: 100,
     attributeFilters: [],

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/status-reporter.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/status-reporter.test.ts
@@ -20,7 +20,6 @@ function makeConfig(locationHash: string, expiresAtIso: string = '2099-12-31T23:
   const config = parseInstrumentationConfiguration({
     InstrumentationType: 'BREAKPOINT',
     SignalType: 'SNAPSHOT',
-    InstrumentationName: `bp-${locationHash}`,
     Location: {
       CodeLocation: {
         Language: 'javascript',


### PR DESCRIPTION
## Summary

- Drop `instrumentation_name` from `BreakpointConfiguration` and its parsing in `from_api_config` — the field was parsed from the API response but never read by any consumer.
- Remove the `InstrumentationName` test fixture entry and the now-empty `test_probe_missing_instrumentation_name_defaults_to_empty` test; update the surrounding docstring/class docstring to drop the name reference.