### PR TITLE
test(agent-observability): pin OTel semconv schema URL to v1.41.0 raw GitHub path

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/otel-schema-validator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/otel-schema-validator.ts
@@ -3,7 +3,8 @@
 
 import * as Ajv from 'ajv';
 
-const OTEL_SCHEMA_BASE = 'https://opentelemetry.io/docs/specs/semconv';
+const OTEL_SEMCONV_VERSION = 'v1.41.0';
+const OTEL_SCHEMA_BASE = `https://raw.githubusercontent.com/open-telemetry/semantic-conventions/${OTEL_SEMCONV_VERSION}/docs`;
 const schemaCache: Record<string, object> = {};
 
 async function fetchSchema(url: string): Promise<object> {


### PR DESCRIPTION
## Summary

- Pin OTel semconv schema URL to `v1.41.0` raw GitHub path so schema-validation tests are stable when the docs site drifts.
- Mirrors python-side fix in aws-observability/aws-otel-python-instrumentation#774. `main` build is currently failing with 38 GenAI tests hitting 404s on `https://opentelemetry.io/docs/specs/semconv/gen-ai/*.json`; pinning to the raw GitHub URL resolves them.

## Test plan

- [ ] Existing schema-validation tests still pass against the pinned URL