### PR TITLE
fix(dynamic-instrumentation): convert numeric epoch-seconds ExpiresAt to milliseconds

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/model/instrumentation-configuration.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/model/instrumentation-configuration.ts
@@ -54,7 +54,14 @@ function clampMaxHits(value: number): number {
 
 function parseTimestamp(value: unknown): number | null {
   if (value === null || value === undefined) return null;
-  if (typeof value === 'number') return value;
+  if (typeof value === 'number') {
+    // Heuristic: if < 1e12, treat as epoch seconds and convert to milliseconds;
+    // otherwise it is already in milliseconds. The Application Signals API
+    // serializes timestamps (e.g. ExpiresAt) as numeric epoch seconds over the
+    // JSON protocol, so without this conversion ExpiresAt is ~1000x too small
+    // and every BREAKPOINT is immediately treated as expired.
+    return value < 1e12 ? value * 1000 : value;
+  }
   if (typeof value === 'string') {
     // Try ISO 8601 format
     const ms = Date.parse(value);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/model/instrumentation-configuration.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/dynamic-instrumentation/model/instrumentation-configuration.test.ts
@@ -130,6 +130,23 @@ describe('parseInstrumentationConfiguration', function () {
     expect(config!.expiresAt).toBe(Date.parse('2026-01-01T00:00:00Z'));
   });
 
+  it('should parse numeric epoch-seconds ExpiresAt as milliseconds for BREAKPOINT', function () {
+    // The Application Signals API serializes ExpiresAt as numeric epoch seconds
+    // over the JSON protocol. It must be converted to milliseconds so it can be
+    // compared against Date.now(); otherwise the breakpoint is treated as expired.
+    const epochSeconds = Math.floor(Date.parse('2026-01-01T00:00:00Z') / 1000);
+    const config = parseInstrumentationConfiguration(makeConfig({ ExpiresAt: epochSeconds }));
+    expect(config).not.toBeNull();
+    expect(config!.expiresAt).toBe(Date.parse('2026-01-01T00:00:00Z'));
+  });
+
+  it('should pass through numeric millisecond ExpiresAt unchanged for BREAKPOINT', function () {
+    const epochMillis = Date.parse('2026-01-01T00:00:00Z');
+    const config = parseInstrumentationConfiguration(makeConfig({ ExpiresAt: epochMillis }));
+    expect(config).not.toBeNull();
+    expect(config!.expiresAt).toBe(epochMillis);
+  });
+
   it('should ignore ExpiresAt for PROBE', function () {
     const config = parseInstrumentationConfiguration(
       makeConfig({


### PR DESCRIPTION
## Problem

Dynamic Instrumentation BREAKPOINTs never produce a snapshot. The breakpoint is fetched and applied, the V8 debugger pauses on the correct line, but the snapshot is silently dropped — no error is logged.

Root cause is in `parseTimestamp` (`src/dynamic-instrumentation/model/instrumentation-configuration.ts`):

```ts
if (typeof value === 'number') return value;   // returned unchanged
```

The Application Signals API serializes `ExpiresAt` as a **numeric epoch-seconds** value over the JSON protocol (e.g. `"ExpiresAt":1.781739623E9`). The numeric branch returns it unchanged, while the string branch already converts seconds→ms (`num < 1e12 ? num * 1000 : num`). The resulting `expiresAt` is ~1000× too small, so `InstrumentationState.checkExpiry()` compares `Date.now()` (ms) against a seconds value and the config is marked `EXPIRED` on creation. `recordHit()` then returns `false` before the first capture, and the snapshot is never emitted.

Effect: BREAKPOINTs created with a valid future expiry (e.g. the default 1 day) are treated as already expired. Since JavaScript supports only BREAKPOINT, this makes DI capture non-functional against the live API.

## Fix

Apply the same seconds-vs-ms heuristic to the numeric branch that the string branch already uses:

```ts
if (typeof value === 'number') {
  return value < 1e12 ? value * 1000 : value;
}
```

Millisecond values (`>= 1e12`) pass through unchanged; epoch-seconds values are converted.

## Tests

Added two regression tests to `instrumentation-configuration.test.ts`:
- numeric epoch-seconds `ExpiresAt` is parsed to the correct millisecond value;
- numeric millisecond `ExpiresAt` passes through unchanged.

The existing suite only covered ISO-string `ExpiresAt`, which is why the numeric path was missed. Verified that the epoch-seconds test fails on the current code and passes with the fix; full file (21 tests) passes.

## Validation

Beyond unit tests, verified end-to-end against the live Application Signals API + CloudWatch Agent: with the fix, a breakpoint on a sample Express app produced a snapshot in `/aws/service-events/<service>` capturing the expected locals — where the unpatched build produced none.
