### PR TITLE
serviceevents: gate error breakdown on faults (5xx) only

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/collectors/endpoint-collector.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/collectors/endpoint-collector.ts
@@ -127,8 +127,10 @@ export class EndpointMetricCollector extends BaseCollector {
       agg.sumDuration += durationNs;
     }
 
-    // Track error breakdown if error occurred
-    if (statusCode >= 400 && errorInfo) {
+    // Track error breakdown only for faults (5xx), matching Java. A 4xx is still
+    // reflected in the aggregate `errors` counter above, but does not produce an
+    // EndpointErrorMetric breakdown data point.
+    if (statusCode >= 500 && errorInfo) {
       const failureType = String(statusCode);
       const errorKey = `${errorInfo.errorType}:${errorInfo.functionName}`;
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/express-instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/express-instrumentation.ts
@@ -69,15 +69,42 @@ function getRoutePattern(req: any): string {
 
 /**
  * Extract error info from investigation data for error breakdown.
+ *
+ * Shared across all four framework hooks (Express/Fastify/Koa/Next.js) — the
+ * resolution logic is framework-independent (it reads only the passed-in
+ * exception and the module-global monitor state), so it lives here and is
+ * imported by the others, mirroring how `endInvestigationOnce` is shared.
  */
-function extractErrorFromCallPath(exception: Error | null): { errorType: string; functionName: string } | undefined {
+export function extractErrorFromCallPath(
+  exception: Error | null
+): { errorType: string; functionName: string } | undefined {
   const monitorState = ServiceEventsMonitorState.getInstance();
   const invData = monitorState.peekInvestigationData();
 
-  const errorType = exception?.constructor?.name ?? 'UnknownError';
-  let functionName = 'unknown';
+  // Resolve the error type. Prefer the passed-in exception; otherwise recover the type the
+  // monitor captured (a global error handler may have converted the error to a 5xx response
+  // before it reached this hook, leaving `exception` null even though a real error occurred).
+  let errorType: string | undefined;
+  if (exception?.constructor?.name) {
+    errorType = exception.constructor.name;
+  } else if (invData?.exception?.name) {
+    errorType = invData.exception.name;
+  }
 
-  if (invData?.callPath && invData.callPath.length > 0) {
+  // No real error type was captured — return undefined so the caller omits the error breakdown
+  // entirely, matching Java (whose gate is `statusCode >= 500 && errorType != null`). A 5xx with
+  // no captured exception (e.g. a handler that returns a 500 status without throwing) must NOT
+  // synthesize an "UnknownError" breakdown entry.
+  if (errorType === undefined) {
+    return undefined;
+  }
+
+  // Find the origin function. Prefer the function the monitor recorded as the actual thrower;
+  // fall back to the innermost call_path frame.
+  let functionName = 'unknown';
+  if (invData?.exception?.functionName) {
+    functionName = invData.exception.functionName;
+  } else if (invData?.callPath && invData.callPath.length > 0) {
     functionName = invData.callPath[0].functionName ?? 'unknown';
   }
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/fastify-instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/fastify-instrumentation.ts
@@ -11,11 +11,11 @@
  */
 
 import { diag } from '@opentelemetry/api';
-import { setCurrentOperation, ServiceEventsMonitorState } from '../serviceevents-monitor';
+import { setCurrentOperation } from '../serviceevents-monitor';
 import { EndpointMetricCollector } from '../collectors/endpoint-collector';
 import { IncidentSnapshotCollector, RequestData } from '../collectors/incident-snapshot-collector';
 import { ServiceEventsConfig, shouldTrackEndpoint } from '../config';
-import { endInvestigationOnce } from './express-instrumentation';
+import { endInvestigationOnce, extractErrorFromCallPath } from './express-instrumentation';
 
 // Global references to collectors
 let _endpointCollector: EndpointMetricCollector | null = null;
@@ -36,23 +36,6 @@ function getRoutePattern(request: any): string {
   }
   // Fallback to raw URL path
   return request.url || '/unknown';
-}
-
-/**
- * Extract error info from investigation data for error breakdown.
- */
-function extractErrorFromCallPath(exception: Error | null): { errorType: string; functionName: string } | undefined {
-  const monitorState = ServiceEventsMonitorState.getInstance();
-  const invData = monitorState.peekInvestigationData();
-
-  const errorType = exception?.constructor?.name ?? 'UnknownError';
-  let functionName = 'unknown';
-
-  if (invData?.callPath && invData.callPath.length > 0) {
-    functionName = invData.callPath[0].functionName ?? 'unknown';
-  }
-
-  return { errorType, functionName };
 }
 
 /**

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/koa-instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/koa-instrumentation.ts
@@ -11,11 +11,11 @@
  */
 
 import { diag } from '@opentelemetry/api';
-import { setCurrentOperation, ServiceEventsMonitorState } from '../serviceevents-monitor';
+import { setCurrentOperation } from '../serviceevents-monitor';
 import { EndpointMetricCollector } from '../collectors/endpoint-collector';
 import { IncidentSnapshotCollector, RequestData } from '../collectors/incident-snapshot-collector';
 import { ServiceEventsConfig, shouldTrackEndpoint } from '../config';
-import { endInvestigationOnce } from './express-instrumentation';
+import { endInvestigationOnce, extractErrorFromCallPath } from './express-instrumentation';
 
 // Global references to collectors
 let _endpointCollector: EndpointMetricCollector | null = null;
@@ -39,23 +39,6 @@ function getRoutePattern(ctx: any): string {
   }
   // Fallback to raw path
   return ctx.path || '/unknown';
-}
-
-/**
- * Extract error info from investigation data for error breakdown.
- */
-function extractErrorFromCallPath(exception: Error | null): { errorType: string; functionName: string } | undefined {
-  const monitorState = ServiceEventsMonitorState.getInstance();
-  const invData = monitorState.peekInvestigationData();
-
-  const errorType = exception?.constructor?.name ?? 'UnknownError';
-  let functionName = 'unknown';
-
-  if (invData?.callPath && invData.callPath.length > 0) {
-    functionName = invData.callPath[0].functionName ?? 'unknown';
-  }
-
-  return { errorType, functionName };
 }
 
 /**

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/nextjs-instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/nextjs-instrumentation.ts
@@ -22,11 +22,11 @@
  */
 
 import { diag } from '@opentelemetry/api';
-import { setCurrentOperation, ServiceEventsMonitorState } from '../serviceevents-monitor';
+import { setCurrentOperation } from '../serviceevents-monitor';
 import { EndpointMetricCollector } from '../collectors/endpoint-collector';
 import { IncidentSnapshotCollector, RequestData } from '../collectors/incident-snapshot-collector';
 import { ServiceEventsConfig, shouldTrackEndpoint } from '../config';
-import { endInvestigationOnce } from './express-instrumentation';
+import { endInvestigationOnce, extractErrorFromCallPath } from './express-instrumentation';
 
 // Global references to collectors
 let _endpointCollector: EndpointMetricCollector | null = null;
@@ -100,23 +100,6 @@ function getRoutePattern(req: any): string {
   // Fallback: raw URL path with query string stripped
   const url = req.url || '/';
   return url.split('?')[0] || '/';
-}
-
-/**
- * Extract error info from investigation data for error breakdown.
- */
-function extractErrorFromCallPath(exception: Error | null): { errorType: string; functionName: string } | undefined {
-  const monitorState = ServiceEventsMonitorState.getInstance();
-  const invData = monitorState.peekInvestigationData();
-
-  const errorType = exception?.constructor?.name ?? 'UnknownError';
-  let functionName = 'unknown';
-
-  if (invData?.callPath && invData.callPath.length > 0) {
-    functionName = invData.callPath[0].functionName ?? 'unknown';
-  }
-
-  return { errorType, functionName };
 }
 
 /**

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/serviceevents-monitor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/serviceevents-monitor.ts
@@ -860,7 +860,15 @@ export function __serviceeventsMonitorException(ctx: MonitorContext | null, err:
     return;
   }
   const invData = investigationStorage.getStore();
-  if (invData) {
+  // First-writer-wins: the AST `catch(err) { __tCatch(ctx, err); throw err }` runs
+  // innermost-first as the exception unwinds, so the first frame to observe it is the
+  // one closest to the raise (the true origin). Outer frames re-observe the SAME
+  // exception and must NOT overwrite invData.exception — otherwise the recorded
+  // functionName would always be the outermost instrumented frame. This matches
+  // Python's __exit__ (`if inv_data.get("exception") is None`) so the recovered
+  // origin function is identical across SDKs. (ctx.exceptionName above is still
+  // credited on every frame — that drives per-function error_count, not the origin.)
+  if (invData && !invData.exception) {
     const message = err instanceof Error ? err.message : String(err);
     const stackTrace = err instanceof Error ? err.stack ?? '' : '';
     invData.exception = {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/collectors/endpoint-collector.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/collectors/endpoint-collector.test.ts
@@ -77,6 +77,44 @@ describe('EndpointMetricCollector (OTLP)', function () {
     expect(evt.errors).toBe(1);
   });
 
+  it('records error_breakdown only for faults (5xx), not 4xx (Java parity)', function () {
+    // 4xx with error info still counts toward the aggregate errors counter, but
+    // produces no breakdown entry — the gate is statusCode >= 500, matching Java.
+    collector.recordRequest('/api/u', 'GET', 404, 10_000_000, {
+      errorType: 'NotFoundError',
+      functionName: 'app.handler',
+    });
+    collector.recordRequest('/api/u', 'GET', 500, 10_000_000, {
+      errorType: 'TypeError',
+      functionName: 'app.handler',
+    });
+    collector.collect();
+    const evt = emitter.endpointSummaries[0];
+    expect(evt.errors).toBe(1);
+    expect(evt.faults).toBe(1);
+    // Only the 5xx fault is in the breakdown.
+    expect(evt.error_breakdown.length).toBe(1);
+    expect(evt.error_breakdown[0].failure_type).toBe('500');
+    expect(evt.error_breakdown[0].errors[0].error_type).toBe('TypeError');
+    // The 5xx fault produces an EndpointErrorMetric; the 4xx does not.
+    expect(emitter.errorMetrics.length).toBe(1);
+    expect(emitter.errorMetrics[0].exception).toBe('TypeError');
+  });
+
+  it('records no error_breakdown for a 5xx without errorInfo (Java parity)', function () {
+    // A 5xx with no captured exception type (e.g. a handler that returns a 500 status
+    // without throwing) is passed to recordRequest with errorInfo=undefined — the framework
+    // hook's extractor returns undefined when no real error type was captured. It still
+    // counts as a fault, but produces no breakdown entry and no EndpointErrorMetric, matching
+    // Java (whose gate is `statusCode >= 500 && errorType != null`).
+    collector.recordRequest('/api/u', 'GET', 500, 10_000_000);
+    collector.collect();
+    const evt = emitter.endpointSummaries[0];
+    expect(evt.faults).toBe(1);
+    expect(evt.error_breakdown.length).toBe(0);
+    expect(emitter.errorMetrics.length).toBe(0);
+  });
+
   it('emits EndpointErrorMetric per error type', function () {
     collector.recordRequest('/api/u', 'GET', 500, 10_000_000, {
       errorType: 'TypeError',

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/instrumentation/express-instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/instrumentation/express-instrumentation.test.ts
@@ -340,4 +340,87 @@ describe('installGlobalHttpPatches', function () {
       expect(state.peekInvestigationData()).toBe(null);
     });
   });
+
+  describe('error breakdown on a 5xx: extractErrorFromCallPath recovery vs. Java-parity omission', function () {
+    // Capture the errorInfo argument the hook passes to recordRequest by spying on a
+    // real collector — the same end-to-end path production uses (global res.end patch →
+    // _processFinish → extractErrorFromCallPath(req.__serviceeventsException ?? null)).
+    function recordWithSpy(req: any, res: any): Array<{ errorType: string; functionName: string } | undefined> {
+      const captured: Array<{ errorType: string; functionName: string } | undefined> = [];
+      const spyCollector = new EndpointMetricCollector(600_000, 'env', 'svc', '0.0.1');
+      (spyCollector as any).recordRequest = (
+        _route: string,
+        _method: string,
+        _statusCode: number,
+        _durationNs: number,
+        errorInfo?: { errorType: string; functionName: string }
+      ) => {
+        captured.push(errorInfo);
+      };
+      installExpressHooks(spyCollector, undefined, 'svc', null);
+      try {
+        patchedResponseEnd.call(res);
+      } catch {
+        // tolerate the stubbed original end()
+      } finally {
+        installExpressHooks(undefined, undefined, undefined, null);
+      }
+      return captured;
+    }
+
+    it('recovers the monitor-captured exception type on a 5xx when the hook received no exception', function () {
+      // FastAPI-global-handler equivalent: a framework error handler converted the error to a
+      // 500 BEFORE the request reached our hook, so req.__serviceeventsException is unset — but
+      // the monitor captured the real exception during the instrumented call. The breakdown must
+      // carry the recovered type (and origin function), not a synthetic "UnknownError".
+      const state = ServiceEventsMonitorState.getInstance();
+      // Do NOT pre-set __serviceeventsStartTime — the arrival hook only begins the
+      // investigation for a request it hasn't seen (no existing start time).
+      const req: any = {
+        url: '/api/orders',
+        method: 'POST',
+        headers: {},
+        route: { path: '/api/orders' },
+      };
+      const res: any = { statusCode: 500, req };
+
+      // Request arrival begins the investigation; the monitor records the thrown exception.
+      invokeEmit(req, res);
+      const inv = state.peekInvestigationData();
+      expect(inv).not.toBe(null);
+      inv!.exception = {
+        name: 'KeyError',
+        message: 'missing id',
+        traceback: '',
+        functionName: 'orders.lookup',
+      };
+      // Note: req.__serviceeventsException is deliberately NOT set.
+
+      const captured = recordWithSpy(req, res);
+
+      expect(captured.length).toBe(1);
+      expect(captured[0]).toEqual({ errorType: 'KeyError', functionName: 'orders.lookup' });
+    });
+
+    it('omits the breakdown on a 5xx with neither a passed-in nor a captured exception (Java parity)', function () {
+      // A handler that returns a 500 status without ever throwing, and with no instrumented frame
+      // having captured an exception. There is no real error type, so the extractor returns
+      // undefined and the hook passes errorInfo=undefined — matching Java's `errorType != null`
+      // gate. No synthetic "UnknownError" breakdown is produced.
+      const req: any = {
+        url: '/api/orders',
+        method: 'POST',
+        headers: {},
+        route: { path: '/api/orders' },
+      };
+      const res: any = { statusCode: 500, req };
+
+      invokeEmit(req, res); // begins an investigation, but no exception is ever recorded
+
+      const captured = recordWithSpy(req, res);
+
+      expect(captured.length).toBe(1);
+      expect(captured[0]).toBeUndefined();
+    });
+  });
 });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/serviceevents-monitor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/serviceevents-monitor.test.ts
@@ -246,6 +246,34 @@ describe('ServiceEventsMonitor', function () {
       __serviceeventsMonitorException(ctx, new Error('test'));
       __serviceeventsMonitorExit(ctx!);
     });
+
+    it('records the INNERMOST frame as the exception origin (first-writer-wins, Python parity)', function () {
+      // The AST `catch(err){ __tCatch(ctx,err); throw err }` fires innermost-first as the
+      // exception unwinds, so the first frame to observe it is the true origin. Outer frames
+      // re-observe the SAME exception and must NOT overwrite invData.exception.functionName —
+      // otherwise the recorded thrower is always the outermost instrumented frame, diverging
+      // from Python's `__exit__` (`if inv_data.get("exception") is None`) and breaking the
+      // spec's "Identical across Java, Python, and JS" guarantee for exception_breakdown.
+      const state = ServiceEventsMonitorState.getInstance();
+      state.beginInvestigation();
+
+      // Simulate a throw propagating through two instrumented frames: outer.dispatch calls
+      // inner.lookup, inner throws, then the error unwinds back out. The AST catch fires
+      // innermost-first, so __serviceeventsMonitorException(inner) runs before (outer); enter/exit
+      // nest LIFO (outer entered first since it's the caller).
+      const outer = __serviceeventsMonitorEnter('outer.dispatch');
+      const inner = __serviceeventsMonitorEnter('inner.lookup');
+      const err = new TypeError('boom');
+      __serviceeventsMonitorException(inner, err); // innermost observes first → origin
+      __serviceeventsMonitorExit(inner!);
+      __serviceeventsMonitorException(outer, err); // outermost re-observes → must NOT overwrite
+      __serviceeventsMonitorExit(outer!);
+
+      const invData = state.getInvestigationData();
+      expect(invData!.exception!.name).toBe('TypeError');
+      // The origin function is the innermost frame, not the outermost — first-writer-wins.
+      expect(invData!.exception!.functionName).toBe('inner.lookup');
+    });
   });
 
   describe('Investigation', function () {

--- a/contract-tests/tests/test/amazon/serviceevents/serviceevents_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/serviceevents/serviceevents_contract_test_base.py
@@ -720,6 +720,21 @@ class ServiceEventsContractTestBase(ServiceEventsTestInfrastructure):
             _sum_for_route("/fault", "aws.service_events.request.errors"), 0, "/fault should have errors == 0"
         )
 
+        # Fault-only breakdown: /error is a bare 4xx (status 400, no throw, no captured
+        # exception), so it increments `request.errors` but must NEVER produce an
+        # exception_breakdown entry. This guards the gate against regressing to the old
+        # `status >= 400` behavior AND against re-synthesizing an "UnknownError" entry for
+        # a 4xx — matching Java's `statusCode >= 500 && errorType != null`. Without this
+        # assertion a gate revert would still pass (the counts above only check errors/faults).
+        for rec in self._get_log_records_matching("aws.service_events.endpoint_summary"):
+            if self.log_attrs(rec).get("url.route") == "/error":
+                breakdown = self.log_body(rec).get("exception_breakdown") or []
+                self.assertEqual(
+                    breakdown,
+                    [],
+                    "/error (4xx) must produce no exception_breakdown entry (fault-only, Java parity)",
+                )
+
     def test_incident_snapshot_latency_trigger(self) -> None:
         """/slow busy-waits ~6s (> the 5000ms default threshold) and returns 200 with
         NO exception, so the only thing that can produce an incident snapshot is the


### PR DESCRIPTION
## What

Gate the per-error `exception_breakdown` (and the `EndpointErrorMetric` `count` data points it feeds) on **faults (5xx) only**, and stop synthesizing an `"UnknownError"` entry when no real exception type was captured.

The breakdown is now populated only for a request with `status_code >= 500` **and** a captured exception type. A 4xx still increments the aggregate `errors` counter but produces no breakdown entry; a 5xx that returned a 500 without a captured exception produces no synthetic entry.

## Changes

- **Gate `>= 400` → `>= 500`** in `endpoint-collector.ts`.
- **No synthetic `UnknownError`**: `extractErrorFromCallPath` returns `undefined` when no real error type can be resolved, so the caller omits the breakdown entirely.
- **De-duplicate `extractErrorFromCallPath`**: export the Express copy and import it from the Fastify/Koa/Next.js hooks (previously four byte-identical copies), mirroring how `endInvestigationOnce` is shared.
- **Recover the monitor-captured exception**: when a global error handler converted the error to a 5xx before it reached the hook (`exception` is null but the monitor captured a real type), recover the type and origin function from the investigation data.
- **First-writer-wins exception origin**: the monitor now preserves the **innermost/origin** frame as `invData.exception.functionName` instead of letting outer frames overwrite it (was last-writer-wins, which recorded the outermost frame). The per-frame `error_count` credit is unchanged.

## Tests

- Fault-only gate (4xx excluded from breakdown, still counted as an error).
- 5xx-without-exception omission (no synthetic `UnknownError`).
- The monitor-capture recovery path on a 5xx with no passed-in exception.
- Multi-frame first-writer-wins: the innermost frame is recorded as the exception origin.

`npm run lint` clean (0 errors), `tsc --noEmit` clean, full serviceevents suite green.
