### PR TITLE
test(dynamic-instrumentation): add coverage for numeric epoch-seconds ExpiresAt

### DIFF
--- a/contract-tests/images/applications/di-express/app.js
+++ b/contract-tests/images/applications/di-express/app.js
@@ -93,6 +93,17 @@ function processNestedCollection(nested) {
   return nested.length;
 }
 
+/**
+ * BREAKPOINT target whose config carries a NUMERIC epoch-seconds ExpiresAt
+ * (the real Application Signals API wire format, e.g. 1.781739623E9). The
+ * breakpoint must NOT be treated as already expired, so a snapshot should
+ * still be captured. See the expiry config in mock_di_api.js.
+ */
+function expiryCheck(token) {
+  const verified = token > 0; // Line 103 - line-level breakpoint here
+  return verified;
+}
+
 // =========================================================================
 // Routes
 // =========================================================================
@@ -145,6 +156,13 @@ app.get('/limits-collection-depth', (req, res) => {
   const nested = [[[['deep']]]];
   const result = processNestedCollection(nested);
   res.json({ status: 'ok', size: result });
+});
+
+app.get('/expiry', (req, res) => {
+  // The expiryCheck breakpoint config carries a numeric epoch-seconds ExpiresAt
+  // set in the future; a snapshot must still be captured (not expired-on-create).
+  const result = expiryCheck(1);
+  res.json({ status: 'ok', verified: result });
 });
 
 app.listen(8080, () => {

--- a/contract-tests/images/applications/di-express/mock_di_api.js
+++ b/contract-tests/images/applications/di-express/mock_di_api.js
@@ -15,6 +15,13 @@
 
 const http = require('http');
 
+// The Application Signals API serializes ExpiresAt/CreatedAt as NUMERIC epoch
+// SECONDS over the JSON protocol (e.g. 1.781739623E9), not ISO-8601 strings or
+// milliseconds. Use a future epoch-seconds value so the breakpoint is valid; the
+// distro must convert seconds->ms, otherwise the breakpoint is treated as expired
+// on creation and never captures a snapshot.
+const EXPIRES_AT_EPOCH_SECONDS = Math.floor(Date.now() / 1000) + 24 * 60 * 60; // +1 day, in SECONDS
+
 // BREAKPOINT configs — all line-level (JS requirement)
 const BREAKPOINT_CONFIGS = [
   // Breakpoint on processData — first executable line
@@ -178,6 +185,34 @@ const BREAKPOINT_CONFIGS = [
         CaptureLocals: ['nested'],
         CaptureStackTrace: false,
         CaptureLimits: { MaxCollectionDepth: 1, MaxObjectDepth: 3 },
+      },
+    },
+  },
+  // Breakpoint on expiryCheck with a NUMERIC epoch-SECONDS ExpiresAt (real API
+  // wire format). Validates that the distro converts seconds->ms; otherwise the
+  // breakpoint is expired-on-create and no snapshot is produced.
+  {
+    InstrumentationType: 'BREAKPOINT',
+    SignalType: 'SNAPSHOT',
+    Location: {
+      CodeLocation: {
+        Language: 'JavaScript',
+        CodeUnit: '',
+        ClassName: '',
+        MethodName: 'expiryCheck',
+        FilePath: 'app.js',
+        LineNumber: 103, // const verified = token > 0;
+      },
+    },
+    LocationHash: 'aabb00000000000a',
+    // Numeric epoch SECONDS (not ms, not ISO string) — matches the live API.
+    ExpiresAt: EXPIRES_AT_EPOCH_SECONDS,
+    CreatedAt: Math.floor(Date.now() / 1000),
+    CaptureConfiguration: {
+      CodeCapture: {
+        CaptureLocals: ['token', 'verified'],
+        CaptureStackTrace: true,
+        CaptureLimits: { MaxStringLength: 255 },
       },
     },
   },

--- a/contract-tests/images/applications/di-express/mock_di_api.js
+++ b/contract-tests/images/applications/di-express/mock_di_api.js
@@ -280,11 +280,28 @@ function startMockDIApi(port) {
           const type = (payload.InstrumentationType || 'BREAKPOINT').toUpperCase();
           const configs = type === 'PROBE' ? PROBE_CONFIGS : BREAKPOINT_CONFIGS;
 
+          // Stamp a realistic NUMERIC epoch-SECONDS ExpiresAt/CreatedAt onto every
+          // BREAKPOINT config as the real Application Signals API does (timestamps are
+          // serialized as numeric epoch seconds, e.g. 1.781739623E9 — not ISO strings or
+          // ms). This keeps the whole BREAKPOINT contract suite exercising the expiry
+          // code path: the distro must convert seconds->ms, else the breakpoint is
+          // treated as expired-on-create and no snapshot is emitted. Configs that set
+          // their own ExpiresAt (e.g. expiryCheck) are left untouched. PROBE configs are
+          // permanent (no expiry) and are not stamped.
+          const nowSeconds = Math.floor(Date.now() / 1000);
+          const served = type === 'PROBE'
+            ? configs
+            : configs.map(cfg =>
+                cfg.ExpiresAt !== undefined
+                  ? cfg
+                  : { ...cfg, ExpiresAt: EXPIRES_AT_EPOCH_SECONDS, CreatedAt: nowSeconds }
+              );
+
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({
             Changed: true,
             SyncedAt: Date.now(),
-            LatestConfigurations: configs,
+            LatestConfigurations: served,
           }));
         } else if (req.url === '/report-instrumentation-configuration-status') {
           res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/contract-tests/tests/test/amazon/di/express_test.py
+++ b/contract-tests/tests/test/amazon/di/express_test.py
@@ -30,6 +30,7 @@ _SHARED_FUNCTION_LINE = 67  # const processed = ...
 _LONG_STRING_LINE = 76  # return longString.length;
 _LARGE_COLLECTION_LINE = 84  # return largeList.length;
 _NESTED_COLLECTION_LINE = 92  # return nested.length;
+_EXPIRY_CHECK_LINE = 103  # const verified = token > 0;
 
 
 class DIExpressBreakpointTest(DITestInfrastructure):
@@ -353,3 +354,70 @@ class DIExpressCaptureLimitsTest(DITestInfrastructure):
             elements[0].get("not_captured_reason"),
             f"Nested array beyond MaxCollectionDepth=1 should be cut with reason 'depth', got: {elements[0]}",
         )
+
+
+class DIExpressNumericExpiresAtTest(DITestInfrastructure):
+    """Regression coverage for numeric epoch-SECONDS ExpiresAt parsing.
+
+    The Application Signals API serializes ExpiresAt as a numeric epoch-seconds
+    value over the JSON protocol (e.g. 1.781739623E9), NOT an ISO-8601 string or
+    milliseconds. The expiryCheck breakpoint config (mock_di_api.js) sets a future
+    epoch-SECONDS ExpiresAt. The distro must convert seconds->milliseconds before
+    comparing against Date.now(); otherwise the value is ~1000x too small, the
+    breakpoint is treated as expired the moment it is created, recordHit() returns
+    false, and NO snapshot is ever emitted.
+
+    Every other DI contract config omits ExpiresAt entirely, which is exactly why
+    the numeric-timestamp bug went uncaught at the contract layer. This class
+    exercises the real wire format and asserts the observable behavior: a snapshot
+    is still captured (the breakpoint is NOT expired-on-create). With the bug
+    present, wait_for_snapshots() times out with zero DI snapshots.
+
+    See PR #487 for the primary one-line source fix in
+    src/dynamic-instrumentation/model/instrumentation-configuration.ts.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    def test_numeric_epoch_seconds_expiry_breakpoint_is_not_expired(self) -> None:
+        response = self.send_request("GET", "expiry")
+        self.assertEqual(200, response.status_code)
+
+        # If ExpiresAt (numeric epoch seconds) were not converted to milliseconds,
+        # the breakpoint would be expired-on-create and this would time out.
+        snapshots = self.wait_for_snapshots(min_count=1)
+        expiry_snaps = self.snapshots_for_line(snapshots, _EXPIRY_CHECK_LINE)
+        self.assertGreater(
+            len(expiry_snaps),
+            0,
+            "Expected a snapshot for expiryCheck — a future numeric epoch-seconds "
+            "ExpiresAt must not be treated as already expired.",
+        )
+
+    def test_numeric_expiry_snapshot_has_correct_location(self) -> None:
+        self.send_request("GET", "expiry")
+        snapshots = self.wait_for_snapshots(min_count=1)
+        snap = self.snapshots_for_line(snapshots, _EXPIRY_CHECK_LINE)[0]
+
+        attrs = self.log_attrs(snap)
+        self.assertEqual(_EXPIRY_CHECK_LINE, attrs.get("aws.di.line_number"))
+        self.assertEqual("aabb00000000000a", attrs.get("aws.di.location_hash"))
+
+    def test_numeric_expiry_snapshot_captures_locals(self) -> None:
+        """The /expiry route calls expiryCheck(1); the breakpoint sits on
+        'const verified = token > 0' with CaptureLocals: ['token', 'verified'],
+        so the argument token must be captured with its actual value."""
+        self.send_request("GET", "expiry")
+        snapshots = self.wait_for_snapshots(min_count=1)
+        snap = self.snapshots_for_line(snapshots, _EXPIRY_CHECK_LINE)[0]
+
+        locals_captured = self._line_locals(snap)
+        self.assertIn(
+            "token", locals_captured, f"Expected local 'token' captured, got: {list(locals_captured.keys())}"
+        )
+        self.assertEqual("1", locals_captured["token"].get("value"))


### PR DESCRIPTION
## Summary

Adds **contract-test** coverage for the numeric epoch-seconds `ExpiresAt`
parsing bug. The one-line source fix is the subject of #487 (the primary fix);
this PR adds the end-to-end contract coverage that was missing, so the
regression can't silently come back. **It carries no source change** — it builds
on the fix already merged on `main`.

## The bug (fixed by #487)

`parseTimestamp` in
`aws-distro-opentelemetry-node-autoinstrumentation/src/dynamic-instrumentation/model/instrumentation-configuration.ts`
did not convert numeric epoch-**seconds** timestamps to milliseconds. The
Application Signals API serializes `ExpiresAt`/`CreatedAt` as numeric epoch
seconds over the JSON protocol (e.g. `1.781739623E9`), but the numeric branch
returned the value unchanged. The resulting `expiresAt` was ~1000x too small, so
`InstrumentationState.checkExpiry()` compared `Date.now()` (ms) against a seconds
value and every BREAKPOINT was treated as **expired the moment it was created**.
`recordHit()` returned `false` before the first capture, so **no snapshot was
ever emitted** against the live API.

## Why existing tests missed it

- The unit suite only exercised **ISO-string** `ExpiresAt`, so the numeric
  branch was never hit (#487 added the two numeric unit-regression tests).
- Every DI **contract** config in `mock_di_api.js` **omits `ExpiresAt`
  entirely**, so the contract suite passed even with the bug present — there was
  no contract config exercising the real numeric wire format.

## What this PR adds

- `contract-tests/images/applications/di-express/mock_di_api.js`: a new
  `expiryCheck` BREAKPOINT config carrying a **future numeric epoch-SECONDS**
  `ExpiresAt` (and `CreatedAt`), mirroring the real API wire format.
- `contract-tests/images/applications/di-express/app.js`: an `expiryCheck`
  function and a `/expiry` route to trigger it.
- `contract-tests/tests/test/amazon/di/express_test.py`:
  `DIExpressNumericExpiresAtTest`, which asserts the **observable behavior** — a
  snapshot is still captured (the breakpoint is not expired-on-create), with the
  expected `aws.di.location_hash`, `aws.di.line_number`, and captured locals.

## Validation

Verified end-to-end against the built di-express image:

- **With the fix (current `main`):** the `expiryCheck` breakpoint is set and a
  snapshot is emitted — `event.name=aws.dynamic_instrumentation.snapshot`,
  `aws.di.location_hash=aabb00000000000a`, `aws.di.line_number=103`.
- **With the fix reverted (pre-#487):** V8 still pauses at `expiryCheck`, but the
  snapshot is dropped (expired-on-create) — the location hash never appears and
  no snapshot event is produced.

So the new test passes with the fix and fails (times out with zero snapshots)
with the bug — the intended regression behavior.

> Note: #487 is the primary one-line source fix; this PR adds contract coverage
> only. They are independent and either can be merged on its own.
