### PR TITLE
fix(serviceevents): align unmatched-route labels with Application Signals

### DIFF
--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/express-instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/express-instrumentation.ts
@@ -15,6 +15,7 @@ import { setCurrentOperation, clearCurrentOperation, ServiceEventsMonitorState }
 import { EndpointMetricCollector } from '../collectors/endpoint-collector';
 import { IncidentSnapshotCollector, RequestData } from '../collectors/incident-snapshot-collector';
 import { ServiceEventsConfig, shouldTrackEndpoint } from '../config';
+import { unmatchedRouteLabel } from './unmatched-route';
 
 // Global references to collectors
 let _endpointCollector: EndpointMetricCollector | null = null;
@@ -22,49 +23,22 @@ let _incidentSnapshotCollector: IncidentSnapshotCollector | null = null;
 let _config: ServiceEventsConfig | null = null;
 
 /**
- * Sentinel route for genuine Express requests that matched no route layer (404s,
- * static-file middleware, errors before routing). Express only populates req.route
- * once a route matches, so an unmatched request has only its raw URL — recording that
- * raw path (/users/12345, /assets/<hash>.js) would create unbounded unique endpoint
- * keys and explode metric cardinality. Collapse unmatched Express traffic into one
- * bucket instead (matches the Python SDK's `<unmatched>` sentinel for Django).
- */
-const UNMATCHED_ROUTE = '<unmatched>';
-
-/**
- * True when `req` is a request decorated by Express. Express adds `app` and
- * `originalUrl` to every request it handles (regardless of whether a route matched),
- * whereas the raw Node IncomingMessage that other frameworks (Fastify/Koa/Next.js)
- * surface to the global http.end patch has neither. Used to decide whether an absent
- * `req.route` means "Express matched nothing" vs. "this isn't an Express request".
- */
-function isExpressRequest(req: any): boolean {
-  return req != null && (req.app !== undefined || typeof req.originalUrl === 'string');
-}
-
-/**
  * Get the route pattern from a request.
  *
  * Uses req.route.path (the parameterized Express pattern, e.g. /users/:id), prefixed
- * with req.baseUrl for mounted routers. When there is no matched route, the fallback
- * depends on who owns the request:
- *  - genuine Express request → UNMATCHED_ROUTE sentinel (bounds 404/static cardinality);
- *  - any other request flowing through the global http.end patch (Fastify/Koa/Next.js
- *    raw Node req) → raw URL path. We must NOT apply Express's "unmatched" logic to a
- *    foreign framework's request — its real route is resolved by its own hook, and
- *    collapsing it here would erase the route entirely. (Matches the cross-SDK model:
- *    the route is derived by the component that owns the request; Java's servlet path
- *    likewise falls back to the request URI, not a sentinel.)
+ * with req.baseUrl for mounted routers. When there is no matched route (404s, static-file
+ * middleware, scanner traffic, or a foreign framework's raw Node req reaching the global
+ * http.end patch), collapse the raw URL to its first path segment, e.g. /wp-admin/x.php →
+ * /wp-admin. Recording the full raw path would create unbounded unique endpoint keys and
+ * explode metric cardinality. The first-segment label matches Application Signals'
+ * unmatched-route handling (AwsSpanProcessingUtil.extractAPIPathValue).
  */
 function getRoutePattern(req: any): string {
   if (req.route?.path) {
     const base = req.baseUrl || '';
     return base + req.route.path;
   }
-  if (isExpressRequest(req)) {
-    return UNMATCHED_ROUTE;
-  }
-  return req.path || req.url || '/unknown';
+  return unmatchedRouteLabel(req.path || req.url);
 }
 
 /**

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/fastify-instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/fastify-instrumentation.ts
@@ -16,6 +16,7 @@ import { EndpointMetricCollector } from '../collectors/endpoint-collector';
 import { IncidentSnapshotCollector, RequestData } from '../collectors/incident-snapshot-collector';
 import { ServiceEventsConfig, shouldTrackEndpoint } from '../config';
 import { endInvestigationOnce, extractErrorFromCallPath } from './express-instrumentation';
+import { unmatchedRouteLabel } from './unmatched-route';
 
 // Global references to collectors
 let _endpointCollector: EndpointMetricCollector | null = null;
@@ -34,8 +35,9 @@ function getRoutePattern(request: any): string {
   if (request.routerPath) {
     return request.routerPath;
   }
-  // Fallback to raw URL path
-  return request.url || '/unknown';
+  // No route matched: collapse the raw URL (which may include a query string) to its first
+  // path segment so scanner/bot traffic can't explode metric cardinality. Matches App Signals.
+  return unmatchedRouteLabel(request.url);
 }
 
 /**

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/koa-instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/koa-instrumentation.ts
@@ -16,6 +16,7 @@ import { EndpointMetricCollector } from '../collectors/endpoint-collector';
 import { IncidentSnapshotCollector, RequestData } from '../collectors/incident-snapshot-collector';
 import { ServiceEventsConfig, shouldTrackEndpoint } from '../config';
 import { endInvestigationOnce, extractErrorFromCallPath } from './express-instrumentation';
+import { unmatchedRouteLabel } from './unmatched-route';
 
 // Global references to collectors
 let _endpointCollector: EndpointMetricCollector | null = null;
@@ -26,7 +27,7 @@ let _config: ServiceEventsConfig | null = null;
  * Get the route pattern from a Koa context.
  *
  * Tries ctx._matchedRoute (set by koa-router), then ctx.routePath,
- * then falls back to ctx.path.
+ * then collapses the raw path to its first segment for unmatched requests.
  */
 function getRoutePattern(ctx: any): string {
   // koa-router sets _matchedRoute
@@ -37,8 +38,9 @@ function getRoutePattern(ctx: any): string {
   if (ctx.routePath) {
     return ctx.routePath;
   }
-  // Fallback to raw path
-  return ctx.path || '/unknown';
+  // No route matched: collapse the raw path to its first segment so scanner/bot traffic
+  // can't explode metric cardinality. Matches App Signals.
+  return unmatchedRouteLabel(ctx.path);
 }
 
 /**

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/nextjs-instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/nextjs-instrumentation.ts
@@ -27,6 +27,7 @@ import { EndpointMetricCollector } from '../collectors/endpoint-collector';
 import { IncidentSnapshotCollector, RequestData } from '../collectors/incident-snapshot-collector';
 import { ServiceEventsConfig, shouldTrackEndpoint } from '../config';
 import { endInvestigationOnce, extractErrorFromCallPath } from './express-instrumentation';
+import { unmatchedRouteLabel } from './unmatched-route';
 
 // Global references to collectors
 let _endpointCollector: EndpointMetricCollector | null = null;
@@ -97,9 +98,9 @@ function getRoutePattern(req: any): string {
     // Ignore
   }
 
-  // Fallback: raw URL path with query string stripped
-  const url = req.url || '/';
-  return url.split('?')[0] || '/';
+  // Fallback: no route matched, collapse the raw URL to its first path segment (query
+  // stripped) so scanner/bot traffic can't explode metric cardinality. Matches App Signals.
+  return unmatchedRouteLabel(req.url);
 }
 
 /**

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/unmatched-route.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/instrumentation/unmatched-route.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AwsSpanProcessingUtil } from '../../aws-span-processing-util';
+
+/**
+ * Route label for a request that matched no framework route (unmatched 404s, scanner/bot
+ * traffic to nonexistent URLs like /wp-admin or /.env).
+ *
+ * Recording the raw path for these would make every probed URL its own metric series — a
+ * cardinality explosion. Instead, collapse to the first path segment, e.g.
+ * "/wp-admin/setup.php" -> "/wp-admin". This is exactly what Application Signals does for a
+ * span whose name can't be resolved to a route (AwsSpanProcessingUtil.extractAPIPathValue),
+ * so ServiceEvents and Application Signals produce the same operation label for unmatched
+ * requests, identically across the Express/Fastify/Koa/Next.js instrumentations. The
+ * delegated helper also strips any query/fragment, so a raw URL like "/wp-admin/x?a=1"
+ * still collapses to "/wp-admin".
+ *
+ * Keeping this in one module makes cross-framework behavior structural rather than a promise
+ * enforced by comments — a single edit here changes every framework at once.
+ */
+export function unmatchedRouteLabel(rawPath: string | undefined | null): string {
+  return AwsSpanProcessingUtil.extractAPIPathValue(rawPath);
+}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/instrumentation/express-instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/instrumentation/express-instrumentation.test.ts
@@ -202,12 +202,12 @@ describe('installGlobalHttpPatches', function () {
     });
   });
 
-  describe('unmatched routes collapse to a sentinel (cardinality bound)', function () {
-    it('records "<unmatched>" for an unmatched EXPRESS request (req.route absent)', function () {
+  describe('unmatched routes collapse to the first path segment (cardinality bound)', function () {
+    it('records the first path segment for an unmatched EXPRESS request (req.route absent)', function () {
       // A genuine Express request that matched no route (404, static middleware) has no
       // req.route. Recording its raw path (/users/12345, /assets/<hash>.js) would explode
-      // endpoint cardinality, so an Express request collapses to the sentinel. Express
-      // decorates every request with `app`/`originalUrl`, which is how we know it's Express.
+      // endpoint cardinality, so an unmatched request collapses to its first path segment
+      // (/users/12345 -> /users), matching Application Signals' unmatched-route handling.
       const recordedRoutes: string[] = [];
       const spyCollector = new EndpointMetricCollector(600_000, 'env', 'svc', '0.0.1');
       (spyCollector as any).recordRequest = (route: string) => {
@@ -231,16 +231,13 @@ describe('installGlobalHttpPatches', function () {
         // tolerate stubbed original end()
       }
 
-      expect(recordedRoutes).toEqual(['<unmatched>']);
+      expect(recordedRoutes).toEqual(['/users']);
       installExpressHooks(undefined, undefined, undefined, null);
     });
 
-    it('keeps the raw path for a NON-Express request (foreign framework via global patch)', function () {
-      // The global http.end patch also fires for Fastify/Koa/Next.js, surfacing a raw
-      // Node req with no Express markers and no req.route. We must NOT collapse those to
-      // <unmatched> — their real route is recorded by their own framework hook; the
-      // global patch falls back to the raw path (cross-SDK: route owned by the component
-      // that handles the request, like Java's servlet requestUri fallback).
+    it('collapses scanner traffic with a deep path to its first segment', function () {
+      // Scanner/bot traffic to nonexistent deep URLs (/wp-admin/setup-config.php) must not
+      // each become a distinct endpoint key — they collapse to the shared first segment.
       const recordedRoutes: string[] = [];
       const spyCollector = new EndpointMetricCollector(600_000, 'env', 'svc', '0.0.1');
       (spyCollector as any).recordRequest = (route: string) => {
@@ -249,15 +246,20 @@ describe('installGlobalHttpPatches', function () {
       installExpressHooks(spyCollector, undefined, 'svc', null);
 
       // Raw Node IncomingMessage shape — no `app`, no `originalUrl`, no `route`.
-      const req: any = { url: '/success', method: 'GET', headers: {}, __serviceeventsStartTime: 1 };
-      const res: any = { statusCode: 200, req };
+      const req: any = {
+        url: '/wp-admin/setup-config.php',
+        method: 'GET',
+        headers: {},
+        __serviceeventsStartTime: 1,
+      };
+      const res: any = { statusCode: 404, req };
       try {
         patchedResponseEnd.call(res);
       } catch {
         // tolerate
       }
 
-      expect(recordedRoutes).toEqual(['/success']);
+      expect(recordedRoutes).toEqual(['/wp-admin']);
       installExpressHooks(undefined, undefined, undefined, null);
     });
 


### PR DESCRIPTION
## Description

Service Events recorded unmatched requests (404s, scanner/bot traffic, and foreign-framework raw Node requests reaching the global `http.end` patch) either via a `<unmatched>` sentinel (Express) or the **full raw URL path** — the latter exploding endpoint-metric cardinality. Application Signals instead collapses an unresolved span name to its **first path segment**. This PR aligns Service Events **to** App Signals (one-way; App Signals behavior is untouched).

### Change
Add a shared `unmatchedRouteLabel()` that delegates to `AwsSpanProcessingUtil.extractAPIPathValue`, and use it as the no-route fallback in **Express, Fastify, Koa, and Next.js**. Both Service Events and App Signals now produce the same first-segment label (`/wp-admin/setup.php` → `/wp-admin`), bounding cardinality on scanner traffic while matching App Signals.

Express's `isExpressRequest()` / raw-path branch is removed: framework hooks claim their own requests (`__serviceeventsRequestEnded`) before the global `http.end` patch runs, so the only requests reaching Express's fallback are genuinely unmatched and carry only a raw URL — recording that raw path was the cardinality risk the old code introduced.

## Testing
- `ts-mocha` serviceevents suite: 382 passing
- `prettier --check`, `eslint` (0 errors), `tsc` compile: clean

## Note
App Signals' `extractAPIPathValue` is **not** modified — Service Events only delegates to it. Companion change for the Python SDK: aws-observability/aws-otel-python-instrumentation#784.