### PR TITLE
 Update lambda compatible runtimes to remove deprecated versions

### DIFF
--- a/.github/workflows/region-build-release.yml
+++ b/.github/workflows/region-build-release.yml
@@ -105,7 +105,7 @@ jobs:
             aws lambda publish-layer-version \
               --layer-name ${{ env.LAYER_NAME }} \
               --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=layer.zip \
-              --compatible-runtimes nodejs18.x nodejs20.x nodejs22.x nodejs24.x \
+              --compatible-runtimes nodejs22.x nodejs24.x \
               --compatible-architectures "arm64" "x86_64" \
               --license-info "Apache-2.0" \
               --description "AWS Distro of OpenTelemetry Lambda Layer for NodeJs Runtime" \

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -241,7 +241,7 @@ jobs:
             aws lambda publish-layer-version \
               --layer-name ${{ env.LAYER_NAME }} \
               --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=layer.zip \
-              --compatible-runtimes nodejs18.x nodejs20.x nodejs22.x nodejs24.x \
+              --compatible-runtimes nodejs22.x nodejs24.x \
               --compatible-architectures "arm64" "x86_64" \
               --license-info "Apache-2.0" \
               --description "AWS Distro of OpenTelemetry Lambda Layer for NodeJs Runtime" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- Update Lambda layer compatible runtimes: remove deprecated nodejs18.x and nodejs20.x
+  ([#TBD](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/TBD))
 - feat: add ServiceEvents deep observability instrumentation — endpoint, function-call,
   deployment, and incident-snapshot telemetry with profiling support
   ([#467](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/467))


### PR DESCRIPTION
## Background
Node.js18.x/20.x have been deprecated as of Sep 1, 2025/Apr 30, 2026 and our instrumentation layer should declare the loss of compatibility so our customers are not using a deprecated version.

## Summary
Updated the release build workflows `release-build.yml` and `region-build-release.yml` to remove Node.js18.x/20.x from the list of compatible runtimes for the AWS Lambda layer.

## Changes
Updated the compatible runtimes list to remove Node.js18.x/20.x

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

