### PR TITLE
ci: parallelize PR build and shard contract tests

### DIFF
--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -35,6 +35,10 @@ inputs:
     required: false
     default: ''
     description: "Path to the .trivyignore.yaml file to use for image scan"
+  run_unit_tests:
+    required: false
+    default: 'true'
+    description: "Whether to run unit tests during set_up"
 
 runs:
   using: "composite"
@@ -52,7 +56,7 @@ runs:
         node_version: ${{ inputs.node_version }}
         package_name: ${{ inputs.package_name }}
         os: ${{ inputs.os }}
-        run_unit_tests: true
+        run_unit_tests: ${{ inputs.run_unit_tests }}
 
     - name: Configure AWS Credentials
       if: ${{ inputs.push_image == true || inputs.push_image == 'true' }}

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -1,0 +1,72 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+name: Contract Tests
+
+on:
+  workflow_call:
+    inputs:
+      tarball-artifact-name:
+        required: false
+        type: string
+        default: distro-tarball
+        description: "Name of the uploaded distro tarball artifact to download."
+      ref:
+        required: false
+        type: string
+        default: ''
+        description: "Git ref to check out. Defaults to the triggering SHA."
+
+permissions:
+  contents: read
+
+jobs:
+  select-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Select tests
+        id: filter
+        run: |
+          tests=$(yq -o=json '.' contract-tests/tests.yaml | jq -c '
+            .test_base as $base
+            | [ .tests[]
+                | { name,
+                    pytest_args: ([ .paths[] | $base + "/" + . ] | join(" ")) } ]')
+          echo "tests=$tests" >> "$GITHUB_OUTPUT"
+
+  contract-test:
+    needs: select-tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ${{ fromJSON(needs.select-tests.outputs.tests) }}
+    name: ${{ matrix.test.name }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #v6.0.0
+        with:
+          python-version: '3.10'
+
+      - name: Download distro tarball
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: ${{ inputs.tarball-artifact-name }}
+          path: dist
+
+      - name: Build images and run ${{ matrix.test.name }} contract tests
+        run: |
+          bash scripts/set-up-contract-tests.sh ${{ matrix.test.name }}
+          pip install pytest
+          pytest ${{ matrix.test.pytest_args }} -v

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -68,5 +68,4 @@ jobs:
       - name: Build images and run ${{ matrix.test.name }} contract tests
         run: |
           bash scripts/set-up-contract-tests.sh ${{ matrix.test.name }}
-          pip install pytest
           pytest ${{ matrix.test.pytest_args }} -v

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -143,6 +143,46 @@ jobs:
           path: dist/aws-aws-distro-opentelemetry-node-autoinstrumentation-*.tgz
           retention-days: 1
 
+  build-and-scan-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
+        with:
+          node-version: 24
+      - name: NPM Clean Install
+        run: npm ci
+      - name: Compile all NPM projects
+        run: npm run compile
+      - name: Build Tarball and Image Files
+        uses: ./.github/actions/artifacts_build
+        with:
+          image_uri_with_tag: pr-build/24
+          push_image: false
+          load_image: true
+          node_version: 24
+          package_name: aws-distro-opentelemetry-node-autoinstrumentation
+          os: ubuntu-latest
+          trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
+
+  build-lambda:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
+        with:
+          node-version: 24
+      - name: NPM Clean Install
+        run: npm ci
+      - name: Compile all NPM projects
+        run: npm run compile
+      - name: Build Lambda Layer
+        run: npm run build-lambda
+
   unit-tests:
     runs-on: ubuntu-latest
     needs: build
@@ -181,70 +221,11 @@ jobs:
         with:
           verbose: true
 
-  build-and-scan-image:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
-        with:
-          node-version: 24
-      - name: NPM Clean Install
-        run: npm ci
-      - name: Compile all NPM projects
-        run: npm run compile
-      - name: Build Tarball
-        run: |
-          cd aws-distro-opentelemetry-node-autoinstrumentation
-          npm pack
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
-      - name: Logout of public AWS ECR
-        run: docker logout public.ecr.aws
-      - name: Build image for testing
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
-        with:
-          push: false
-          context: .
-          platforms: linux/amd64
-          tags: pr-build/24
-          load: true
-      - name: Perform image scan
-        uses: ./.github/actions/image_scan
-        with:
-          image-ref: pr-build/24
-          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
-          logout: 'true'
-          trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
-
-  build-lambda:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
-        with:
-          node-version: 24
-      - name: NPM Clean Install
-        run: npm ci
-      - name: Compile all NPM projects
-        run: npm run compile
-      - name: Build Lambda Layer
-        run: npm run build-lambda
-
   contract-test:
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
-        with:
-          node-version: 24
       - name: Download distro tarball
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,28 +27,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      # This action wrapper by raven-actions provides cross-platform support and caching
-      # Catches the same issues as GitHub's web editor: syntax errors, type mismatches,
-      # undefined inputs/secrets, circular dependencies, and more
-      # Note: actionlint cannot validate composite actions - see https://github.com/rhysd/actionlint/issues/350
       - name: Validate GitHub Actions workflows
         if: always()
         uses: raven-actions/actionlint@e01d1ea33dd6a5ed517d95b4c0c357560ac6f518 # v2.1.1
         with:
           files: .github/workflows/*.yml
-          # Temporarily ignore specific shellcheck codes while we systematically fix them
-          # SC2027: The surrounding quotes actually unquote this
-          # SC2086: Double quote to prevent globbing and word splitting
-          # SC2129: Consider using { cmd1; cmd2; } >> file instead of individual redirects
-          # SC2162: read without -r will mangle backslashes
-          # SC2206: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a
           flags: |
             -ignore SC2027
             -ignore SC2086
             -ignore SC2129
             -ignore SC2162
             -ignore SC2206
-          
+
       - name: Check CHANGELOG
         if: always()
         run: |
@@ -57,25 +47,25 @@ jobs:
             echo "Skipping check: PR from aws-application-signals-bot"
             exit 0
           fi
-          
+
           if [[ "${{ env.USER }}" == "dependabot[bot]" ]]; then
             echo "Skipping check: PR from dependabot"
             exit 0
           fi
-          
+
           # Check for skip changelog label
           if echo '${{ env.LABELS }}' | jq -r '.[]' | grep -q "skip changelog"; then
             echo "Skipping check: skip changelog label found"
             exit 0
           fi
-          
+
           # Fetch base branch and check for CHANGELOG modifications
           git fetch origin ${{ github.base_ref }}
           if git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -q "CHANGELOG.md"; then
             echo "CHANGELOG.md entry found - check passed"
             exit 0
           fi
-          
+
           echo "It looks like you didn't add an entry to CHANGELOG.md. If this change affects the SDK behavior, please update CHANGELOG.md and link this PR in your entry. If this PR does not need a CHANGELOG entry, you can add the 'Skip Changelog' label to this PR."
           exit 1
 
@@ -84,7 +74,7 @@ jobs:
         run: |
           # Get changed GitHub workflow/action files
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E "^\.github/(workflows|actions)/.*\.ya?ml$" || true)
-          
+
           if [ -n "$CHANGED_FILES" ]; then
             # Check for any versioned actions, excluding comments and this validation script
             VIOLATIONS=$(grep -Hn "uses:.*@v" $CHANGED_FILES | grep -v "grep.*uses:.*@v" | grep -v "#.*@v" || true)
@@ -94,7 +84,7 @@ jobs:
               exit 1
             fi
           fi
-          
+
           echo "No versioned actions found in changed files"
 
       - name: Check for github.event in run steps
@@ -102,7 +92,7 @@ jobs:
         run: |
           # Get changed GitHub workflow/action files
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E "^\.github/(workflows|actions)/.*\.ya?ml$" || true)
-          
+
           if [ -n "$CHANGED_FILES" ]; then
             VIOLATIONS=""
             for file in $CHANGED_FILES; do
@@ -112,25 +102,18 @@ jobs:
                 VIOLATIONS="$VIOLATIONS$file: Contains github.event.* in run step\n"
               fi
             done
-            
+
             if [ -n "$VIOLATIONS" ]; then
               echo -e "Found github.event.* usage in run steps. This can lead to script injection vulnerabilities:"
               echo -e "$VIOLATIONS"
               exit 1
             fi
           fi
-          
+
           echo "No github.event usage found in run steps"
 
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
-      matrix:
-        node: ["18", "20", "22", "24"]
-        include:
-          - node: 20
-            code-coverage: true
     env:
       NPM_CONFIG_UNSAFE_PERM: true
     steps:
@@ -141,24 +124,48 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24
       - name: NPM Clean Install
-        # https://docs.npmjs.com/cli/v10/commands/npm-ci
         run: npm ci
       - name: Compile all NPM projects
         run: npm run compile
-      - name: Build Tarball and Image Files
-        uses: ./.github/actions/artifacts_build
+      - name: Build Tarball
+        run: |
+          cd aws-distro-opentelemetry-node-autoinstrumentation
+          npm pack
+          cd ..
+          mkdir -p dist
+          mv aws-distro-opentelemetry-node-autoinstrumentation/aws-aws-distro-opentelemetry-node-autoinstrumentation-*.tgz dist/
+      - name: Upload distro tarball
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
-          image_uri_with_tag: pr-build/${{ matrix.node }}
-          push_image: false
-          load_image: true
-          node_version: ${{ matrix.node }}
-          package_name: aws-distro-opentelemetry-node-autoinstrumentation
-          os: ubuntu-latest
-          trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
-      - name: Build Lambda Layer
-        run: npm run build-lambda
+          name: distro-tarball
+          path: dist/aws-aws-distro-opentelemetry-node-autoinstrumentation-*.tgz
+          retention-days: 1
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["18", "20", "22", "24"]
+        include:
+          - node: 20
+            code-coverage: true
+    env:
+      NPM_CONFIG_UNSAFE_PERM: true
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
+        with:
+          node-version: ${{ matrix.node }}
+      - name: NPM Clean Install
+        run: npm ci
+      - name: Compile all NPM projects
+        run: npm run compile
       - name: Run unit tests
         run: |
           if [ "${{ matrix.node }}" == "18" ]; then
@@ -174,13 +181,77 @@ jobs:
         with:
           verbose: true
 
+  build-and-scan-image:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
+        with:
+          node-version: 24
+      - name: NPM Clean Install
+        run: npm ci
+      - name: Compile all NPM projects
+        run: npm run compile
+      - name: Build Tarball
+        run: |
+          cd aws-distro-opentelemetry-node-autoinstrumentation
+          npm pack
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+      - name: Logout of public AWS ECR
+        run: docker logout public.ecr.aws
+      - name: Build image for testing
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+        with:
+          push: false
+          context: .
+          platforms: linux/amd64
+          tags: pr-build/24
+          load: true
+      - name: Perform image scan
+        uses: ./.github/actions/image_scan
+        with:
+          image-ref: pr-build/24
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+          logout: 'true'
+          trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
+
+  build-lambda:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
+        with:
+          node-version: 24
+      - name: NPM Clean Install
+        run: npm ci
+      - name: Compile all NPM projects
+        run: npm run compile
+      - name: Build Lambda Layer
+        run: npm run build-lambda
+
   contract-test:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-      - name: run contract tests
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
+        with:
+          node-version: 24
+      - name: Download distro tarball
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: distro-tarball
+          path: dist
+      - name: Run contract tests
         run: |
-          bash ./scripts/build_and_install_distro.sh
           bash scripts/set-up-contract-tests.sh
           pip install pytest
           pytest contract-tests/tests
@@ -202,7 +273,7 @@ jobs:
 
   all-pr-checks-pass:
     runs-on: ubuntu-latest
-    needs: [static-code-checks, contract-test, lint, build]
+    needs: [static-code-checks, contract-test, lint, build, unit-tests, build-and-scan-image, build-lambda]
     if: always()
     steps:
       - name: Checkout to get workflow file
@@ -216,14 +287,14 @@ jobs:
             echo "Some jobs failed"
             exit 1
           fi
-          
+
           # Extract all job names from workflow (excluding this gate job)
           all_jobs=$(yq eval '.jobs | keys | .[]' .github/workflows/pr-build.yml | grep -v "all-pr-checks-pass" | sort)
-          
+
           # Extract job names from needs array
           needed_jobs='${{ toJSON(needs) }}'
           needs_list=$(echo "$needed_jobs" | jq -r 'keys[]' | sort)
-          
+
           # Check if any jobs are missing from needs
           missing_jobs=$(comm -23 <(echo "$all_jobs") <(echo "$needs_list"))
           if [ -n "$missing_jobs" ]; then
@@ -232,5 +303,5 @@ jobs:
             echo "Please add these jobs to the needs array of all-pr-checks-pass"
             exit 1
           fi
-          
+
           echo "All checks passed and no jobs missing from gate!"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -221,21 +221,9 @@ jobs:
         with:
           verbose: true
 
-  contract-test:
-    runs-on: ubuntu-latest
+  contract-tests:
     needs: build
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-      - name: Download distro tarball
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
-        with:
-          name: distro-tarball
-          path: dist
-      - name: Run contract tests
-        run: |
-          bash scripts/set-up-contract-tests.sh
-          pip install pytest
-          pytest contract-tests/tests
+    uses: ./.github/workflows/contract-tests.yml
 
   lint:
     runs-on: ubuntu-latest
@@ -254,7 +242,7 @@ jobs:
 
   all-pr-checks-pass:
     runs-on: ubuntu-latest
-    needs: [static-code-checks, contract-test, lint, build, unit-tests, build-and-scan-image, build-lambda]
+    needs: [static-code-checks, contract-tests, lint, build, unit-tests, build-and-scan-image, build-lambda]
     if: always()
     steps:
       - name: Checkout to get workflow file

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -148,14 +148,6 @@ jobs:
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-      - name: Setup Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
-        with:
-          node-version: 24
-      - name: NPM Clean Install
-        run: npm ci
-      - name: Compile all NPM projects
-        run: npm run compile
       - name: Build Tarball and Image Files
         uses: ./.github/actions/artifacts_build
         with:
@@ -166,6 +158,7 @@ jobs:
           package_name: aws-distro-opentelemetry-node-autoinstrumentation
           os: ubuntu-latest
           trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
+          run_unit_tests: false
 
   build-lambda:
     runs-on: ubuntu-latest
@@ -185,7 +178,6 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    needs: build
     strategy:
       fail-fast: false
       matrix:

--- a/contract-tests/tests.yaml
+++ b/contract-tests/tests.yaml
@@ -1,0 +1,33 @@
+#   name  - the application image to build AND the CI job label. Resolves to
+#            contract-tests/images/applications/<name>/Dockerfile.
+#   paths - pytest paths to run, relative to test_base.
+test_base: contract-tests/tests/test/amazon
+tests:
+  - name: http
+    paths:
+      - http
+      - misc/configuration_test.py
+      - misc/service_name_in_env_var_test.py
+      - misc/service_name_in_resource_attributes_test.py
+      - misc/unknown_service_name_test.py
+  - name: aws-sdk
+    paths:
+      - aws-sdk
+  - name: mongodb
+    paths:
+      - mongodb
+  - name: mongoose
+    paths:
+      - mongoose
+  - name: mysql2
+    paths:
+      - mysql2
+  - name: di-express
+    paths:
+      - di
+  - name: serviceevents-express
+    paths:
+      - serviceevents/express_test.py
+  - name: serviceevents-fastify
+    paths:
+      - serviceevents/fastify_test.py

--- a/scripts/set-up-contract-tests.sh
+++ b/scripts/set-up-contract-tests.sh
@@ -5,6 +5,10 @@
 # Fail fast
 set -e
 
+# Optional: pass an app name to build only that image (for sharded CI).
+# When omitted, all images are built (original behavior).
+TARGET_APP="${1:-}"
+
 # Check script is running in contract-tests
 current_path=`pwd`
 current_dir="${current_path##*/}"
@@ -47,15 +51,30 @@ fi
 
 # Create application images
 cd ..
-for dir in contract-tests/images/applications/*
-do
-  application="${dir##*/}"
-  docker build . --progress=plain --no-cache -t aws-application-signals-tests-${application}-app -f ${dir}/Dockerfile --build-arg="DISTRO=${DISTRO}"
-  if [ $? = 1 ]; then
-    echo "Docker build for ${application} application failed"
+if [ -n "$TARGET_APP" ]; then
+  # Sharded mode: build only the requested app image
+  dir="contract-tests/images/applications/${TARGET_APP}"
+  if [ ! -d "$dir" ]; then
+    echo "Unknown application: ${TARGET_APP}"
     exit 1
   fi
-done
+  docker build . --progress=plain --no-cache -t aws-application-signals-tests-${TARGET_APP}-app -f ${dir}/Dockerfile --build-arg="DISTRO=${DISTRO}"
+  if [ $? = 1 ]; then
+    echo "Docker build for ${TARGET_APP} application failed"
+    exit 1
+  fi
+else
+  # Build all application images
+  for dir in contract-tests/images/applications/*
+  do
+    application="${dir##*/}"
+    docker build . --progress=plain --no-cache -t aws-application-signals-tests-${application}-app -f ${dir}/Dockerfile --build-arg="DISTRO=${DISTRO}"
+    if [ $? = 1 ]; then
+      echo "Docker build for ${application} application failed"
+      exit 1
+    fi
+  done
+fi
 
 # Build and install mock-collector
 cd contract-tests/images/mock-collector


### PR DESCRIPTION
## Summary
Ports the Python repo's CI parallelization pattern ([PR #788](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/788)) to JS:

- **Build once, reuse everywhere**: compile + pack the distro tarball in a single `build` job, upload as artifact. Unit tests and contract tests download it instead of rebuilding from source.
- **Fan out unit tests**: matrix across Node 18/20/22/24 runs in parallel after build (previously each version redundantly compiled + built Docker + ran tests).
- **Shard contract tests**: new reusable `contract-tests.yml` workflow reads `contract-tests/tests.yaml` and creates one job per test suite (8 parallel jobs). Each shard builds only its Docker image + mock-collector instead of all 8 serially (~30 min → ~5 min critical path).
- **Independent validation jobs**: Docker image build/scan and lambda layer build run with no dependency on `build`, so they don't block the test critical path.

## Test plan
- [ ] PR build completes successfully with all jobs green
- [ ] Unit tests pass across all Node versions (18, 20, 22, 24)
- [ ] Each sharded contract test suite passes independently
- [ ] Image scan and lambda build pass independently
- [ ] Overall PR build wall-clock time is reduced