### PR TITLE
feat(serviceevents): accept bare package tokens in PACKAGES_INCLUDE/EXCLUDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(serviceevents): accept bare package tokens (e.g. `myapp`, `src/myapp`) in
+  `OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE`/`_EXCLUDE`, not just `**/…/**` globs
+  ([#507](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/507))
 - feat: support lite mode on ESM handlers and Node.js 24
   ([#502](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/502))
 - refactor(serviceevents): make the endpoint span processor framework-agnostic

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/config.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/config.ts
@@ -231,35 +231,62 @@ function getList(envVar: string, defaultValue: string[]): string[] {
 }
 
 /**
- * Parse a package-pattern list env var, rejecting bare match-everything sentinels.
+ * Backslash-escape glob metacharacters so a token matches literally.
+ * A real dir like Next.js `[id]` must not be read as a glob character class.
+ * `/` and `.` are left alone: `/` is a path separator, `.` is already literal.
+ */
+function escapeGlobToken(token: string): string {
+  return token.replace(/[?[\]{}()!+@|\\]/g, '\\$&');
+}
+
+/**
+ * Turn a plain package token into globs that match its files.
+ * `myapp` -> instruments the whole `myapp/` subtree, like Java `com.myapp` /
+ * Python `myapp`. A token with a `*` is already a glob and is left as-is.
  *
- * Bare `*` and `**` are rejected as too broad: under minimatch's `matchBase: true`
- * they match every path, defeating the point of an explicit allowlist. Strip these
- * entries and warn — `diag.warn` rather than `diag.info` because we're silently
- * altering user-provided configuration, and info-level diag is often suppressed in
- * production OTel setups.
+ * We emit three patterns because the matcher runs against full file paths:
+ *   `**\/myapp/**`  -> files inside the dir (`myapp/index.js`)
+ *   `**\/myapp.*`   -> a file named after the token (`myapp.js`)
+ *   `**\/myapp`     -> when the token already includes the extension (`server.js`)
+ */
+function expandBarePattern(entry: string): string[] {
+  if (entry.includes('*')) {
+    return [entry]; // already a glob — use it as written
+  }
+  const token = entry.replace(/^\/+|\/+$/g, ''); // drop leading/trailing slashes
+  if (token.length === 0) {
+    return [];
+  }
+  const esc = escapeGlobToken(token);
+  return [`**/${esc}/**`, `**/${esc}.*`, `**/${esc}`];
+}
+
+/**
+ * Read a package-list env var and turn each entry into match globs. Used for both
+ * PACKAGES_INCLUDE and PACKAGES_EXCLUDE.
  *
- * An empty list instruments nothing — there is no implicit default scope (see the
- * scope rule in ast-transformation.ts).
+ * A bare `*` or `**` is dropped (it would match everything, defeating the allowlist)
+ * and warned about. Everything else is expanded by expandBarePattern. An empty list
+ * instruments nothing — there is no default scope (see ast-transformation.ts).
  */
 function getPatternList(envVar: string, defaultValue: string[]): string[] {
   const raw = getList(envVar, defaultValue);
   const rejected: string[] = [];
-  const normalized: string[] = [];
+  const out: string[] = [];
   for (const item of raw) {
     if (item === '*' || item === '**') {
       rejected.push(item);
       continue;
     }
-    normalized.push(item);
+    out.push(...expandBarePattern(item));
   }
   if (rejected.length > 0) {
     diag.warn(
       `ServiceEvents: ignoring match-everything entries ${JSON.stringify(rejected)} in ${envVar}; ` +
-        'use specific package prefixes (e.g. src/myapp/**). An empty list instruments nothing.'
+        'use a package token (e.g. myapp) or a glob (e.g. **/myapp/**). An empty list instruments nothing.'
     );
   }
-  return normalized;
+  return out;
 }
 
 /**

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/ast-transformation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/ast-transformation.test.ts
@@ -20,6 +20,7 @@
 
 import expect from 'expect';
 import { shouldTransformFile, SDK_SELF_EXCLUDE } from '../../src/serviceevents/ast-transformation';
+import { createServiceEventsConfigFromEnv } from '../../src/serviceevents/config';
 
 describe('shouldTransformFile (scope precedence)', function () {
   // --- Baseline rules 0–4 ---
@@ -185,6 +186,113 @@ describe('shouldTransformFile (scope precedence)', function () {
       expect(SDK_SELF_EXCLUDE).toContain('/node_modules/acorn/');
       expect(SDK_SELF_EXCLUDE).toContain('/node_modules/pirates/');
       expect(SDK_SELF_EXCLUDE).toContain('/node_modules/minimatch/');
+    });
+  });
+
+  // --- Bare-token ergonomic: parse tokens through the real env parser, then match ---
+  // This is the end-to-end proof that a bare `myapp` (not just a `**/myapp/**` glob)
+  // actually instruments the right files. Tokens go through createServiceEventsConfigFromEnv
+  // so the parse-time expansion (config.ts) and the matcher (this file) are exercised together.
+  describe('bare package tokens (parsed via env) instrument the intended files', function () {
+    let savedEnv: Record<string, string | undefined>;
+
+    beforeEach(function () {
+      savedEnv = { ...process.env };
+    });
+
+    afterEach(function () {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in savedEnv)) {
+          delete process.env[key];
+        }
+      }
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    });
+
+    // Parse PACKAGES_INCLUDE/EXCLUDE from env exactly as production does.
+    function parseScope(include?: string, exclude?: string): { include: string[]; exclude: string[] } {
+      delete process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE;
+      delete process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_EXCLUDE;
+      if (include !== undefined) {
+        process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = include;
+      }
+      if (exclude !== undefined) {
+        process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_EXCLUDE = exclude;
+      }
+      const config = createServiceEventsConfigFromEnv();
+      return { include: config.packagesInclude, exclude: config.packagesExclude };
+    }
+
+    it('instruments the token dir subtree (bare myapp)', function () {
+      const { include } = parseScope('myapp');
+      expect(shouldTransformFile('/app/src/myapp/service.js', [], include)).toBe(true);
+      expect(shouldTransformFile('/app/src/myapp/sub/deep.js', [], include)).toBe(true);
+    });
+
+    it('instruments the single-file module (myapp.js) via the .* form', function () {
+      const { include } = parseScope('myapp');
+      // For an extensionless token, the `.*` form is what finds `myapp.js`.
+      expect(include).toContain('**/myapp.*');
+      expect(shouldTransformFile('/app/src/myapp.js', [], include)).toBe(true);
+    });
+
+    it('instruments a filename-with-extension token (server.js) via the bare-filename form', function () {
+      // Regression: a token that already carries an extension (`server.js`) is a real
+      // filename. The `.*` form looks for `server.js.<ext>` and misses it; the bare
+      // `**/<token>` form matches the file itself. Before that form existed, this
+      // silently instrumented nothing (and on the exclude side silently no-op'd).
+      const { include } = parseScope('server.js');
+      expect(include).toContain('**/server.js');
+      expect(shouldTransformFile('/app/src/server.js', [], include)).toBe(true);
+    });
+
+    it('a filename-with-extension EXCLUDE token actually subtracts the file', function () {
+      // The exclude side is the dangerous one: an explicit `secrets.js` exclusion must
+      // not be a silent no-op that leaves the file instrumented.
+      const { include, exclude } = parseScope('src', 'secrets.js');
+      expect(shouldTransformFile('/app/src/secrets.js', exclude, include)).toBe(false);
+      // A sibling file under the same include subtree still instruments.
+      expect(shouldTransformFile('/app/src/service.js', exclude, include)).toBe(true);
+    });
+
+    it('does NOT match a hyphen/underscore sibling (basename boundary)', function () {
+      const { include } = parseScope('myapp');
+      expect(shouldTransformFile('/app/src/myapp-utils/foo.js', [], include)).toBe(false);
+      expect(shouldTransformFile('/app/src/myapp-utils.js', [], include)).toBe(false);
+    });
+
+    it('DOES match dotted-sibling files (chosen .* behavior: user.model.js, user.test.js)', function () {
+      const { include } = parseScope('user');
+      expect(shouldTransformFile('/app/src/user.model.js', [], include)).toBe(true);
+      expect(shouldTransformFile('/app/src/user.test.js', [], include)).toBe(true);
+      // No dot boundary → not a sibling, must not match.
+      expect(shouldTransformFile('/app/src/users.js', [], include)).toBe(false);
+    });
+
+    it('instruments a real glob-metacharacter dir literally (Next.js [id] route)', function () {
+      const { include } = parseScope('[id]');
+      // The escaped token matches the literal `[id]/` dir …
+      expect(shouldTransformFile('/app/pages/[id]/page.js', [], include)).toBe(true);
+      // … and NOT the char-class interpretation that would match `/i/`.
+      expect(shouldTransformFile('/app/pages/i/page.js', [], include)).toBe(false);
+    });
+
+    it('drops files outside the token subtree', function () {
+      const { include } = parseScope('myapp');
+      expect(shouldTransformFile('/app/other/bar.js', [], include)).toBe(false);
+    });
+
+    it('bare-token exclude subtracts its subtree from a bare-token include', function () {
+      const { include, exclude } = parseScope('myapp', 'models');
+      expect(shouldTransformFile('/app/src/myapp/models/user.js', exclude, include)).toBe(false);
+      // A non-excluded file under the include subtree still instruments.
+      expect(shouldTransformFile('/app/src/myapp/service.js', exclude, include)).toBe(true);
     });
   });
 });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/config.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/config.test.ts
@@ -339,11 +339,92 @@ describe('ServiceEventsConfig', function () {
     it('should parse OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE as comma-separated list', function () {
       clearServiceEventsEnvVars();
 
-      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = 'my-lib,another-lib';
+      // Use explicit globs here so this test stays focused on comma-splitting; the
+      // bare-token expansion behavior is covered by the dedicated tests below.
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = '**/my-lib/**,**/another-lib/**';
 
       const config = createServiceEventsConfigFromEnv();
 
-      expect(config.packagesInclude).toEqual(['my-lib', 'another-lib']);
+      expect(config.packagesInclude).toEqual(['**/my-lib/**', '**/another-lib/**']);
+    });
+  });
+
+  describe('createServiceEventsConfigFromEnv() expands glob-free package tokens', function () {
+    it('expands a bare token to its subtree + file globs (PACKAGES_INCLUDE)', function () {
+      clearServiceEventsEnvVars();
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = 'myapp';
+      const config = createServiceEventsConfigFromEnv();
+      expect(config.packagesInclude).toEqual(['**/myapp/**', '**/myapp.*', '**/myapp']);
+    });
+
+    it('expands a slashed non-glob token (src/myapp)', function () {
+      clearServiceEventsEnvVars();
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = 'src/myapp';
+      const config = createServiceEventsConfigFromEnv();
+      expect(config.packagesInclude).toEqual(['**/src/myapp/**', '**/src/myapp.*', '**/src/myapp']);
+    });
+
+    it('trims leading/trailing slashes before expanding', function () {
+      clearServiceEventsEnvVars();
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = '/myapp/';
+      const config = createServiceEventsConfigFromEnv();
+      expect(config.packagesInclude).toEqual(['**/myapp/**', '**/myapp.*', '**/myapp']);
+    });
+
+    it('expands a filename-with-extension token so the bare-filename form matches it', function () {
+      clearServiceEventsEnvVars();
+      // `server.js` names a file directly; the `**/<token>` form matches it literally
+      // (the `.*` form alone would only find `server.js.<ext>`, e.g. a sourcemap).
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = 'server.js';
+      const config = createServiceEventsConfigFromEnv();
+      expect(config.packagesInclude).toEqual(['**/server.js/**', '**/server.js.*', '**/server.js']);
+    });
+
+    it('escapes the extglob @ in a scoped-package token but keeps the internal slash', function () {
+      clearServiceEventsEnvVars();
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = '@scope/pkg';
+      const config = createServiceEventsConfigFromEnv();
+      expect(config.packagesInclude).toEqual(['**/\\@scope/pkg/**', '**/\\@scope/pkg.*', '**/\\@scope/pkg']);
+    });
+
+    it('passes explicit globs through unchanged', function () {
+      clearServiceEventsEnvVars();
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = '**/myapp/**,src/lib/*';
+      const config = createServiceEventsConfigFromEnv();
+      expect(config.packagesInclude).toEqual(['**/myapp/**', 'src/lib/*']);
+    });
+
+    it('handles a mixed list of bare tokens and globs', function () {
+      clearServiceEventsEnvVars();
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = 'myapp,**/vendor/**';
+      const config = createServiceEventsConfigFromEnv();
+      expect(config.packagesInclude).toEqual(['**/myapp/**', '**/myapp.*', '**/myapp', '**/vendor/**']);
+    });
+
+    it('applies the same expansion to PACKAGES_EXCLUDE', function () {
+      clearServiceEventsEnvVars();
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_EXCLUDE = 'models';
+      const config = createServiceEventsConfigFromEnv();
+      expect(config.packagesExclude).toEqual(['**/models/**', '**/models.*', '**/models']);
+    });
+
+    it('escapes glob metacharacters so Next.js dynamic-route dirs match literally', function () {
+      clearServiceEventsEnvVars();
+      // A char-class `[id]`, a route group `(group)`, and a `?` are real directory
+      // names on disk — they must be escaped, not glob-interpreted.
+      process.env.OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE = '[id],(group),my?lib';
+      const config = createServiceEventsConfigFromEnv();
+      expect(config.packagesInclude).toEqual([
+        '**/\\[id\\]/**',
+        '**/\\[id\\].*',
+        '**/\\[id\\]',
+        '**/\\(group\\)/**',
+        '**/\\(group\\).*',
+        '**/\\(group\\)',
+        '**/my\\?lib/**',
+        '**/my\\?lib.*',
+        '**/my\\?lib',
+      ]);
     });
   });
 


### PR DESCRIPTION
## Description

`OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE` / `_EXCLUDE` now accept a plain
package token (`myapp`, `src/myapp`, `@scope/pkg`) that instruments that code
subtree — the same "no wildcard needed" ergonomic the Java (`com.myapp`) and
Python (`myapp`) distros already offer, and the one the public CloudWatch docs
already describe for Node.js.

Before this change, only `**/…/**` globs worked: the function-instrumentation
matcher runs minimatch against fully-resolved absolute file paths under
`matchBase`, where a slashed pattern is anchored to the whole path. A bare
`myapp` (or the documented `src/myapp`) matched **nothing** — a silent no-op.

## What changed

`getPatternList` (the single parse point for both include and exclude) now
expands each glob-free entry via a new `expandBarePattern`:

- `**/<token>/**` — files under the token's directory (`myapp/index.js`)
- `**/<token>.*`  — an extensionless token as a file (`myapp` → `myapp.js`)
- `**/<token>`    — a token that already carries an extension (`server.js`)

Entries containing `*` are treated as explicit globs and pass through
untouched, so every currently-working config is unchanged. Glob metacharacters
in a token (`[id]`, `(group)`, `?`, `@`, …) are escaped so real Next.js
dynamic-route dirs and scoped packages match literally.

The leading `**/` is required because the app root varies by deployment
(`/app`, `/var/task`, `/usr/src/app`, …); it also makes a copy-pasted
stack-frame path work portably across environments.

## Behavior notes

- **Strictly additive on the glob side**; on the plain-token side it fixes
  configs that were previously silent no-ops — including `PACKAGES_EXCLUDE`,
  where an explicit `secrets.js` exclusion previously failed to subtract the
  file.
- Matching is unanchored and the `.*` form also matches dotted-sibling files
  (`user.model.js`, `user.test.js`) — intended for Node role-file conventions.
  These are JS-specific broadenings vs. the dotted-name Java/Python matchers,
  not a mechanism port.
- The warn message for rejected bare `*`/`**` entries now recommends a package
  token instead of the previously-suggested (non-working) `src/myapp/**`.

## Testing

- Added unit tests for the expansion: bare, slashed, trimmed,
  filename-with-extension, scoped `@scope/pkg`, glob passthrough, exclude, and
  metacharacter escaping.
- Added end-to-end matcher tests that parse tokens through the real env parser
  and assert `shouldTransformFile` results, including the filename-with-extension
  include/exclude regression.
- `npm run compile`, `npm run lint`, and the full serviceevents unit suite
  (482 passing) — all green.
- serviceevents contract tests (express + fastify) run locally: **39 passed,
  2 skipped**.
