### PR TITLE
Key incident-snapshot dedup hash on operation + throw-site origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   ([#507](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/507))
 - feat: support lite mode on ESM handlers and Node.js 24
   ([#502](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/502))
+- fix(serviceevents): key the incident-snapshot dedup hash on operation + bounded throw-site origin (`basename.function`)
+  ([#509](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/509))
 - refactor(serviceevents): make the endpoint span processor framework-agnostic
 - fix(serviceevents): gate incident trace correlation on the SAMPLED flag and harden incident dedup/rate-limiting
 - feat: feat: add OTel lite SDK for Lambda cold start optimization

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/collectors/incident-snapshot-collector.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/collectors/incident-snapshot-collector.ts
@@ -158,13 +158,16 @@ export class IncidentSnapshotCollector extends BaseCollector {
     }
 
     // Generate error hash for deduplication. The processor passes exception=null (like Java) and
-    // defers exception detail to the collector, so recover the error identity (type + message) from
-    // the investigation data — already seeded from the span's exception event for uninstrumented
-    // 5xx — BEFORE hashing. Without this the hash would collapse to route-only and two distinct
-    // errors on the same route would deduplicate together. Latency incidents have no exception →
-    // route-only hash, matching the pre-refactor behavior.
-    const { type: excType, message: excMessage } = this.recoverErrorIdentity(exception);
-    const errorHash = this.errorHash(route, excType, excMessage);
+    // defers exception detail to the collector, so recover the error identity (type + file-qualified
+    // throw-site origin) from the investigation data — already seeded from the span's exception event
+    // for uninstrumented 5xx — BEFORE hashing. Without this the hash would collapse to operation-only
+    // and two distinct errors on the same operation would deduplicate together. The origin (not the
+    // unbounded message) keeps the key bounded. The key uses the full operation (`<method> <route>`)
+    // so different methods on one route are distinct incidents, matching Java. Latency incidents have
+    // no exception → operation-only hash.
+    const operation = `${method} ${route}`;
+    const { type: excType, origin } = this.recoverErrorIdentity(exception);
+    const errorHash = this.errorHash(operation, excType, origin);
 
     // Check batch-level deduplication FIRST (one per error type per collection interval)
     if (this._currentBatchHashes.has(errorHash)) {
@@ -367,47 +370,126 @@ export class IncidentSnapshotCollector extends BaseCollector {
   // --- Deduplication ---
 
   /**
-   * Recover the {type, message} that keys the dedup hash.
+   * Recover the {type, origin} that keys the dedup hash.
    *
    * The endpoint span processor passes `exception=null` (like Java) and defers exception detail to
    * the collector, so the dedup key must be recovered from the same investigation data the snapshot
-   * body uses. Without this the hash would collapse to route-only and two distinct errors on the
-   * same route would deduplicate together (defeating per-error incident coverage).
+   * body uses. Without this the hash would collapse to operation-only and two distinct errors on the
+   * same operation would deduplicate together (defeating per-error incident coverage).
    *
-   * - When an explicit `exception` object is supplied (manual callers), use it directly.
+   * The second field is the *file-qualified throw-site origin* (`file.function`), not the exception
+   * message. The message is unbounded — it routinely embeds request-specific data (IDs, timestamps,
+   * values) — so keying on it lets a single recurring error spawn a distinct hash per occurrence,
+   * defeating dedup and churning the per-window hash map against its size cap. The origin is bounded
+   * and stable across deploys. It is file-qualified so two same-named functions in different modules
+   * don't collide into one incident, mirroring the composite name the AST monitor assigns
+   * instrumented frames (see `calculateFunctionName`) and Java's `class.method`.
+   *
+   * This value is used ONLY for the dedup hash. Customer-consumed telemetry (the endpoint error
+   * breakdown key and the snapshot body `function_name`) is left untouched — those still carry the
+   * bare/monitor-recorded name, so this change does not alter emitted data.
+   *
+   * - When an explicit `exception` object is supplied (manual callers), take the type from it and
+   *   the origin from the first frame of its stack (the throw site).
    * - Otherwise PEEK the per-request investigation data — the AST monitor's captured exception, or
-   *   the span's exception event seeded into it by the processor for uninstrumented 5xx.
-   * - A latency incident (no exception anywhere) returns {type: null} → route-only hash, matching
+   *   the span's exception event seeded into it by the processor for uninstrumented 5xx — and
+   *   qualify the origin from the captured `traceback` string.
+   * - A latency incident (no exception anywhere) returns {type: null} → operation-only hash, matching
    *   the pre-refactor behavior for slow requests.
    *
    * Best-effort and guarded: hashing must never crash the host, so any failure degrades to
-   * {type: null} (route-only), the safe default.
+   * {type: null} (operation-only), the safe default.
    */
-  private recoverErrorIdentity(exception: Error | null): { type: string | null; message: string } {
+  private recoverErrorIdentity(exception: Error | null): { type: string | null; origin: string } {
     try {
       if (exception !== null) {
-        return { type: exception.constructor?.name ?? 'Error', message: exception.message ?? String(exception) };
+        return {
+          type: exception.constructor?.name ?? 'Error',
+          origin: this.originFromStack(exception.stack, exception.message),
+        };
       }
       const invData = this._monitorState.peekInvestigationData();
       const excData = invData?.exception;
       if (excData && excData.name) {
-        return { type: excData.name, message: excData.message ?? '' };
+        return { type: excData.name, origin: this.originFromStack(excData.traceback, excData.message) };
       }
     } catch (err) {
       diag.debug(`Failed to recover error identity for dedup hash: ${err}`);
     }
-    return { type: null, message: '' };
+    return { type: null, origin: '' };
   }
 
   /**
-   * Hash the dedup key from route + recovered exception type/message.
+   * Build a file-qualified origin (`<basename>.<function>`) from the top frame of a V8 stack trace.
    *
-   * Keyed `route:<route>` for latency (no exception) or `route:<route>|exc:<type>:<message>` for
-   * errors, matching the documented per-SDK key (see SERVICE_EVENTS_INCIDENT_RATE_LIMITING.md) and
-   * the Python distro's `_error_hash`.
+   * Parses the SINGLE top `at` frame so the function name and file always come from the same frame —
+   * V8 frames read `    at functionName (/path/to/file.js:line:col)` or, for anonymous/top-level
+   * frames, the bare `    at /path/to/file.js:line:col`. The `async ` prefix and `[as alias]` suffix
+   * V8 attaches to some frames are stripped so they don't leak into the key, and the `:line:col`
+   * suffix is dropped (deploy-unstable). The basename (extension stripped) matches the AST monitor's
+   * `calculateFunctionName` shape. Used ONLY for the dedup hash; returns '' when the stack is
+   * absent/unparseable (→ operation-only key, the safe default). The line-anchored match tolerates
+   * Windows drive-letter paths (`C:\...`), which a colon-delimited scan would mis-split.
+   *
+   * `message` is the exception message: V8 renders the stack as `<Name>: <message>` followed by the
+   * frames, so the leading `1 + newlines(message)` lines are the header. Dropping them first means a
+   * MULTI-LINE message that itself embeds indented `at …` text cannot be mis-parsed as the top frame
+   * (which would inject a request-specific origin and reintroduce unbounded-key proliferation).
    */
-  private errorHash(route: string, excType: string | null, excMessage: string): string {
-    const hashInput = excType === null ? `route:${route}` : `route:${route}|exc:${excType}:${excMessage}`;
+  private originFromStack(stack: string | undefined, message: string | undefined): string {
+    if (!stack) {
+      return '';
+    }
+    // Drop the header lines (the `<Name>: <message>` block) so message text can't be read as a frame.
+    // Slice unconditionally: for a header-only stack (no real frames) this leaves nothing to parse
+    // and the regex below returns '' — NOT falling through to parse the message as a frame.
+    const lines = stack.split('\n');
+    const headerLines = 1 + (message ? message.match(/\n/g)?.length ?? 0 : 0);
+    const body = lines.slice(headerLines).join('\n');
+    // First "\tat …" frame line — the throw site (most-recent-call-first).
+    const frameLine = body.match(/^[ \t]+at[ \t]+(.+)$/m);
+    if (!frameLine) {
+      return '';
+    }
+    const frame = frameLine[1].trim();
+    // "functionName (location)" vs a bare "location" (anonymous/top-level) frame.
+    const parenMatch = frame.match(/^(.*?)\s+\((.*)\)$/);
+    let fn = parenMatch ? parenMatch[1] : '';
+    const location = parenMatch ? parenMatch[2] : frame;
+    // V8 decorates some frames with an `async ` prefix or an `[as alias]` suffix — neither is part
+    // of the stable identity, so strip both. Treat the explicit `<anonymous>` marker as no name.
+    fn = fn
+      .replace(/^async\s+/, '')
+      .replace(/\s+\[as .+\]$/, '')
+      .trim();
+    if (fn === '<anonymous>') {
+      fn = '';
+    }
+    // Strip the trailing `:line:col` (deploy-unstable) from the location to get the file path.
+    const locMatch = location.match(/^(.*):\d+:\d+$/);
+    const filePath = locMatch ? locMatch[1] : location;
+    const base = filePath.replace(/\\/g, '/').split('/').pop() ?? '';
+    const basename = base.replace(/\.(js|mjs|cjs|ts|tsx|mts|cts)$/i, '');
+    if (!basename) {
+      return fn; // no resolvable file → fall back to the bare function name (may be '')
+    }
+    return fn ? `${basename}.${fn}` : basename;
+  }
+
+  /**
+   * Hash the dedup key from operation + recovered exception type/origin.
+   *
+   * Keyed `op:<operation>` for latency (no exception) or `op:<operation>|exc:<type>:<origin>` for
+   * errors, following the same `op:`/`|exc:` scheme as the Python and Java distros. The operation is
+   * `<method> <route>`, so different HTTP methods on one route are distinct incidents. The
+   * file-qualified origin (not the message) keeps the key bounded — see `recoverErrorIdentity`.
+   *
+   * Hashes are compared only within a distro, never across them, so the strings need not be
+   * byte-identical between distros — and they are not: when the origin is unresolvable this distro
+   * emits a trailing `:` (empty origin), whereas Java omits the `:origin` segment entirely.
+   */
+  private errorHash(operation: string, excType: string | null, origin: string): string {
+    const hashInput = excType === null ? `op:${operation}` : `op:${operation}|exc:${excType}:${origin}`;
     return crypto.createHash('md5').update(hashInput, 'utf-8').digest('hex');
   }
 
@@ -696,11 +778,12 @@ export class IncidentSnapshotCollector extends BaseCollector {
       );
       // Preserve the original identity so the already-emitted endpoint exemplar pointer stays valid.
       replacement.snapshot_id = pending.snapshot_id;
-      // Preserve the original affected_endpoint too. The dedup hash keys on route (not method), so a
-      // GET and a POST to the same route with the same error share a hash and can upgrade each other.
-      // The endpoint exemplar is filed under the FIRST occurrence's operation key; rebuilding
-      // affected_endpoint from THIS occurrence's method would make the swapped snapshot's operation
-      // disagree with the endpoint summary that references its snapshot_id. Keep the first one.
+      // Preserve the original affected_endpoint too. The dedup hash keys on operation
+      // (`<method> <route>`), so only occurrences sharing an operation (e.g. two GET /api/x with the
+      // same error) share a hash and can upgrade each other. The endpoint exemplar is filed under the
+      // FIRST occurrence's operation key; rebuilding affected_endpoint from THIS occurrence would make
+      // the swapped snapshot's operation disagree with the endpoint summary that references its
+      // snapshot_id. Keep the first one.
       replacement.affected_endpoint = pending.affected_endpoint;
 
       const idx = this._pendingSnapshots.indexOf(pending);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/collectors/incident-snapshot-collector.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/serviceevents/collectors/incident-snapshot-collector.ts
@@ -469,7 +469,7 @@ export class IncidentSnapshotCollector extends BaseCollector {
     const locMatch = location.match(/^(.*):\d+:\d+$/);
     const filePath = locMatch ? locMatch[1] : location;
     const base = filePath.replace(/\\/g, '/').split('/').pop() ?? '';
-    const basename = base.replace(/\.(js|mjs|cjs|ts|tsx|mts|cts)$/i, '');
+    const basename = base.replace(/\.(js|jsx|mjs|cjs|ts|tsx|mts|cts)$/i, '');
     if (!basename) {
       return fn; // no resolvable file → fall back to the bare function name (may be '')
     }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/collectors/incident-snapshot-collector.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/serviceevents/collectors/incident-snapshot-collector.test.ts
@@ -434,15 +434,24 @@ describe('IncidentSnapshotCollector (OTLP)', function () {
     });
   });
 
-  describe('dedup keys on the recovered error identity (not route-only)', function () {
+  describe('dedup keys on the recovered error identity (not operation-only)', function () {
     // Regression: the span processor passes exception=null and defers exception detail to the
     // collector. The dedup hash must recover the error type+message from investigation data so two
-    // DISTINCT errors on the same route do NOT collapse to one snapshot under maxSameError=1.
-    function seedException(name: string, message: string): void {
+    // DISTINCT errors on the same operation do NOT collapse to one snapshot under maxSameError=1.
+    // The hash derives its origin from the traceback (a V8 stack string), NOT from functionName —
+    // functionName is the customer-consumed value the hash leaves untouched. So vary the stack's
+    // top frame (file + function) to drive distinct-vs-same dedup behavior.
+    function seedException(
+      name: string,
+      message: string,
+      file: string = '/app/handler.js',
+      func: string = 'handle'
+    ): void {
       const state = ServiceEventsMonitorState.getInstance();
       state.beginInvestigation(true);
       const inv = state.peekInvestigationData();
-      inv!.exception = { name, message, traceback: `${name}: ${message}`, functionName: 'app.handler' };
+      const traceback = `${name}: ${message}\n    at ${func} (${file}:10:5)\n    at caller (/app/main.js:3:1)`;
+      inv!.exception = { name, message, traceback, functionName: func };
     }
 
     it('two distinct error TYPES on the same route both emit (maxSameError=1)', function () {
@@ -460,13 +469,32 @@ describe('IncidentSnapshotCollector (OTLP)', function () {
       }
     });
 
-    it('two distinct error MESSAGES of the same type on one route both emit (maxSameError=1)', function () {
+    it('two distinct MESSAGES of the same type+function on one route deduplicate (maxSameError=1)', function () {
+      // The unbounded-key fix: the message is no longer part of the dedup key, so two occurrences of
+      // the same error that differ only in request-specific message text now collide.
       const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
       try {
-        seedException('DbError', 'timeout on shard A');
+        seedException('DbError', 'timeout on shard A', '/app/db.js', 'queryOrders');
         expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
         c.collect();
-        seedException('DbError', 'timeout on shard B');
+        seedException('DbError', 'timeout on shard B', '/app/db.js', 'queryOrders');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).toBeNull();
+        c.collect();
+        expect(emitter.snapshots.length).toBe(1);
+      } finally {
+        c.stop();
+      }
+    });
+
+    it('the same type+function name in distinct MODULES on one route both emit (maxSameError=1)', function () {
+      // The file-qualified origin keeps same-named functions in different files apart — the
+      // collision the qualification fixes.
+      const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
+      try {
+        seedException('DbError', 'timeout', '/app/orders.js', 'handle');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        seedException('DbError', 'timeout', '/app/users.js', 'handle');
         expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
         c.collect();
         expect(emitter.snapshots.length).toBe(2);
@@ -475,13 +503,29 @@ describe('IncidentSnapshotCollector (OTLP)', function () {
       }
     });
 
-    it('the SAME error (type+message) on one route deduplicates (maxSameError=1)', function () {
+    it('the same error type from distinct FUNCTIONS on one route both emit (maxSameError=1)', function () {
+      // The origin function keeps two same-type errors apart now that the message is gone.
       const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
       try {
-        seedException('DbError', 'timeout');
+        seedException('DbError', 'timeout', '/app/db.js', 'queryOrders');
         expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
         c.collect();
-        seedException('DbError', 'timeout');
+        seedException('DbError', 'timeout', '/app/db.js', 'writeOrders');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        expect(emitter.snapshots.length).toBe(2);
+      } finally {
+        c.stop();
+      }
+    });
+
+    it('the SAME error (type+function) on one route deduplicates (maxSameError=1)', function () {
+      const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
+      try {
+        seedException('DbError', 'timeout', '/app/db.js', 'queryOrders');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        seedException('DbError', 'timeout', '/app/db.js', 'queryOrders');
         // Same recovered identity → same hash → period-deduplicated.
         expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).toBeNull();
         c.collect();
@@ -491,15 +535,165 @@ describe('IncidentSnapshotCollector (OTLP)', function () {
       }
     });
 
-    it('a latency incident (no exception) still keys route-only', function () {
+    it('a latency incident (no exception) still keys operation-only', function () {
       const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
       try {
-        // No investigation exception; two slow 2xx on the same route dedup together (route-only).
+        // No investigation exception; two slow 2xx on the same operation dedup together.
         expect(c.processPotentialIncident('/slow', 'GET', 200, 6000, null, makeRequestData())).not.toBeNull();
         c.collect();
         expect(c.processPotentialIncident('/slow', 'GET', 200, 6000, null, makeRequestData())).toBeNull();
         c.collect();
         expect(emitter.snapshots.length).toBe(1);
+      } finally {
+        c.stop();
+      }
+    });
+
+    it('the same error on distinct METHODS of one route both emit (maxSameError=1)', function () {
+      // The key is `<method> <route>`, so GET and POST on the same route are distinct incidents even
+      // for the identical recovered error — matching the Java and Python distros.
+      const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
+      try {
+        seedException('DbError', 'timeout', '/app/db.js', 'queryOrders');
+        expect(c.processPotentialIncident('/orders', 'GET', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        seedException('DbError', 'timeout', '/app/db.js', 'queryOrders');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        expect(emitter.snapshots.length).toBe(2);
+      } finally {
+        c.stop();
+      }
+    });
+
+    // originFromStack frame-shape parsing: the top frame's function AND file must come from the SAME
+    // frame, with V8 decorations (async prefix, [as alias]), anonymous frames, and Windows paths all
+    // handled so the origin stays bounded and deploy-stable. These seed a raw traceback directly.
+    function seedRawTraceback(name: string, traceback: string, message: string = 'x'): void {
+      const state = ServiceEventsMonitorState.getInstance();
+      state.beginInvestigation(true);
+      const inv = state.peekInvestigationData();
+      inv!.exception = { name, message, traceback, functionName: 'ignored' };
+    }
+
+    it('a shifted line number in the top frame does not change the dedup key', function () {
+      // The `:line:col` suffix is deploy-unstable (an edit above the throw site shifts it), so it must
+      // be excluded — otherwise a recurring bug re-fires as a new incident after every deploy.
+      const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
+      try {
+        seedRawTraceback('DbError', 'DbError: x\n    at queryOrders (/app/db.js:10:5)');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        seedRawTraceback('DbError', 'DbError: x\n    at queryOrders (/app/db.js:99:12)');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).toBeNull();
+        c.collect();
+        expect(emitter.snapshots.length).toBe(1);
+      } finally {
+        c.stop();
+      }
+    });
+
+    it('a multi-line message embedding a fake frame cannot hijack the origin', function () {
+      // V8 renders the (multi-line) message BEFORE the frames, so a message containing indented
+      // `at pwn (/req/<id>.js:..)` text must NOT be parsed as the top frame — otherwise the
+      // request-specific id would key the hash per request (the unbounded-key bug). Two requests
+      // that differ ONLY in that injected message text must dedup to one incident.
+      const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
+      try {
+        const realFrames = '\n    at queryOrders (/app/db.js:5:2)\n    at handler (/app/main.js:9:1)';
+        seedRawTraceback(
+          'DbError',
+          'DbError: boom\n    at pwn (/req/111.js:1:1)' + realFrames,
+          'boom\n    at pwn (/req/111.js:1:1)'
+        );
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        seedRawTraceback(
+          'DbError',
+          'DbError: boom\n    at pwn (/req/222.js:1:1)' + realFrames,
+          'boom\n    at pwn (/req/222.js:1:1)'
+        );
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).toBeNull();
+        c.collect();
+        expect(emitter.snapshots.length).toBe(1);
+      } finally {
+        c.stop();
+      }
+    });
+
+    it('a header-only stack (no real frames) with an injected message frame does not proliferate', function () {
+      // Frameless stack (e.g. Error.stackTraceLimit=0, or a synthetic span-event stacktrace): after
+      // dropping the header there are NO frames, so the origin degrades to '' (operation-only). Two
+      // requests differing only in the injected per-request message text must still dedup to one.
+      const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
+      try {
+        seedRawTraceback(
+          'DbError',
+          'DbError: boom\n    at pwn (/req/111.js:1:1)',
+          'boom\n    at pwn (/req/111.js:1:1)'
+        );
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        seedRawTraceback(
+          'DbError',
+          'DbError: boom\n    at pwn (/req/222.js:1:1)',
+          'boom\n    at pwn (/req/222.js:1:1)'
+        );
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).toBeNull();
+        c.collect();
+        expect(emitter.snapshots.length).toBe(1);
+      } finally {
+        c.stop();
+      }
+    });
+
+    it('the async prefix and [as alias] decoration do not leak into the origin', function () {
+      // `at async queryOrders (...)` and `at Server.handle [as _handle] (...)` must key the same as
+      // the undecorated frame — the decorations are not part of the stable throw-site identity.
+      const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
+      try {
+        seedRawTraceback('DbError', 'DbError: x\n    at queryOrders (/app/db.js:10:5)');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        seedRawTraceback('DbError', 'DbError: x\n    at async queryOrders (/app/db.js:10:5)');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).toBeNull();
+        c.collect();
+        expect(emitter.snapshots.length).toBe(1);
+      } finally {
+        c.stop();
+      }
+    });
+
+    it('same-named anonymous-frame files in distinct modules stay apart (file-qualified)', function () {
+      // Anonymous top frames (`at /path/file.js:line:col`) still qualify by file, so a recurring
+      // anonymous throw in db.js and one in users.js are distinct incidents rather than both keying
+      // on the raw `file:line:col`.
+      const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
+      try {
+        seedRawTraceback('DbError', 'DbError: x\n    at /app/db.js:10:5');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        seedRawTraceback('DbError', 'DbError: x\n    at /app/users.js:10:5');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        expect(emitter.snapshots.length).toBe(2);
+      } finally {
+        c.stop();
+      }
+    });
+
+    it('a Windows drive-letter path in the top frame still qualifies distinct modules', function () {
+      // `C:\app\db.js` must not be mis-split on its drive-letter colon — same-named functions in
+      // different Windows-path modules must stay apart.
+      const c = new IncidentSnapshotCollector(600_000, 5000, 100, 'env', 'svc', '0.0.1', 1, emitter, null);
+      try {
+        seedRawTraceback('DbError', 'DbError: x\n    at handle (C:\\app\\orders.js:10:5)');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        seedRawTraceback('DbError', 'DbError: x\n    at handle (C:\\app\\users.js:10:5)');
+        expect(c.processPotentialIncident('/orders', 'POST', 500, 10, null, makeRequestData())).not.toBeNull();
+        c.collect();
+        expect(emitter.snapshots.length).toBe(2);
       } finally {
         c.stop();
       }
@@ -514,8 +708,12 @@ describe('IncidentSnapshotCollector (OTLP)', function () {
       // a duplicate even though it never produced a snapshot.
       const c = new IncidentSnapshotCollector(600_000, 5000, 1, 'env', 'svc', '0.0.1', 1, emitter, null);
       try {
-        const errA = new Error('A');
-        const errB = new Error('B');
+        // Two DISTINCT errors: same type, but thrown from differently-named functions so their
+        // stacks yield different origin frames → different hashes (the message is not in the key).
+        const throwA = (): Error => new Error('A');
+        const throwB = (): Error => new Error('B');
+        const errA = throwA();
+        const errB = throwB();
         expect(c.processPotentialIncident('/x', 'GET', 500, 10, errA, makeRequestData())).not.toBeNull();
         // Second distinct error: gates would pass dedup but the rate window (1) is full → rejected.
         expect(c.processPotentialIncident('/x', 'GET', 500, 10, errB, makeRequestData())).toBeNull();
@@ -574,17 +772,17 @@ describe('IncidentSnapshotCollector (OTLP)', function () {
       }
     });
 
-    it('preserves the first occurrence affected_endpoint when a different-method occurrence upgrades', function () {
-      // The dedup hash keys on route (not method), so GET /api/x and POST /api/x with the same error
-      // share a hash. The exemplar is filed under the FIRST occurrence's operation, so the swapped
-      // snapshot must keep the first occurrence's affected_endpoint, not adopt the upgrader's method.
+    it('preserves the first occurrence exemplar when a later sampled occurrence upgrades', function () {
+      // The dedup hash keys on operation (`<method> <route>`), so a later sampled occurrence upgrades
+      // the pending (unsampled) snapshot only when it shares the same operation. The exemplar is filed
+      // under the FIRST occurrence, so the swapped snapshot must keep the first occurrence's identity.
       const err = new Error('boom');
       const exemplar = collector.processPotentialIncident('/api/x', 'GET', 500, 50, err, makeRequestData());
       expect(exemplar).not.toBeNull();
-      // Sampled POST occurrence of the same error upgrades the pending (unsampled) GET snapshot.
+      // Sampled GET occurrence of the same error upgrades the pending (unsampled) GET snapshot.
       collector.processPotentialIncident(
         '/api/x',
-        'POST',
+        'GET',
         500,
         50,
         err,
@@ -592,7 +790,6 @@ describe('IncidentSnapshotCollector (OTLP)', function () {
       );
       collector.collect();
       expect(emitter.snapshots.length).toBe(1);
-      // affected_endpoint stays 'GET /api/x' (the exemplar's filed operation), NOT 'POST /api/x'.
       expect(emitter.snapshots[0].affected_endpoint).toBe('GET /api/x');
       expect(emitter.snapshots[0].snapshot_id).toBe(exemplar!.snapshot_id);
     });


### PR DESCRIPTION
The incident-snapshot deduplication hash keyed on bare route + exception
message. The message is unbounded — it embeds request-specific data (IDs,
timestamps, values) — so a single recurring error spawned a distinct hash
per occurrence, defeating dedup and churning the per-window hash map against
its size cap.

Key on the full operation (`<method> <route>`) so different HTTP methods on
one route are distinct incidents (matching Java), and replace the message with
a bounded file-qualified throw-site origin (`basename.function`) parsed in a
single pass over the top V8 frame (function and file always from the same
frame). The parser strips the async prefix and [as alias] decoration, drops
the deploy-unstable :line:col suffix, tolerates Windows drive-letter paths,
and drops the message header lines first so a multi-line message embedding
`at …` text cannot be mis-parsed as the top frame.

The origin is used ONLY for the internal hash — customer-consumed telemetry
(error breakdown key, snapshot body function_name) is left byte-for-byte
unchanged. Hashes are compared only within a distro; the empty-origin branch
is intentionally not byte-identical across distros (Java omits the :origin
segment, Python/Node emit a trailing colon).

## Testing
- Unit: serviceevents mocha suite passes (54 collector tests incl. distinct-method/same-route, shifted-line, async/[as alias] decoration, anonymous-frame, Windows path, multi-line + header-only message injection).
- Contract: serviceevents contract tests green (express + fastify; 2 fastify skips are a pre-existing onError-ordering gap, unrelated to this change).
- Lint: eslint + prettier clean.
- E2E: EC2 dev-loop against live CloudWatch — 5/5 Service Events validators pass.