### PR TITLE
fix: redact AWS presigned URL credentials from span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix: redact AWS presigned URL credentials from span attributes
+  ([#514](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/514))
 - feat(serviceevents): accept bare package tokens (e.g. `myapp`, `src/myapp`) in
   `OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE`/`_EXCLUDE`, not just `**/…/**` globs
   ([#507](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/507))

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/opentelemetry-lite-sdk.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/opentelemetry-lite-sdk.ts
@@ -1004,6 +1004,12 @@ function instrumentationConfigFor(name: string): Record<string, unknown> {
   if (name === '@opentelemetry/instrumentation-aws-lambda') {
     return { eventContextExtractor: liteEventContextExtractor };
   }
+  if (name === '@opentelemetry/instrumentation-http') {
+    // Redact AWS SigV4 credentials (and the upstream defaults) from captured URLs. See
+    // REDACTED_QUERY_PARAMS for why the full list must be provided here.
+    const { REDACTED_QUERY_PARAMS } = require('./utils');
+    return { redactedQueryParams: REDACTED_QUERY_PARAMS };
+  }
   return {};
 }
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/register.ts
@@ -41,7 +41,7 @@ import {
   INSTRUMENTATION_SHORT_NAME as VERCEL_AI_SHORT_NAME,
 } from './instrumentation/instrumentation-vercel-ai/instrumentation';
 import { applyInstrumentationPatches, customExtractor } from './patches/instrumentation-patch';
-import { getAwsRegionFromEnvironment, isAgentObservabilityEnabled } from './utils';
+import { getAwsRegionFromEnvironment, isAgentObservabilityEnabled, REDACTED_QUERY_PARAMS } from './utils';
 
 const logLevelEnv = getStringFromEnv('OTEL_LOG_LEVEL');
 const logLevel = logLevelEnv ? diagLogLevelFromString(logLevelEnv) : undefined;
@@ -230,10 +230,15 @@ export const instrumentationConfigs: InstrumentationConfigMap = {
   '@opentelemetry/instrumentation-mongoose': {
     suppressInternalInstrumentation: true,
   },
-  ...(isAgentObservabilityEnabled() && {
-    '@opentelemetry/instrumentation-http': {
+  '@opentelemetry/instrumentation-http': {
+    // Redact AWS SigV4 credentials (and the upstream defaults) from captured URLs. See
+    // REDACTED_QUERY_PARAMS for why the full list must be provided here.
+    redactedQueryParams: REDACTED_QUERY_PARAMS,
+    ...(isAgentObservabilityEnabled() && {
       ignoreIncomingRequestHook: isHttpPingRequest,
-    },
+    }),
+  },
+  ...(isAgentObservabilityEnabled() && {
     '@opentelemetry/instrumentation-undici': {
       ignoreRequestHook: isUndiciPingRequest,
     },

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/utils.ts
@@ -15,6 +15,23 @@ export const OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS = 'OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEY
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#improved-control-over-mapped-type-modifiers
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 
+/**
+ * Query-string parameters whose values `@opentelemetry/instrumentation-http` redacts from the URL
+ * captured on HTTP spans. The `redactedQueryParams` config replaces the upstream default list
+ * rather than extending it, so the defaults are re-included below.
+ */
+export const REDACTED_QUERY_PARAMS: string[] = [
+  // Upstream DEFAULT_QUERY_STRINGS_TO_REDACT — re-included because the config replaces, not extends.
+  'sig',
+  'Signature',
+  'AWSAccessKeyId',
+  'X-Goog-Signature',
+  // AWS SigV4/SigV4a query-string authentication credentials.
+  'X-Amz-Signature',
+  'X-Amz-Credential',
+  'X-Amz-Security-Token',
+];
+
 export const getNodeVersion = () => {
   const nodeVersion = process.versions.node;
   const versionParts = nodeVersion.split('.');

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/opentelemetry-lite-sdk.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/opentelemetry-lite-sdk.test.ts
@@ -1578,6 +1578,16 @@ describe('LiteSdk - buildInstrumentations', () => {
     expect(names).toContain('AwsInstrumentation');
     expect(names).not.toContain('HttpInstrumentation');
   });
+
+  it('configures instrumentation-http to redact the AWS SigV4 credential params', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { REDACTED_QUERY_PARAMS } = require('../src/utils');
+    process.env[ENABLED] = 'http';
+    const instrs = buildInstrumentations();
+    const http = instrs.find(i => i.constructor.name === 'HttpInstrumentation');
+    expect(http).toBeDefined();
+    expect(http.getConfig().redactedQueryParams).toEqual(REDACTED_QUERY_PARAMS);
+  });
 });
 
 // ─── Parity Check: Lite SDK vs Full SDK ───────────────────────────────────────

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -483,6 +483,48 @@ describe('Register', function () {
     });
   });
 
+  describe('HTTP query-parameter redaction', () => {
+    // This suite's module-level require of register.ts runs with AGENT_OBSERVABILITY_ENABLED unset,
+    // so this covers the redaction-applies-by-default case.
+    it('configures instrumentation-http to redact the AWS SigV4 credential params', () => {
+      const { instrumentationConfigs } = require('../src/register');
+      const { REDACTED_QUERY_PARAMS } = require('../src/utils');
+      const httpConfig = instrumentationConfigs['@opentelemetry/instrumentation-http'];
+      assert.ok(httpConfig, 'instrumentation-http config should be present');
+      assert.deepStrictEqual(httpConfig.redactedQueryParams, REDACTED_QUERY_PARAMS);
+    });
+
+    it('redacts regardless of AGENT_OBSERVABILITY_ENABLED', () => {
+      // instrumentationConfigs is built once at module load, so agent observability has to be set
+      // in a fresh process. Redaction must not be gated behind it (only the ping hook is).
+      const script = `
+        const assert = require('assert');
+        const { instrumentationConfigs } = require('../build/src/register.js');
+        const { REDACTED_QUERY_PARAMS } = require('../build/src/utils.js');
+        const httpConfig = instrumentationConfigs['@opentelemetry/instrumentation-http'];
+        assert.deepStrictEqual(httpConfig.redactedQueryParams, REDACTED_QUERY_PARAMS);
+        assert.ok(typeof httpConfig.ignoreIncomingRequestHook === 'function');
+        process.exit(0);
+      `;
+      const proc = spawnSync(process.execPath, ['-e', script], {
+        cwd: __dirname,
+        timeout: 10000,
+        killSignal: 'SIGKILL',
+        env: {
+          ...process.env,
+          AGENT_OBSERVABILITY_ENABLED: 'true',
+          OTEL_NODE_RESOURCE_DETECTORS: 'none',
+          OTEL_TRACES_EXPORTER: 'none',
+          OTEL_METRICS_EXPORTER: 'none',
+          OTEL_LOGS_EXPORTER: 'none',
+          OTEL_LOG_LEVEL: 'NONE',
+        },
+      });
+      assert.ifError(proc.error);
+      assert.equal(proc.status, 0, proc.stderr?.toString());
+    });
+  });
+
   describe('Healthcheck suppression', () => {
     it('suppresses /ping for incoming HTTP requests', () => {
       const { isHttpPingRequest } = require('../src/register');

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/utils.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/utils.test.ts
@@ -13,7 +13,12 @@ import {
   checkDigits,
   isAccountId,
   OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS,
+  REDACTED_QUERY_PARAMS,
 } from '../src/utils';
+// Upstream default list that `redactedQueryParams` REPLACES (does not extend). Imported here so
+// the test fails if a dependency bump adds/removes an upstream default we no longer re-include.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { DEFAULT_QUERY_STRINGS_TO_REDACT } = require('@opentelemetry/instrumentation-http/build/src/internal-types');
 
 describe('Utils', function () {
   beforeEach(() => {
@@ -156,5 +161,34 @@ describe('Utils', function () {
     expect(isAccountId('123456789012')).toBeTruthy();
     expect(isAccountId('abc')).toBeFalsy();
     expect(isAccountId('')).toBeFalsy();
+  });
+
+  describe('REDACTED_QUERY_PARAMS', () => {
+    it('re-includes every upstream default (config replaces, does not extend)', () => {
+      // The HTTP instrumentation applies redactedQueryParams verbatim in place of its built-in
+      // defaults, so omitting any default would silently stop redacting it.
+      for (const param of DEFAULT_QUERY_STRINGS_TO_REDACT) {
+        expect(REDACTED_QUERY_PARAMS).toContain(param);
+      }
+    });
+
+    it('adds the AWS SigV4 credential query parameters', () => {
+      expect(REDACTED_QUERY_PARAMS).toContain('X-Amz-Signature');
+      expect(REDACTED_QUERY_PARAMS).toContain('X-Amz-Credential');
+      expect(REDACTED_QUERY_PARAMS).toContain('X-Amz-Security-Token');
+    });
+
+    it('does not redact the non-sensitive SigV4 parameters needed for presigned-URL detection', () => {
+      // Blanking these would break presigned-URL attribution, which reads them to recognize the
+      // request. They must NOT appear in the redaction list.
+      expect(REDACTED_QUERY_PARAMS).not.toContain('X-Amz-Algorithm');
+      expect(REDACTED_QUERY_PARAMS).not.toContain('X-Amz-Date');
+      expect(REDACTED_QUERY_PARAMS).not.toContain('X-Amz-Expires');
+      expect(REDACTED_QUERY_PARAMS).not.toContain('X-Amz-SignedHeaders');
+    });
+
+    it('contains no duplicate entries', () => {
+      expect(new Set(REDACTED_QUERY_PARAMS).size).toBe(REDACTED_QUERY_PARAMS.length);
+    });
   });
 });


### PR DESCRIPTION
## Description

AWS presigned URLs carry SigV4/SigV4a authentication material in the query string. When such a URL is requested through a raw HTTP client (rather than the AWS SDK), the HTTP instrumentation captures the full URL on the span, so the signature and credential scope are exported via `url.full` / `http.url`.

`@opentelemetry/instrumentation-http` supports redacting sensitive query parameters via its `redactedQueryParams` config, but its built-in default list (`sig`, `Signature`, `AWSAccessKeyId`, `X-Goog-Signature`) does not include the `X-Amz-*` SigV4 parameters that AWS SDKs and tooling emit.

Port of the redaction half of aws-observability/aws-otel-java-instrumentation#1419 to JavaScript.

## Changes

- New `REDACTED_QUERY_PARAMS` in `src/utils.ts`, adding `X-Amz-Signature`, `X-Amz-Credential`, and `X-Amz-Security-Token`.
- Wired into `redactedQueryParams` on `@opentelemetry/instrumentation-http` in **both** SDK paths: `register.ts` (standard) and `opentelemetry-lite-sdk.ts` `instrumentationConfigFor()` (Lambda lite).
- Unit tests for the parameter list plus wiring assertions on each path.
- CHANGELOG entry.

Two upstream behaviours this depends on, both verified against the installed `@opentelemetry/instrumentation-http`:

1. **`redactedQueryParams` replaces the default list rather than extending it** (the default is only applied when the config is `undefined`). `REDACTED_QUERY_PARAMS` therefore re-includes all four upstream defaults alongside the new parameters — omitting them would silently stop redacting them. A test asserts this against the upstream `DEFAULT_QUERY_STRINGS_TO_REDACT` so a dependency bump that adds a new default cannot regress it unnoticed.
2. **Redaction blanks the value (`-> REDACTED`) while preserving the parameter key.** This means the non-sensitive SigV4 parameters (`X-Amz-Algorithm`, `X-Amz-Date`, `X-Amz-Expires`, `X-Amz-SignedHeaders`) remain intact, which a follow-up change relies on to attribute presigned S3 URLs in Application Signals. This PR is independently useful and has no dependency on that follow-up.

Note that redaction is applied **unconditionally**. Previously the entire `instrumentation-http` config block was gated behind `AGENT_OBSERVABILITY_ENABLED`; redaction now applies in all deployments, while the agent-observability-only `ignoreIncomingRequestHook` is unchanged. A test pins this invariant with the env var set.

## Testing

- 7 new tests (4 for the parameter list including the upstream cross-check, 2 for the standard path, 1 for the lite path).
- Full suite: 1719 passing, 0 failing.
- `npm run compile` clean; `eslint` reports 0 errors on the changed files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.