### PR TITLE
feat: wire AlwaysRecordSampler when agent observability is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: wire `AlwaysRecordSampler` when agent observability is enabled so unsampled spans are still recorded and exported
+  ([#516](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/516))
 - fix: redact AWS presigned URL credentials from span attributes
   ([#514](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/514))
 - feat(serviceevents): accept bare package tokens (e.g. `myapp`, `src/myapp`) in

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -395,7 +395,7 @@ export class AwsOpentelemetryConfigurator {
   }
 
   static customizeSampler(sampler: Sampler): Sampler {
-    if (AwsOpentelemetryConfigurator.isApplicationSignalsEnabled()) {
+    if (AwsOpentelemetryConfigurator.isApplicationSignalsEnabled() || isAgentObservabilityEnabled()) {
       return AlwaysRecordSampler.create(sampler);
     }
     return sampler;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -17,6 +17,7 @@ import {
   AlwaysOffSampler,
   AlwaysOnSampler,
   BatchSpanProcessor,
+  InMemorySpanExporter,
   ParentBasedSampler,
   ReadableSpan,
   SpanProcessor,
@@ -441,6 +442,46 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     expect(customizedSampler).toBeInstanceOf(AlwaysRecordSampler);
     expect(mockSampler).toEqual((customizedSampler as any).rootSampler);
     delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;
+  });
+
+  it('CustomizeSamplerWithAgentObservabilityTest', () => {
+    const mockSampler: Sampler = sinon.createStubInstance(AlwaysOnSampler);
+
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+    const customizedSampler: Sampler = AwsOpentelemetryConfigurator.customizeSampler(mockSampler);
+    expect(customizedSampler).toBeInstanceOf(AlwaysRecordSampler);
+    expect(mockSampler).toEqual((customizedSampler as any).rootSampler);
+
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'false';
+    expect(mockSampler).toEqual(AwsOpentelemetryConfigurator.customizeSampler(mockSampler));
+
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+  });
+
+  it('UnsampledSpanIsRecordedAndExportedWithAgentObservabilityTest', async () => {
+    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+
+    const exporter: InMemorySpanExporter = new InMemorySpanExporter();
+    const processor: AwsBatchUnsampledSpanProcessor = new AwsBatchUnsampledSpanProcessor(exporter);
+    const tracerProvider: NodeTracerProvider = new NodeTracerProvider({
+      sampler: AwsOpentelemetryConfigurator.customizeSampler(new AlwaysOffSampler()),
+      spanProcessors: [processor],
+    });
+
+    const span: Span = tracerProvider.getTracer('test').startSpan('unsampled-span');
+    expect(span.isRecording()).toBeTruthy();
+    expect(span.spanContext().traceFlags).toEqual(TraceFlags.NONE);
+    span.end();
+
+    await processor.forceFlush();
+
+    const exportedSpans: ReadableSpan[] = exporter.getFinishedSpans();
+    expect(exportedSpans.length).toEqual(1);
+    expect(exportedSpans[0].name).toEqual('unsampled-span');
+    expect(exportedSpans[0].attributes[AWS_ATTRIBUTE_KEYS.AWS_TRACE_FLAG_SAMPLED]).toEqual(false);
+
+    await processor.shutdown();
+    delete process.env.AGENT_OBSERVABILITY_ENABLED;
   });
 
   it('CustomizeExporterTest', () => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -447,15 +447,17 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
   it('CustomizeSamplerWithAgentObservabilityTest', () => {
     const mockSampler: Sampler = sinon.createStubInstance(AlwaysOnSampler);
 
-    process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
-    const customizedSampler: Sampler = AwsOpentelemetryConfigurator.customizeSampler(mockSampler);
-    expect(customizedSampler).toBeInstanceOf(AlwaysRecordSampler);
-    expect(mockSampler).toEqual((customizedSampler as any).rootSampler);
+    try {
+      process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+      const customizedSampler: Sampler = AwsOpentelemetryConfigurator.customizeSampler(mockSampler);
+      expect(customizedSampler).toBeInstanceOf(AlwaysRecordSampler);
+      expect(mockSampler).toEqual((customizedSampler as any).rootSampler);
 
-    process.env.AGENT_OBSERVABILITY_ENABLED = 'false';
-    expect(mockSampler).toEqual(AwsOpentelemetryConfigurator.customizeSampler(mockSampler));
-
-    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+      process.env.AGENT_OBSERVABILITY_ENABLED = 'false';
+      expect(mockSampler).toEqual(AwsOpentelemetryConfigurator.customizeSampler(mockSampler));
+    } finally {
+      delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    }
   });
 
   it('UnsampledSpanIsRecordedAndExportedWithAgentObservabilityTest', async () => {
@@ -468,20 +470,22 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
       spanProcessors: [processor],
     });
 
-    const span: Span = tracerProvider.getTracer('test').startSpan('unsampled-span');
-    expect(span.isRecording()).toBeTruthy();
-    expect(span.spanContext().traceFlags).toEqual(TraceFlags.NONE);
-    span.end();
+    try {
+      const span: Span = tracerProvider.getTracer('test').startSpan('unsampled-span');
+      expect(span.isRecording()).toBeTruthy();
+      expect(span.spanContext().traceFlags).toEqual(TraceFlags.NONE);
+      span.end();
 
-    await processor.forceFlush();
+      await processor.forceFlush();
 
-    const exportedSpans: ReadableSpan[] = exporter.getFinishedSpans();
-    expect(exportedSpans.length).toEqual(1);
-    expect(exportedSpans[0].name).toEqual('unsampled-span');
-    expect(exportedSpans[0].attributes[AWS_ATTRIBUTE_KEYS.AWS_TRACE_FLAG_SAMPLED]).toEqual(false);
-
-    await processor.shutdown();
-    delete process.env.AGENT_OBSERVABILITY_ENABLED;
+      const exportedSpans: ReadableSpan[] = exporter.getFinishedSpans();
+      expect(exportedSpans.length).toEqual(1);
+      expect(exportedSpans[0].name).toEqual('unsampled-span');
+      expect(exportedSpans[0].attributes[AWS_ATTRIBUTE_KEYS.AWS_TRACE_FLAG_SAMPLED]).toEqual(false);
+    } finally {
+      await tracerProvider.shutdown();
+      delete process.env.AGENT_OBSERVABILITY_ENABLED;
+    }
   });
 
   it('CustomizeExporterTest', () => {


### PR DESCRIPTION
## Description

Wire `AlwaysRecordSampler` when `AGENT_OBSERVABILITY_ENABLED=true`, so unsampled spans stay recording and can still be exported via `AwsBatchUnsampledSpanProcessor`. Previously this only happened when Application Signals was enabled. Matches the Python change in aws-observability/aws-otel-python-instrumentation#844.

## Testing

Unit test for the sampler gate, plus an end-to-end test that emits an unsampled span under `AlwaysOffSampler` and validates it is created, recorded, and exported through `AwsBatchUnsampledSpanProcessor` into an `InMemorySpanExporter`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.