### PR TITLE
fix(agent-observability): normalize GenAI message content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(agent-observability): preserve structured tool values, binary content, and typed multimodal/reasoning
+  message parts in native GenAI instrumentation
 - feat: attribute presigned S3 URLs as `AWS::S3` dependencies in Application Signals, opt-in via
   `OTEL_AWS_APPLICATION_SIGNALS_PRESIGNED_URL_ATTRIBUTION_ENABLED`
   ([#515](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/515))

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
@@ -64,7 +64,7 @@ export function tryParseJson(value: string): unknown {
   }
 }
 
-export function serializeToJson(value: unknown, maxDepth: number = 10): string {
+function trySerializeToJson(value: unknown, maxDepth: number = 10): string | undefined {
   const ancestors = new WeakSet<object>();
   const sanitize = (obj: unknown, depth: number): unknown => {
     if (depth <= 0) return '...';
@@ -108,16 +108,24 @@ export function serializeToJson(value: unknown, maxDepth: number = 10): string {
     const serialized = JSON.stringify(sanitize(value, maxDepth));
     return serialized === undefined ? JSON.stringify('undefined') : serialized;
   } catch {
-    return JSON.stringify('[Unserializable]');
+    return undefined;
   }
 }
 
+export function serializeToJson(value: unknown, maxDepth: number = 10): string {
+  return trySerializeToJson(value, maxDepth) ?? JSON.stringify('[Unserializable]');
+}
+
 export function toToolAttributeValue(value: unknown): string | number | boolean | undefined {
-  if (value === undefined) return undefined;
-  if (value === null) return 'null';
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
-  const encodedBinary = binaryToBase64(value);
-  return encodedBinary ?? serializeToJson(value);
+  try {
+    if (value === undefined) return undefined;
+    if (value === null) return 'null';
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+    const encodedBinary = binaryToBase64(value);
+    return encodedBinary ?? trySerializeToJson(value);
+  } catch {
+    return undefined;
+  }
 }
 
 export function contentToParts(content: unknown): Array<Record<string, unknown>> {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
@@ -103,6 +103,14 @@ export function toToolAttributeValue(value: unknown): string | number | boolean 
 }
 
 export function contentToParts(content: unknown): Array<Record<string, unknown>> {
+  try {
+    return convertContentToParts(content);
+  } catch {
+    return [];
+  }
+}
+
+function convertContentToParts(content: unknown): Array<Record<string, unknown>> {
   if (typeof content === 'string') {
     return content ? [{ type: 'text', content }] : [];
   }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
@@ -64,423 +64,107 @@ export function tryParseJson(value: string): unknown {
   }
 }
 
-function trySerializeToJson(value: unknown, maxDepth: number = 10): string | undefined {
-  const ancestors = new WeakSet<object>();
+export function serializeToJson(value: unknown, maxDepth: number = 10): string {
+  const seen = new WeakSet<object>();
   const sanitize = (obj: unknown, depth: number): unknown => {
     if (depth <= 0) return '...';
     if (obj === null || obj === undefined) return obj;
     if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean') return obj;
     const encodedBinary = binaryToBase64(obj);
     if (encodedBinary !== undefined) return encodedBinary;
-    if (obj instanceof Date) return obj.toISOString();
-    if (obj instanceof Error) {
-      return {
-        name: obj.name,
-        message: obj.message,
-        stack: obj.stack,
-      };
-    }
     if (typeof obj === 'object') {
-      if (ancestors.has(obj as object)) return '[Circular]';
-      ancestors.add(obj as object);
-      try {
-        if (Array.isArray(obj)) return obj.map(item => sanitize(item, depth - 1));
-        if (obj instanceof Map) {
-          return Array.from(obj.entries(), ([key, val]) => [sanitize(key, depth - 1), sanitize(val, depth - 1)]);
-        }
-        if (obj instanceof Set) {
-          return Array.from(obj.values(), item => sanitize(item, depth - 1));
-        }
-        const result: Record<string, unknown> = {};
-        for (const [key, val] of Object.entries(obj)) {
-          result[key] = sanitize(val, depth - 1);
-        }
-        return result;
-      } finally {
-        ancestors.delete(obj as object);
+      if (seen.has(obj as object)) return '[Circular]';
+      seen.add(obj as object);
+      if (Array.isArray(obj)) return obj.map(item => sanitize(item, depth - 1));
+      const result: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(obj)) {
+        result[key] = sanitize(val, depth - 1);
       }
+      return result;
     }
     return String(obj);
   };
 
   try {
-    if (value === undefined) return JSON.stringify('undefined');
-    const serialized = JSON.stringify(sanitize(value, maxDepth));
-    return serialized === undefined ? JSON.stringify('undefined') : serialized;
+    return JSON.stringify(sanitize(value, maxDepth));
   } catch {
-    return undefined;
+    return String(value);
   }
-}
-
-export function serializeToJson(value: unknown, maxDepth: number = 10): string {
-  return trySerializeToJson(value, maxDepth) ?? JSON.stringify('[Unserializable]');
 }
 
 export function toToolAttributeValue(value: unknown): string | number | boolean | undefined {
   try {
-    if (value === undefined) return undefined;
-    if (value === null) return 'null';
+    if (value === null || value === undefined) return undefined;
     if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
-    const encodedBinary = binaryToBase64(value);
-    return encodedBinary ?? trySerializeToJson(value);
+    return binaryToBase64(value) ?? serializeToJson(value);
   } catch {
     return undefined;
   }
 }
 
+// Keep this aligned with AWS OTel Python's content_to_parts contract.
 export function contentToParts(content: unknown): Array<Record<string, unknown>> {
-  try {
-    if (typeof content === 'string') {
-      return content ? [{ type: 'text', content }] : [];
+  if (typeof content === 'string') {
+    return content ? [{ type: 'text', content }] : [];
+  }
+  let blocks: unknown[];
+  if (isRecord(content)) {
+    blocks = [content];
+  } else if (Array.isArray(content)) {
+    blocks = content;
+  } else {
+    return content === null || content === undefined ? [] : [{ type: 'text', content: String(content) }];
+  }
+
+  const parts: Array<Record<string, unknown>> = [];
+  for (const block of blocks) {
+    if (typeof block === 'string') {
+      if (block) parts.push({ type: 'text', content: block });
+      continue;
+    }
+    if (!isRecord(block)) {
+      parts.push({ type: 'text', content: String(block) });
+      continue;
     }
 
-    const blocks = Array.isArray(content) ? content : isRecord(content) ? [content] : [];
-    if (blocks.length === 0) {
-      return content === null || content === undefined ? [] : [{ type: 'text', content: String(content) }];
-    }
-
-    return blocks.flatMap(contentBlockToParts);
-  } catch {
-    return [{ type: 'text', content: '[Unserializable]' }];
-  }
-}
-
-function contentBlockToParts(block: unknown): Array<Record<string, unknown>> {
-  if (typeof block === 'string') {
-    return block ? [{ type: 'text', content: block }] : [];
-  }
-  if (!isRecord(block)) {
-    return [{ type: 'text', content: String(block) }];
-  }
-
-  const blockType = typeof block.type === 'string' ? block.type : '';
-  if (['text', 'input_text', 'output_text'].includes(blockType)) {
-    const text = block.text ?? block.content;
-    return text === null || text === undefined || text === '' ? [] : [{ type: 'text', content: String(text) }];
-  }
-
-  if (['thinking', 'reasoning', 'reasoning_text', 'summary_text'].includes(blockType)) {
-    const reasoning = block.thinking ?? block.reasoning ?? block.text ?? block.content;
-    return reasoning === null || reasoning === undefined || reasoning === ''
-      ? []
-      : [{ type: 'reasoning', content: String(reasoning) }];
-  }
-
-  if (blockType === 'text-plain' && typeof block.text === 'string') {
-    return [
-      copySelectedFields(
-        { type: 'text', content: block.text },
-        [block],
-        ['title', 'context', 'providerMetadata', 'providerOptions', 'providerData', 'metadata']
-      ),
-    ];
-  }
-
-  const modality = mediaModality(blockType);
-  if (modality) {
-    const mediaPart = imageContentToPart(block, modality);
-    return mediaPart ? [mediaPart] : [{ ...block, type: blockType }];
-  }
-
-  if (blockType === 'tool-call' || blockType === 'tool_call' || blockType === 'tool_use') {
-    const args = block.args ?? block.arguments ?? block.input ?? {};
-    return [
-      {
-        type: 'tool_call',
-        id: block.toolCallId ?? block.id ?? null,
-        name: block.toolName ?? block.name ?? '',
-        arguments: typeof args === 'string' ? tryParseJson(args) : args,
-      },
-    ];
-  }
-
-  if (blockType === 'tool-result' || blockType === 'tool_call_response') {
-    return [
-      {
-        type: 'tool_call_response',
-        id: block.toolCallId ?? block.id ?? null,
-        response: block.result ?? block.response ?? block.output ?? '',
-      },
-    ];
-  }
-
-  if (!blockType) {
-    return [{ ...block, type: 'unknown' }];
-  }
-  return [{ ...block, type: blockType }];
-}
-
-function imageContentToPart(block: Record<string, unknown>, modality: string): Record<string, unknown> | undefined {
-  try {
-    return imageContentToPartUnsafe(block, modality);
-  } catch {
-    return undefined;
-  }
-}
-
-function imageContentToPartUnsafe(
-  block: Record<string, unknown>,
-  modality: string
-): Record<string, unknown> | undefined {
-  const source = isRecord(block.source) ? block.source : undefined;
-  const inputAudio = isRecord(block.input_audio) ? block.input_audio : undefined;
-  const primary = getPrimaryMediaValue(block);
-  const primaryRecord = isRecord(primary) ? primary : undefined;
-  const sources = [block, primaryRecord, inputAudio, source].filter(isRecord);
-  const mimeType = getMimeType(sources, modality);
-
-  const fileId = getFileId(block, primaryRecord, source);
-  if (fileId) {
-    return withMediaMetadata(withOptionalMimeType({ type: 'file', modality, file_id: fileId }, mimeType), sources);
-  }
-
-  const explicitUrl = block.image_url ?? block.file_url ?? block.url ?? primaryRecord?.url ?? source?.url;
-  const uriPart = buildAutoMediaPart(explicitUrl, modality, mimeType, sources, false);
-  if (uriPart) return uriPart;
-
-  const base64Data = block.file_data ?? inputAudio?.data ?? primaryRecord?.data ?? block.data ?? source?.data;
-  const base64Part = buildBase64MediaPart(base64Data, modality, mimeType, sources);
-  if (base64Part) return base64Part;
-
-  return buildAutoMediaPart(primary, modality, mimeType, sources, true);
-}
-
-function mediaModality(blockType: string): string | undefined {
-  switch (blockType) {
-    case 'image':
-    case 'image_url':
-    case 'input_image':
-    case 'output_image':
-      return 'image';
-    case 'audio':
-    case 'input_audio':
-      return 'audio';
-    case 'video':
-      return 'video';
-    case 'file':
-    case 'input_file':
-      return 'document';
-    case 'text-plain':
-      return 'text';
-    default:
-      return undefined;
-  }
-}
-
-function getPrimaryMediaValue(block: Record<string, unknown>): unknown {
-  switch (block.type) {
-    case 'image':
-    case 'input_image':
-    case 'output_image':
-      return block.image;
-    case 'audio':
-      return block.audio;
-    case 'input_file':
-    case 'file':
-      return block.file;
-    default:
-      return undefined;
-  }
-}
-
-function getFileId(
-  block: Record<string, unknown>,
-  primary: Record<string, unknown> | undefined,
-  source: Record<string, unknown> | undefined
-): string | undefined {
-  const directId = block.fileId ?? block.file_id;
-  if (typeof directId === 'string' && directId) return directId;
-  if (typeof primary?.id === 'string' && primary.id) return primary.id;
-  if (typeof primary?.fileId === 'string' && primary.fileId) return primary.fileId;
-  if (typeof source?.fileId === 'string' && source.fileId) return source.fileId;
-  if (source && (source.type === 'id' || source.source_type === 'id') && typeof source.id === 'string' && source.id) {
-    return source.id;
-  }
-  if (block.source_type === 'id' && typeof block.id === 'string' && block.id) return block.id;
-  return undefined;
-}
-
-function buildAutoMediaPart(
-  value: unknown,
-  modality: string,
-  mimeType: string | undefined,
-  sources: Record<string, unknown>[],
-  allowBase64: boolean
-): Record<string, unknown> | undefined {
-  if (isRecord(value)) {
-    if (typeof value.id === 'string' && value.id) {
-      return withMediaMetadata(withOptionalMimeType({ type: 'file', modality, file_id: value.id }, mimeType), [
-        ...sources,
-        value,
-      ]);
-    }
-    if (value.url !== undefined) {
-      return buildAutoMediaPart(value.url, modality, mimeType, [...sources, value], false);
-    }
-    if (value.data !== undefined) {
-      return buildBase64MediaPart(value.data, modality, mimeType, [...sources, value]);
-    }
-  }
-  if (value instanceof URL) {
-    return buildUriOrDataUrlPart(value.toString(), modality, mimeType, sources);
-  }
-  if (typeof value === 'string') {
-    if (!value) return undefined;
-    if (value.toLowerCase().startsWith('data:') || looksLikeUri(value)) {
-      return buildUriOrDataUrlPart(value, modality, mimeType, sources);
-    }
-    return allowBase64 ? buildBlobPart(value, modality, mimeType, sources) : undefined;
-  }
-  const encodedBinary = binaryToBase64(value);
-  return encodedBinary === undefined ? undefined : buildBlobPart(encodedBinary, modality, mimeType, sources);
-}
-
-function buildBase64MediaPart(
-  value: unknown,
-  modality: string,
-  mimeType: string | undefined,
-  sources: Record<string, unknown>[]
-): Record<string, unknown> | undefined {
-  if (value instanceof URL) {
-    return buildUriOrDataUrlPart(value.toString(), modality, mimeType, sources);
-  }
-  if (typeof value === 'string') {
-    return value ? buildBlobPart(value, modality, mimeType, sources) : undefined;
-  }
-  const encodedBinary = binaryToBase64(value);
-  return encodedBinary === undefined ? undefined : buildBlobPart(encodedBinary, modality, mimeType, sources);
-}
-
-function buildUriOrDataUrlPart(
-  value: string,
-  modality: string,
-  mimeType: string | undefined,
-  sources: Record<string, unknown>[]
-): Record<string, unknown> {
-  const dataUrl = parseDataUrl(value);
-  if (dataUrl) {
-    const content = dataUrl.isBase64
-      ? Buffer.from(dataUrl.data, 'base64').toString('base64')
-      : percentEncodedDataToBuffer(dataUrl.data).toString('base64');
-    return buildBlobPart(content, modality, dataUrl.mimeType ?? mimeType, sources);
-  }
-  return withMediaMetadata(withOptionalMimeType({ type: 'uri', modality, uri: value }, mimeType), sources);
-}
-
-function buildBlobPart(
-  content: string,
-  modality: string,
-  mimeType: string | undefined,
-  sources: Record<string, unknown>[]
-): Record<string, unknown> {
-  return withMediaMetadata(
-    withOptionalMimeType(
-      {
-        type: 'blob',
-        modality,
-        content,
-      },
-      mimeType ?? defaultMimeType(modality)
-    ),
-    sources
-  );
-}
-
-function parseDataUrl(value: string): { mimeType?: string; data: string; isBase64: boolean } | undefined {
-  if (!value.toLowerCase().startsWith('data:')) return undefined;
-  const commaIndex = value.indexOf(',');
-  const header = commaIndex >= 0 ? value.slice(5, commaIndex) : value.slice(5);
-  const data = commaIndex >= 0 ? value.slice(commaIndex + 1) : '';
-  const tokens = header.split(';');
-  const mimeType = tokens[0] || undefined;
-  return {
-    mimeType,
-    data,
-    isBase64: tokens.slice(1).some(token => token.toLowerCase() === 'base64'),
-  };
-}
-
-function percentEncodedDataToBuffer(value: string): Buffer {
-  const chunks: Buffer[] = [];
-  let literalStart = 0;
-  for (let index = 0; index < value.length; index++) {
-    if (value[index] !== '%' || !/^[0-9a-fA-F]{2}$/.test(value.slice(index + 1, index + 3))) continue;
-    if (literalStart < index) chunks.push(Buffer.from(value.slice(literalStart, index), 'utf8'));
-    chunks.push(Buffer.from([parseInt(value.slice(index + 1, index + 3), 16)]));
-    index += 2;
-    literalStart = index + 1;
-  }
-  if (literalStart < value.length) chunks.push(Buffer.from(value.slice(literalStart), 'utf8'));
-  return Buffer.concat(chunks);
-}
-
-function looksLikeUri(value: string): boolean {
-  return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value);
-}
-
-function getMimeType(sources: Record<string, unknown>[], modality: string): string | undefined {
-  for (const source of sources) {
-    const mimeType = source.mimeType ?? source.mediaType ?? source.media_type ?? source.mime_type;
-    if (typeof mimeType === 'string' && mimeType) return mimeType;
-  }
-  for (const source of sources) {
-    if (typeof source.format === 'string' && source.format) {
-      return modality === 'audio' ? `audio/${source.format}` : source.format;
-    }
-  }
-  return undefined;
-}
-
-function defaultMimeType(modality: string): string | undefined {
-  switch (modality) {
-    case 'image':
-      return 'image/*';
-    case 'audio':
-      return 'audio/*';
-    case 'video':
-      return 'video/*';
-    case 'document':
-      return 'application/octet-stream';
-    case 'text':
-      return 'text/plain';
-    default:
-      return undefined;
-  }
-}
-
-function withOptionalMimeType(part: Record<string, unknown>, mimeType: string | undefined): Record<string, unknown> {
-  return mimeType ? { ...part, mime_type: mimeType } : part;
-}
-
-function withMediaMetadata(part: Record<string, unknown>, sources: Record<string, unknown>[]): Record<string, unknown> {
-  return copySelectedFields(part, sources, [
-    'filename',
-    'transcript',
-    'format',
-    'title',
-    'context',
-    'detail',
-    'providerMetadata',
-    'providerOptions',
-    'providerData',
-    'metadata',
-  ]);
-}
-
-function copySelectedFields(
-  target: Record<string, unknown>,
-  sources: Record<string, unknown>[],
-  fields: string[]
-): Record<string, unknown> {
-  const result = { ...target };
-  for (const source of sources) {
-    for (const field of fields) {
-      if (result[field] === undefined && source[field] !== undefined) {
-        result[field] = source[field];
+    const blockType = typeof block.type === 'string' ? block.type : '';
+    if (blockType === 'text') {
+      if (block.text !== null && block.text !== undefined && block.text !== '') {
+        parts.push({ type: 'text', content: String(block.text) });
       }
+    } else if (blockType === 'thinking' || blockType === 'reasoning') {
+      const reasoning = block.thinking || block.reasoning || block.content;
+      if (reasoning) {
+        parts.push({ type: 'reasoning', content: String(reasoning) });
+      }
+    } else if (blockType === 'image_url') {
+      const imageUrl = isRecord(block.image_url) ? block.image_url.url : undefined;
+      if (typeof imageUrl !== 'string' || !imageUrl) continue;
+      if (imageUrl.startsWith('data:')) {
+        const commaIndex = imageUrl.indexOf(',');
+        const header = commaIndex >= 0 ? imageUrl.slice(5, commaIndex) : imageUrl.slice(5);
+        const data = commaIndex >= 0 ? imageUrl.slice(commaIndex + 1) : '';
+        parts.push({
+          type: 'blob',
+          modality: 'image',
+          mime_type: header.split(';', 1)[0] || 'image/*',
+          content: data,
+        });
+      } else {
+        parts.push({ type: 'uri', modality: 'image', uri: imageUrl });
+      }
+    } else if (blockType === 'image') {
+      parts.push({
+        type: 'blob',
+        modality: 'image',
+        mime_type: block.media_type || block.mime_type || 'image/*',
+        content: block.data ?? '',
+      });
+    } else {
+      parts.push({ ...block, type: blockType || 'text' });
     }
   }
-  return result;
+  return parts;
 }
 
 function binaryToBase64(value: unknown): string | undefined {
@@ -498,43 +182,4 @@ function binaryToBase64(value: unknown): string | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-export function normalizeFinishReason(reason: string): string {
-  switch (reason) {
-    case 'stop':
-    case 'STOP':
-    case 'end_turn':
-    case 'stop_sequence':
-    case 'STOP_SEQUENCE':
-    case 'COMPLETE':
-      return 'stop';
-    case 'length':
-    case 'max_tokens':
-    case 'MAX_TOKENS':
-    case 'ERROR_LIMIT':
-    case 'max_output_tokens':
-      return 'length';
-    case 'content_filter':
-    case 'content_filtered':
-    case 'content-filter':
-    case 'SAFETY':
-    case 'RECITATION':
-    case 'ERROR_TOXIC':
-    case 'refusal':
-      return 'content_filter';
-    case 'tool_use':
-    case 'tool_calls':
-    case 'function_call':
-    case 'TOOL_CALL':
-    case 'tool-calls':
-      return 'tool_call';
-    case 'error':
-    case 'ERROR':
-    case 'TIMEOUT':
-    case 'failed':
-      return 'error';
-    default:
-      return reason;
-  }
 }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
@@ -104,76 +104,72 @@ export function toToolAttributeValue(value: unknown): string | number | boolean 
 
 export function contentToParts(content: unknown): Array<Record<string, unknown>> {
   try {
-    return convertContentToParts(content);
-  } catch {
-    return [];
-  }
-}
-
-function convertContentToParts(content: unknown): Array<Record<string, unknown>> {
-  if (typeof content === 'string') {
-    return content ? [{ type: 'text', content }] : [];
-  }
-  let blocks: unknown[];
-  if (isRecord(content)) {
-    blocks = [content];
-  } else if (Array.isArray(content)) {
-    blocks = content;
-  } else {
-    return content === null || content === undefined ? [] : [{ type: 'text', content: String(content) }];
-  }
-
-  const parts: Array<Record<string, unknown>> = [];
-  for (const block of blocks) {
-    if (typeof block === 'string') {
-      if (block) parts.push({ type: 'text', content: block });
-      continue;
+    if (typeof content === 'string') {
+      return content ? [{ type: 'text', content }] : [];
     }
-    if (!isRecord(block)) {
-      parts.push({ type: 'text', content: String(block) });
-      continue;
+    let blocks: unknown[];
+    if (isRecord(content)) {
+      blocks = [content];
+    } else if (Array.isArray(content)) {
+      blocks = content;
+    } else {
+      return content === null || content === undefined ? [] : [{ type: 'text', content: String(content) }];
     }
 
-    const blockType = typeof block.type === 'string' ? block.type : '';
-    if (blockType === 'text') {
-      if (block.text !== null && block.text !== undefined && block.text !== '') {
-        parts.push({ type: 'text', content: String(block.text) });
+    const parts: Array<Record<string, unknown>> = [];
+    for (const block of blocks) {
+      if (typeof block === 'string') {
+        if (block) parts.push({ type: 'text', content: block });
+        continue;
       }
-    } else if (blockType === 'thinking' || blockType === 'reasoning') {
-      const reasoning = block.thinking || block.reasoning || block.content;
-      if (reasoning) {
-        parts.push({ type: 'reasoning', content: String(reasoning) });
+      if (!isRecord(block)) {
+        parts.push({ type: 'text', content: String(block) });
+        continue;
       }
-    } else if (blockType === 'image_url') {
-      const imageUrl = isRecord(block.image_url) ? block.image_url.url : undefined;
-      if (typeof imageUrl !== 'string' || !imageUrl) continue;
-      if (imageUrl.startsWith('data:')) {
-        // https://www.rfc-editor.org/rfc/rfc2397#section-3
-        const payload = imageUrl.slice('data:'.length);
-        const commaIndex = payload.indexOf(',');
-        const header = commaIndex >= 0 ? payload.slice(0, commaIndex) : payload;
-        const data = commaIndex >= 0 ? payload.slice(commaIndex + 1) : '';
+
+      const blockType = typeof block.type === 'string' ? block.type : '';
+      if (blockType === 'text') {
+        if (block.text !== null && block.text !== undefined && block.text !== '') {
+          parts.push({ type: 'text', content: String(block.text) });
+        }
+      } else if (blockType === 'thinking' || blockType === 'reasoning') {
+        const reasoning = block.thinking || block.reasoning || block.content;
+        if (reasoning) {
+          parts.push({ type: 'reasoning', content: String(reasoning) });
+        }
+      } else if (blockType === 'image_url') {
+        const imageUrl = isRecord(block.image_url) ? block.image_url.url : undefined;
+        if (typeof imageUrl !== 'string' || !imageUrl) continue;
+        if (imageUrl.startsWith('data:')) {
+          // https://www.rfc-editor.org/rfc/rfc2397#section-3
+          const payload = imageUrl.slice('data:'.length);
+          const commaIndex = payload.indexOf(',');
+          const header = commaIndex >= 0 ? payload.slice(0, commaIndex) : payload;
+          const data = commaIndex >= 0 ? payload.slice(commaIndex + 1) : '';
+          parts.push({
+            type: 'blob',
+            modality: 'image',
+            mime_type: header.split(';', 1)[0] || 'image/*',
+            content: data,
+          });
+        } else {
+          parts.push({ type: 'uri', modality: 'image', uri: imageUrl });
+        }
+      } else if (blockType === 'image') {
         parts.push({
           type: 'blob',
           modality: 'image',
-          mime_type: header.split(';', 1)[0] || 'image/*',
-          content: data,
+          mime_type: block.media_type || block.mime_type || 'image/*',
+          content: block.data ?? '',
         });
       } else {
-        parts.push({ type: 'uri', modality: 'image', uri: imageUrl });
+        parts.push({ ...block, type: blockType || 'text' });
       }
-    } else if (blockType === 'image') {
-      parts.push({
-        type: 'blob',
-        modality: 'image',
-        mime_type: block.media_type || block.mime_type || 'image/*',
-        content: block.data ?? '',
-      });
-    } else {
-      parts.push({ ...block, type: blockType || 'text' });
     }
+    return parts;
+  } catch {
+    return [];
   }
-  return parts;
 }
 
 function binaryToBase64(value: unknown): string | undefined {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
@@ -65,27 +65,468 @@ export function tryParseJson(value: string): unknown {
 }
 
 export function serializeToJson(value: unknown, maxDepth: number = 10): string {
-  const seen = new WeakSet<object>();
+  const ancestors = new WeakSet<object>();
   const sanitize = (obj: unknown, depth: number): unknown => {
     if (depth <= 0) return '...';
     if (obj === null || obj === undefined) return obj;
     if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean') return obj;
+    const encodedBinary = binaryToBase64(obj);
+    if (encodedBinary !== undefined) return encodedBinary;
+    if (obj instanceof Date) return obj.toISOString();
+    if (obj instanceof Error) {
+      return {
+        name: obj.name,
+        message: obj.message,
+        stack: obj.stack,
+      };
+    }
     if (typeof obj === 'object') {
-      if (seen.has(obj as object)) return '[Circular]';
-      seen.add(obj as object);
-      if (Array.isArray(obj)) return obj.map(item => sanitize(item, depth - 1));
-      const result: Record<string, unknown> = {};
-      for (const [key, val] of Object.entries(obj)) {
-        result[key] = sanitize(val, depth - 1);
+      if (ancestors.has(obj as object)) return '[Circular]';
+      ancestors.add(obj as object);
+      try {
+        if (Array.isArray(obj)) return obj.map(item => sanitize(item, depth - 1));
+        if (obj instanceof Map) {
+          return Array.from(obj.entries(), ([key, val]) => [sanitize(key, depth - 1), sanitize(val, depth - 1)]);
+        }
+        if (obj instanceof Set) {
+          return Array.from(obj.values(), item => sanitize(item, depth - 1));
+        }
+        const result: Record<string, unknown> = {};
+        for (const [key, val] of Object.entries(obj)) {
+          result[key] = sanitize(val, depth - 1);
+        }
+        return result;
+      } finally {
+        ancestors.delete(obj as object);
       }
-      return result;
     }
     return String(obj);
   };
 
   try {
-    return JSON.stringify(sanitize(value, maxDepth));
+    if (value === undefined) return JSON.stringify('undefined');
+    const serialized = JSON.stringify(sanitize(value, maxDepth));
+    return serialized === undefined ? JSON.stringify('undefined') : serialized;
   } catch {
-    return String(value);
+    return JSON.stringify('[Unserializable]');
+  }
+}
+
+export function toToolAttributeValue(value: unknown): string | number | boolean | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return 'null';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value;
+  const encodedBinary = binaryToBase64(value);
+  return encodedBinary ?? serializeToJson(value);
+}
+
+export function contentToParts(content: unknown): Array<Record<string, unknown>> {
+  try {
+    if (typeof content === 'string') {
+      return content ? [{ type: 'text', content }] : [];
+    }
+
+    const blocks = Array.isArray(content) ? content : isRecord(content) ? [content] : [];
+    if (blocks.length === 0) {
+      return content === null || content === undefined ? [] : [{ type: 'text', content: String(content) }];
+    }
+
+    return blocks.flatMap(contentBlockToParts);
+  } catch {
+    return [{ type: 'text', content: '[Unserializable]' }];
+  }
+}
+
+function contentBlockToParts(block: unknown): Array<Record<string, unknown>> {
+  if (typeof block === 'string') {
+    return block ? [{ type: 'text', content: block }] : [];
+  }
+  if (!isRecord(block)) {
+    return [{ type: 'text', content: String(block) }];
+  }
+
+  const blockType = typeof block.type === 'string' ? block.type : '';
+  if (['text', 'input_text', 'output_text'].includes(blockType)) {
+    const text = block.text ?? block.content;
+    return text === null || text === undefined || text === '' ? [] : [{ type: 'text', content: String(text) }];
+  }
+
+  if (['thinking', 'reasoning', 'reasoning_text', 'summary_text'].includes(blockType)) {
+    const reasoning = block.thinking ?? block.reasoning ?? block.text ?? block.content;
+    return reasoning === null || reasoning === undefined || reasoning === ''
+      ? []
+      : [{ type: 'reasoning', content: String(reasoning) }];
+  }
+
+  if (blockType === 'text-plain' && typeof block.text === 'string') {
+    return [
+      copySelectedFields(
+        { type: 'text', content: block.text },
+        [block],
+        ['title', 'context', 'providerMetadata', 'providerOptions', 'providerData', 'metadata']
+      ),
+    ];
+  }
+
+  const modality = mediaModality(blockType);
+  if (modality) {
+    const mediaPart = imageContentToPart(block, modality);
+    return mediaPart ? [mediaPart] : [{ ...block, type: blockType }];
+  }
+
+  if (blockType === 'tool-call' || blockType === 'tool_call' || blockType === 'tool_use') {
+    const args = block.args ?? block.arguments ?? block.input ?? {};
+    return [
+      {
+        type: 'tool_call',
+        id: block.toolCallId ?? block.id ?? null,
+        name: block.toolName ?? block.name ?? '',
+        arguments: typeof args === 'string' ? tryParseJson(args) : args,
+      },
+    ];
+  }
+
+  if (blockType === 'tool-result' || blockType === 'tool_call_response') {
+    return [
+      {
+        type: 'tool_call_response',
+        id: block.toolCallId ?? block.id ?? null,
+        response: block.result ?? block.response ?? block.output ?? '',
+      },
+    ];
+  }
+
+  if (!blockType) {
+    return [{ ...block, type: 'unknown' }];
+  }
+  return [{ ...block, type: blockType }];
+}
+
+function imageContentToPart(block: Record<string, unknown>, modality: string): Record<string, unknown> | undefined {
+  try {
+    return imageContentToPartUnsafe(block, modality);
+  } catch {
+    return undefined;
+  }
+}
+
+function imageContentToPartUnsafe(
+  block: Record<string, unknown>,
+  modality: string
+): Record<string, unknown> | undefined {
+  const source = isRecord(block.source) ? block.source : undefined;
+  const inputAudio = isRecord(block.input_audio) ? block.input_audio : undefined;
+  const primary = getPrimaryMediaValue(block);
+  const primaryRecord = isRecord(primary) ? primary : undefined;
+  const sources = [block, primaryRecord, inputAudio, source].filter(isRecord);
+  const mimeType = getMimeType(sources, modality);
+
+  const fileId = getFileId(block, primaryRecord, source);
+  if (fileId) {
+    return withMediaMetadata(withOptionalMimeType({ type: 'file', modality, file_id: fileId }, mimeType), sources);
+  }
+
+  const explicitUrl = block.image_url ?? block.file_url ?? block.url ?? primaryRecord?.url ?? source?.url;
+  const uriPart = buildAutoMediaPart(explicitUrl, modality, mimeType, sources, false);
+  if (uriPart) return uriPart;
+
+  const base64Data = block.file_data ?? inputAudio?.data ?? primaryRecord?.data ?? block.data ?? source?.data;
+  const base64Part = buildBase64MediaPart(base64Data, modality, mimeType, sources);
+  if (base64Part) return base64Part;
+
+  return buildAutoMediaPart(primary, modality, mimeType, sources, true);
+}
+
+function mediaModality(blockType: string): string | undefined {
+  switch (blockType) {
+    case 'image':
+    case 'image_url':
+    case 'input_image':
+    case 'output_image':
+      return 'image';
+    case 'audio':
+    case 'input_audio':
+      return 'audio';
+    case 'video':
+      return 'video';
+    case 'file':
+    case 'input_file':
+      return 'document';
+    case 'text-plain':
+      return 'text';
+    default:
+      return undefined;
+  }
+}
+
+function getPrimaryMediaValue(block: Record<string, unknown>): unknown {
+  switch (block.type) {
+    case 'image':
+    case 'input_image':
+    case 'output_image':
+      return block.image;
+    case 'audio':
+      return block.audio;
+    case 'input_file':
+    case 'file':
+      return block.file;
+    default:
+      return undefined;
+  }
+}
+
+function getFileId(
+  block: Record<string, unknown>,
+  primary: Record<string, unknown> | undefined,
+  source: Record<string, unknown> | undefined
+): string | undefined {
+  const directId = block.fileId ?? block.file_id;
+  if (typeof directId === 'string' && directId) return directId;
+  if (typeof primary?.id === 'string' && primary.id) return primary.id;
+  if (typeof primary?.fileId === 'string' && primary.fileId) return primary.fileId;
+  if (typeof source?.fileId === 'string' && source.fileId) return source.fileId;
+  if (source && (source.type === 'id' || source.source_type === 'id') && typeof source.id === 'string' && source.id) {
+    return source.id;
+  }
+  if (block.source_type === 'id' && typeof block.id === 'string' && block.id) return block.id;
+  return undefined;
+}
+
+function buildAutoMediaPart(
+  value: unknown,
+  modality: string,
+  mimeType: string | undefined,
+  sources: Record<string, unknown>[],
+  allowBase64: boolean
+): Record<string, unknown> | undefined {
+  if (isRecord(value)) {
+    if (typeof value.id === 'string' && value.id) {
+      return withMediaMetadata(withOptionalMimeType({ type: 'file', modality, file_id: value.id }, mimeType), [
+        ...sources,
+        value,
+      ]);
+    }
+    if (value.url !== undefined) {
+      return buildAutoMediaPart(value.url, modality, mimeType, [...sources, value], false);
+    }
+    if (value.data !== undefined) {
+      return buildBase64MediaPart(value.data, modality, mimeType, [...sources, value]);
+    }
+  }
+  if (value instanceof URL) {
+    return buildUriOrDataUrlPart(value.toString(), modality, mimeType, sources);
+  }
+  if (typeof value === 'string') {
+    if (!value) return undefined;
+    if (value.toLowerCase().startsWith('data:') || looksLikeUri(value)) {
+      return buildUriOrDataUrlPart(value, modality, mimeType, sources);
+    }
+    return allowBase64 ? buildBlobPart(value, modality, mimeType, sources) : undefined;
+  }
+  const encodedBinary = binaryToBase64(value);
+  return encodedBinary === undefined ? undefined : buildBlobPart(encodedBinary, modality, mimeType, sources);
+}
+
+function buildBase64MediaPart(
+  value: unknown,
+  modality: string,
+  mimeType: string | undefined,
+  sources: Record<string, unknown>[]
+): Record<string, unknown> | undefined {
+  if (value instanceof URL) {
+    return buildUriOrDataUrlPart(value.toString(), modality, mimeType, sources);
+  }
+  if (typeof value === 'string') {
+    return value ? buildBlobPart(value, modality, mimeType, sources) : undefined;
+  }
+  const encodedBinary = binaryToBase64(value);
+  return encodedBinary === undefined ? undefined : buildBlobPart(encodedBinary, modality, mimeType, sources);
+}
+
+function buildUriOrDataUrlPart(
+  value: string,
+  modality: string,
+  mimeType: string | undefined,
+  sources: Record<string, unknown>[]
+): Record<string, unknown> {
+  const dataUrl = parseDataUrl(value);
+  if (dataUrl) {
+    const content = dataUrl.isBase64
+      ? Buffer.from(dataUrl.data, 'base64').toString('base64')
+      : percentEncodedDataToBuffer(dataUrl.data).toString('base64');
+    return buildBlobPart(content, modality, dataUrl.mimeType ?? mimeType, sources);
+  }
+  return withMediaMetadata(withOptionalMimeType({ type: 'uri', modality, uri: value }, mimeType), sources);
+}
+
+function buildBlobPart(
+  content: string,
+  modality: string,
+  mimeType: string | undefined,
+  sources: Record<string, unknown>[]
+): Record<string, unknown> {
+  return withMediaMetadata(
+    withOptionalMimeType(
+      {
+        type: 'blob',
+        modality,
+        content,
+      },
+      mimeType ?? defaultMimeType(modality)
+    ),
+    sources
+  );
+}
+
+function parseDataUrl(value: string): { mimeType?: string; data: string; isBase64: boolean } | undefined {
+  if (!value.toLowerCase().startsWith('data:')) return undefined;
+  const commaIndex = value.indexOf(',');
+  const header = commaIndex >= 0 ? value.slice(5, commaIndex) : value.slice(5);
+  const data = commaIndex >= 0 ? value.slice(commaIndex + 1) : '';
+  const tokens = header.split(';');
+  const mimeType = tokens[0] || undefined;
+  return {
+    mimeType,
+    data,
+    isBase64: tokens.slice(1).some(token => token.toLowerCase() === 'base64'),
+  };
+}
+
+function percentEncodedDataToBuffer(value: string): Buffer {
+  const chunks: Buffer[] = [];
+  let literalStart = 0;
+  for (let index = 0; index < value.length; index++) {
+    if (value[index] !== '%' || !/^[0-9a-fA-F]{2}$/.test(value.slice(index + 1, index + 3))) continue;
+    if (literalStart < index) chunks.push(Buffer.from(value.slice(literalStart, index), 'utf8'));
+    chunks.push(Buffer.from([parseInt(value.slice(index + 1, index + 3), 16)]));
+    index += 2;
+    literalStart = index + 1;
+  }
+  if (literalStart < value.length) chunks.push(Buffer.from(value.slice(literalStart), 'utf8'));
+  return Buffer.concat(chunks);
+}
+
+function looksLikeUri(value: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value);
+}
+
+function getMimeType(sources: Record<string, unknown>[], modality: string): string | undefined {
+  for (const source of sources) {
+    const mimeType = source.mimeType ?? source.mediaType ?? source.media_type ?? source.mime_type;
+    if (typeof mimeType === 'string' && mimeType) return mimeType;
+  }
+  for (const source of sources) {
+    if (typeof source.format === 'string' && source.format) {
+      return modality === 'audio' ? `audio/${source.format}` : source.format;
+    }
+  }
+  return undefined;
+}
+
+function defaultMimeType(modality: string): string | undefined {
+  switch (modality) {
+    case 'image':
+      return 'image/*';
+    case 'audio':
+      return 'audio/*';
+    case 'video':
+      return 'video/*';
+    case 'document':
+      return 'application/octet-stream';
+    case 'text':
+      return 'text/plain';
+    default:
+      return undefined;
+  }
+}
+
+function withOptionalMimeType(part: Record<string, unknown>, mimeType: string | undefined): Record<string, unknown> {
+  return mimeType ? { ...part, mime_type: mimeType } : part;
+}
+
+function withMediaMetadata(part: Record<string, unknown>, sources: Record<string, unknown>[]): Record<string, unknown> {
+  return copySelectedFields(part, sources, [
+    'filename',
+    'transcript',
+    'format',
+    'title',
+    'context',
+    'detail',
+    'providerMetadata',
+    'providerOptions',
+    'providerData',
+    'metadata',
+  ]);
+}
+
+function copySelectedFields(
+  target: Record<string, unknown>,
+  sources: Record<string, unknown>[],
+  fields: string[]
+): Record<string, unknown> {
+  const result = { ...target };
+  for (const source of sources) {
+    for (const field of fields) {
+      if (result[field] === undefined && source[field] !== undefined) {
+        result[field] = source[field];
+      }
+    }
+  }
+  return result;
+}
+
+function binaryToBase64(value: unknown): string | undefined {
+  if (Buffer.isBuffer(value)) {
+    return value.toString('base64');
+  }
+  if (value instanceof ArrayBuffer) {
+    return Buffer.from(new Uint8Array(value)).toString('base64');
+  }
+  if (ArrayBuffer.isView(value)) {
+    return Buffer.from(new Uint8Array(value.buffer, value.byteOffset, value.byteLength)).toString('base64');
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function normalizeFinishReason(reason: string): string {
+  switch (reason) {
+    case 'stop':
+    case 'STOP':
+    case 'end_turn':
+    case 'stop_sequence':
+    case 'STOP_SEQUENCE':
+    case 'COMPLETE':
+      return 'stop';
+    case 'length':
+    case 'max_tokens':
+    case 'MAX_TOKENS':
+    case 'ERROR_LIMIT':
+    case 'max_output_tokens':
+      return 'length';
+    case 'content_filter':
+    case 'content_filtered':
+    case 'content-filter':
+    case 'SAFETY':
+    case 'RECITATION':
+    case 'ERROR_TOXIC':
+    case 'refusal':
+      return 'content_filter';
+    case 'tool_use':
+    case 'tool_calls':
+    case 'function_call':
+    case 'TOOL_CALL':
+    case 'tool-calls':
+      return 'tool_call';
+    case 'error':
+    case 'ERROR':
+    case 'TIMEOUT':
+    case 'failed':
+      return 'error';
+    default:
+      return reason;
   }
 }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/common/instrumentation-utils.ts
@@ -102,7 +102,6 @@ export function toToolAttributeValue(value: unknown): string | number | boolean 
   }
 }
 
-// Keep this aligned with AWS OTel Python's content_to_parts contract.
 export function contentToParts(content: unknown): Array<Record<string, unknown>> {
   if (typeof content === 'string') {
     return content ? [{ type: 'text', content }] : [];
@@ -141,9 +140,11 @@ export function contentToParts(content: unknown): Array<Record<string, unknown>>
       const imageUrl = isRecord(block.image_url) ? block.image_url.url : undefined;
       if (typeof imageUrl !== 'string' || !imageUrl) continue;
       if (imageUrl.startsWith('data:')) {
-        const commaIndex = imageUrl.indexOf(',');
-        const header = commaIndex >= 0 ? imageUrl.slice(5, commaIndex) : imageUrl.slice(5);
-        const data = commaIndex >= 0 ? imageUrl.slice(commaIndex + 1) : '';
+        // https://www.rfc-editor.org/rfc/rfc2397#section-3
+        const payload = imageUrl.slice('data:'.length);
+        const commaIndex = payload.indexOf(',');
+        const header = commaIndex >= 0 ? payload.slice(0, commaIndex) : payload;
+        const data = commaIndex >= 0 ? payload.slice(commaIndex + 1) : '';
         parts.push({
           type: 'blob',
           modality: 'image',

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
@@ -293,7 +293,7 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
         this._setAttribute(
           entry.span,
           ATTR_GEN_AI_TOOL_CALL_RESULT,
-          toToolAttributeValue(OpenTelemetryCallbackHandler._semanticToolOutput(output))
+          toToolAttributeValue(OpenTelemetryCallbackHandler._extractToolResult(output))
         );
       }
     }
@@ -696,8 +696,8 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
   }
 
   private static _messageContentParts(message: BaseMessage): Array<Record<string, unknown>> {
-    // Provider translators can omit normalized tool_calls from contentBlocks
-    // (notably Bedrock Converse), while other providers expose them in both.
+    // Provider translators, notably Bedrock Converse, can omit normalized
+    // tool_calls from contentBlocks, while other providers expose them in both.
     // Convert both sources through the shared helper and collapse duplicates.
     const parts = contentToParts([...message.contentBlocks, ...(isAIMessage(message) ? message.tool_calls ?? [] : [])]);
     const seen = new Set<string>();
@@ -710,7 +710,7 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
     });
   }
 
-  private static _semanticToolOutput(output: unknown): unknown {
+  private static _extractToolResult(output: unknown): unknown {
     if (!ToolMessage.isInstance(output)) return output;
     const semantic: Record<string, unknown> = {
       content: output.content,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
@@ -696,24 +696,10 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
   }
 
   private static _messageContentParts(message: BaseMessage): Array<Record<string, unknown>> {
-    const blocks = [...message.contentBlocks];
-    if (isAIMessage(message) && message.tool_calls) {
-      for (const toolCall of message.tool_calls) {
-        const alreadyPresent = blocks.some(block => block.id === toolCall.id && block.name === toolCall.name);
-        if (!alreadyPresent) {
-          blocks.push({
-            type: 'tool_call',
-            id: toolCall.id,
-            name: toolCall.name,
-            args: toolCall.args,
-          });
-        }
-      }
-    }
-    return OpenTelemetryCallbackHandler._dedupeToolCalls(contentToParts(blocks));
-  }
-
-  private static _dedupeToolCalls(parts: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+    // Provider translators can omit normalized tool_calls from contentBlocks
+    // (notably Bedrock Converse), while other providers expose them in both.
+    // Convert both sources through the shared helper and collapse duplicates.
+    const parts = contentToParts([...message.contentBlocks, ...(isAIMessage(message) ? message.tool_calls ?? [] : [])]);
     const seen = new Set<string>();
     return parts.filter(part => {
       if (part.type !== 'tool_call') return true;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
@@ -33,19 +33,14 @@ import {
   GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT,
   GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
 } from '../common/semconv';
-import {
-  contentToParts,
-  normalizeFinishReason,
-  PROVIDER_MAP,
-  serializeToJson,
-  toToolAttributeValue,
-} from '../common/instrumentation-utils';
+import { contentToParts, PROVIDER_MAP, serializeToJson, toToolAttributeValue } from '../common/instrumentation-utils';
 import type { Serialized } from '@langchain/core/load/serializable';
 import type { ChatGeneration, Generation, LLMResult } from '@langchain/core/outputs';
 import type { ChainValues } from '@langchain/core/utils/types';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { ToolCall } from '@langchain/core/messages/tool';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
-import { isAIMessage, ToolMessage } from '@langchain/core/messages';
+import { isAIMessage } from '@langchain/core/messages';
 
 const LANGGRAPH_STEP_SPAN_ATTR = 'langgraph.step';
 const LANGGRAPH_NODE_SPAN_ATTR = 'langgraph.node';
@@ -290,11 +285,8 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
     if (this.captureMessageContent) {
       const entry = this.runIdToSpanMap.get(runId);
       if (entry?.span) {
-        this._setAttribute(
-          entry.span,
-          ATTR_GEN_AI_TOOL_CALL_RESULT,
-          toToolAttributeValue(OpenTelemetryCallbackHandler._extractToolResult(output))
-        );
+        const content = output && typeof output === 'object' && 'content' in output ? output.content : output;
+        this._setAttribute(entry.span, ATTR_GEN_AI_TOOL_CALL_RESULT, toToolAttributeValue(content));
       }
     }
     this._endSpan(runId);
@@ -666,16 +658,16 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
   }
 
   private static _extractFinishReason(generation: Generation): string | undefined {
-    const message = 'message' in generation ? (generation as ChatGeneration).message : undefined;
-    const metadata = (message?.response_metadata ?? {}) as Record<string, unknown>;
+    if (!('message' in generation)) return undefined;
+    const message = (generation as ChatGeneration).message;
+    const metadata = (message.response_metadata ?? {}) as Record<string, unknown>;
     const rawReason =
       generation.generationInfo?.finish_reason ??
-      generation.generationInfo?.finishReason ??
       metadata.finish_reason ??
       metadata.stop_reason ??
       metadata.stopReason ??
       metadata.finishReason;
-    return typeof rawReason === 'string' ? normalizeFinishReason(rawReason) : undefined;
+    return typeof rawReason === 'string' ? OpenTelemetryCallbackHandler._normalizeFinishReason(rawReason) : undefined;
   }
 
   private static _normalizeRole(messageType: string): string {
@@ -696,32 +688,54 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
   }
 
   private static _toOtelMessageParts(message: BaseMessage): Array<Record<string, unknown>> {
-    // Provider translators, notably Bedrock Converse, can omit normalized
-    // tool_calls from contentBlocks, while other providers expose them in both.
-    // Convert both sources through the shared helper and collapse duplicates.
-    const parts = contentToParts([...message.contentBlocks, ...(isAIMessage(message) ? message.tool_calls ?? [] : [])]);
-    const seen = new Set<string>();
-    return parts.filter(part => {
-      if (part.type !== 'tool_call') return true;
-      const key = `${String(part.id ?? '')}:${String(part.name ?? '')}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
+    const contentBlocks = message.contentBlocks.map(block => {
+      if (block.type !== 'image') return block;
+      if ('url' in block && typeof block.url === 'string') {
+        return { type: 'image_url', image_url: { url: block.url } };
+      }
+      return { ...block, mime_type: block.mime_type ?? block.mimeType };
     });
+    const contentParts = contentToParts(contentBlocks).filter(
+      part => part.type !== 'tool_call' && part.type !== 'tool-call' && part.type !== 'tool_use'
+    );
+    const toolCallParts = isAIMessage(message)
+      ? (message.tool_calls ?? []).map((toolCall: ToolCall) => ({
+          type: 'tool_call',
+          id: toolCall.id ?? '',
+          name: toolCall.name,
+          arguments: toolCall.args,
+        }))
+      : [];
+    return [...contentParts, ...toolCallParts];
   }
 
-  private static _extractToolResult(output: unknown): unknown {
-    if (!ToolMessage.isInstance(output)) return output;
-    const semantic: Record<string, unknown> = {
-      content: output.content,
-      tool_call_id: output.tool_call_id,
-    };
-    for (const field of ['artifact', 'status', 'name', 'metadata'] as const) {
-      if (output[field] !== undefined) {
-        semantic[field] = output[field];
-      }
+  private static _normalizeFinishReason(raw: string): string {
+    switch (raw) {
+      case 'stop':
+      case 'end_turn':
+      case 'STOP':
+      case 'COMPLETE':
+        return 'stop';
+      case 'length':
+      case 'max_tokens':
+      case 'MAX_TOKENS':
+      case 'ERROR_LIMIT':
+        return 'length';
+      case 'content_filter':
+      case 'SAFETY':
+      case 'RECITATION':
+      case 'ERROR_TOXIC':
+        return 'content_filter';
+      case 'tool_use':
+      case 'tool_calls':
+      case 'function_call':
+        return 'tool_call';
+      case 'error':
+      case 'ERROR':
+        return 'error';
+      default:
+        return raw;
     }
-    return semantic;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
@@ -33,14 +33,19 @@ import {
   GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT,
   GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
 } from '../common/semconv';
-import { PROVIDER_MAP, serializeToJson } from '../common/instrumentation-utils';
+import {
+  contentToParts,
+  normalizeFinishReason,
+  PROVIDER_MAP,
+  serializeToJson,
+  toToolAttributeValue,
+} from '../common/instrumentation-utils';
 import type { Serialized } from '@langchain/core/load/serializable';
 import type { ChatGeneration, Generation, LLMResult } from '@langchain/core/outputs';
 import type { ChainValues } from '@langchain/core/utils/types';
 import type { BaseMessage } from '@langchain/core/messages';
-import type { ToolCall } from '@langchain/core/messages/tool';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
-import { isAIMessage } from '@langchain/core/messages';
+import { isAIMessage, ToolMessage } from '@langchain/core/messages';
 
 const LANGGRAPH_STEP_SPAN_ATTR = 'langgraph.step';
 const LANGGRAPH_NODE_SPAN_ATTR = 'langgraph.node';
@@ -277,7 +282,7 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
     this._setAttribute(span, ATTR_GEN_AI_TOOL_TYPE, 'function');
     this._setAttribute(span, ATTR_GEN_AI_TOOL_CALL_ID, toolCallId);
     if (this.captureMessageContent) {
-      this._setAttribute(span, ATTR_GEN_AI_TOOL_CALL_ARGUMENTS, input);
+      this._setAttribute(span, ATTR_GEN_AI_TOOL_CALL_ARGUMENTS, toToolAttributeValue(input));
     }
   }
 
@@ -285,9 +290,11 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
     if (this.captureMessageContent) {
       const entry = this.runIdToSpanMap.get(runId);
       if (entry?.span) {
-        const content = output && typeof output === 'object' && 'content' in output ? output.content : output;
-        const outputStr = typeof content === 'string' ? content : serializeToJson(content);
-        this._setAttribute(entry.span, ATTR_GEN_AI_TOOL_CALL_RESULT, outputStr);
+        this._setAttribute(
+          entry.span,
+          ATTR_GEN_AI_TOOL_CALL_RESULT,
+          toToolAttributeValue(OpenTelemetryCallbackHandler._semanticToolOutput(output))
+        );
       }
     }
     this._endSpan(runId);
@@ -555,10 +562,10 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
   //       ] },
   //     ]
   private static _formatMessages(messages: BaseMessage[][]): {
-    systemInstructions: Array<{ type: string; content: string }>;
+    systemInstructions: Array<Record<string, unknown>>;
     conversation: Array<{ role: string; parts: Array<Record<string, unknown>> }>;
   } {
-    const systemInstructions: Array<{ type: string; content: string }> = [];
+    const systemInstructions: Array<Record<string, unknown>> = [];
     const conversation: Array<{ role: string; parts: Array<Record<string, unknown>> }> = [];
 
     for (const messageGroup of messages) {
@@ -566,37 +573,26 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
         const messageType = message.getType();
         const role = OpenTelemetryCallbackHandler._normalizeRole(messageType);
         const parts: Array<Record<string, unknown>> = [];
-
-        const textContent = OpenTelemetryCallbackHandler._extractTextContent(message.content);
-
         const isToolMessage = role === 'tool' && 'tool_call_id' in message && message.tool_call_id;
 
-        if (textContent && !isToolMessage) {
-          parts.push({ type: 'text', content: textContent });
+        if (role === 'system') {
+          systemInstructions.push(...OpenTelemetryCallbackHandler._messageContentParts(message));
+          continue;
         }
 
-        if (isAIMessage(message) && message.tool_calls) {
-          for (const toolCall of message.tool_calls as ToolCall[]) {
-            parts.push({
-              type: 'tool_call',
-              id: toolCall.id ?? '',
-              name: toolCall.name,
-              arguments: toolCall.args,
-            });
-          }
+        if (!isToolMessage) {
+          parts.push(...OpenTelemetryCallbackHandler._messageContentParts(message));
         }
 
         if (isToolMessage) {
           parts.push({
             type: 'tool_call_response',
             id: message.tool_call_id,
-            response: textContent,
+            response: message.content ?? '',
           });
         }
 
-        if (role === 'system') {
-          systemInstructions.push({ type: 'text', content: textContent });
-        } else if (parts.length > 0) {
+        if (parts.length > 0) {
           conversation.push({ role, parts });
         }
       }
@@ -635,29 +631,14 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
 
         if ('message' in generation) {
           const message = (generation as ChatGeneration).message;
-
-          const textContent = OpenTelemetryCallbackHandler._extractTextContent(message.content);
-
-          if (textContent) {
-            parts.push({ type: 'text', content: textContent });
-          }
-
-          if (isAIMessage(message) && message.tool_calls) {
-            for (const toolCall of message.tool_calls as ToolCall[]) {
-              parts.push({
-                type: 'tool_call',
-                id: toolCall.id ?? '',
-                name: toolCall.name,
-                arguments: toolCall.args,
-              });
-            }
-          }
+          parts.push(...OpenTelemetryCallbackHandler._messageContentParts(message));
 
           finishReason = OpenTelemetryCallbackHandler._extractFinishReason(generation);
         } else {
           if (generation.text) {
             parts.push({ type: 'text', content: generation.text });
           }
+          finishReason = OpenTelemetryCallbackHandler._extractFinishReason(generation);
         }
 
         if (parts.length > 0) {
@@ -673,20 +654,6 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
     return outputMessages;
   }
 
-  private static _extractTextContent(content: BaseMessage['content']): string {
-    if (typeof content === 'string') return content;
-    if (Array.isArray(content)) {
-      return content
-        .filter(
-          (block): block is { type: 'text'; text: string } =>
-            typeof block === 'object' && block !== null && 'type' in block && block.type === 'text'
-        )
-        .map(block => block.text)
-        .join('');
-    }
-    return '';
-  }
-
   private static _extractFinishReasons(response: LLMResult): string[] {
     const reasons: string[] = [];
     for (const generationGroup of response.generations) {
@@ -699,16 +666,16 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
   }
 
   private static _extractFinishReason(generation: Generation): string | undefined {
-    if (!('message' in generation)) return undefined;
-    const message = (generation as ChatGeneration).message;
-    const metadata = (message.response_metadata ?? {}) as Record<string, unknown>;
+    const message = 'message' in generation ? (generation as ChatGeneration).message : undefined;
+    const metadata = (message?.response_metadata ?? {}) as Record<string, unknown>;
     const rawReason =
       generation.generationInfo?.finish_reason ??
+      generation.generationInfo?.finishReason ??
       metadata.finish_reason ??
       metadata.stop_reason ??
       metadata.stopReason ??
       metadata.finishReason;
-    return typeof rawReason === 'string' ? OpenTelemetryCallbackHandler._normalizeFinishReason(rawReason) : undefined;
+    return typeof rawReason === 'string' ? normalizeFinishReason(rawReason) : undefined;
   }
 
   private static _normalizeRole(messageType: string): string {
@@ -728,33 +695,47 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
     }
   }
 
-  private static _normalizeFinishReason(raw: string): string {
-    switch (raw) {
-      case 'stop':
-      case 'end_turn':
-      case 'STOP':
-      case 'COMPLETE':
-        return 'stop';
-      case 'length':
-      case 'max_tokens':
-      case 'MAX_TOKENS':
-      case 'ERROR_LIMIT':
-        return 'length';
-      case 'content_filter':
-      case 'SAFETY':
-      case 'RECITATION':
-      case 'ERROR_TOXIC':
-        return 'content_filter';
-      case 'tool_use':
-      case 'tool_calls':
-      case 'function_call':
-        return 'tool_call';
-      case 'error':
-      case 'ERROR':
-        return 'error';
-      default:
-        return raw;
+  private static _messageContentParts(message: BaseMessage): Array<Record<string, unknown>> {
+    const blocks = [...message.contentBlocks];
+    if (isAIMessage(message) && message.tool_calls) {
+      for (const toolCall of message.tool_calls) {
+        const alreadyPresent = blocks.some(block => block.id === toolCall.id && block.name === toolCall.name);
+        if (!alreadyPresent) {
+          blocks.push({
+            type: 'tool_call',
+            id: toolCall.id,
+            name: toolCall.name,
+            args: toolCall.args,
+          });
+        }
+      }
     }
+    return OpenTelemetryCallbackHandler._dedupeToolCalls(contentToParts(blocks));
+  }
+
+  private static _dedupeToolCalls(parts: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+    const seen = new Set<string>();
+    return parts.filter(part => {
+      if (part.type !== 'tool_call') return true;
+      const key = `${String(part.id ?? '')}:${String(part.name ?? '')}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+
+  private static _semanticToolOutput(output: unknown): unknown {
+    if (!ToolMessage.isInstance(output)) return output;
+    const semantic: Record<string, unknown> = {
+      content: output.content,
+      tool_call_id: output.tool_call_id,
+    };
+    for (const field of ['artifact', 'status', 'name', 'metadata'] as const) {
+      if (output[field] !== undefined) {
+        semantic[field] = output[field];
+      }
+    }
+    return semantic;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
@@ -568,12 +568,12 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
         const isToolMessage = role === 'tool' && 'tool_call_id' in message && message.tool_call_id;
 
         if (role === 'system') {
-          systemInstructions.push(...OpenTelemetryCallbackHandler._toOtelMessageParts(message));
+          systemInstructions.push(...OpenTelemetryCallbackHandler._contentToParts(message));
           continue;
         }
 
         if (!isToolMessage) {
-          parts.push(...OpenTelemetryCallbackHandler._toOtelMessageParts(message));
+          parts.push(...OpenTelemetryCallbackHandler._contentToParts(message));
         }
 
         if (isToolMessage) {
@@ -623,7 +623,7 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
 
         if ('message' in generation) {
           const message = (generation as ChatGeneration).message;
-          parts.push(...OpenTelemetryCallbackHandler._toOtelMessageParts(message));
+          parts.push(...OpenTelemetryCallbackHandler._contentToParts(message));
 
           finishReason = OpenTelemetryCallbackHandler._extractFinishReason(generation);
         } else {
@@ -687,7 +687,7 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
     }
   }
 
-  private static _toOtelMessageParts(message: BaseMessage): Array<Record<string, unknown>> {
+  private static _contentToParts(message: BaseMessage): Array<Record<string, unknown>> {
     const contentBlocks = message.contentBlocks.map(block => {
       if (block.type !== 'image') return block;
       if ('url' in block && typeof block.url === 'string') {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
@@ -688,29 +688,25 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
   }
 
   private static _formatMessageParts(message: BaseMessage): Array<Record<string, unknown>> {
-    try {
-      const contentBlocks = message.contentBlocks.map(block => {
-        if (block.type !== 'image') return block;
-        if ('url' in block && typeof block.url === 'string') {
-          return { type: 'image_url', image_url: { url: block.url } };
-        }
-        return { ...block, mime_type: block.mime_type ?? block.mimeType };
-      });
-      const contentParts = contentToParts(contentBlocks).filter(
-        part => part.type !== 'tool_call' && part.type !== 'tool-call' && part.type !== 'tool_use'
-      );
-      const toolCallParts = isAIMessage(message)
-        ? (message.tool_calls ?? []).map((toolCall: ToolCall) => ({
-            type: 'tool_call',
-            id: toolCall.id ?? '',
-            name: toolCall.name,
-            arguments: toolCall.args,
-          }))
-        : [];
-      return [...contentParts, ...toolCallParts];
-    } catch {
-      return [];
-    }
+    const contentBlocks = message.contentBlocks.map(block => {
+      if (block.type !== 'image') return block;
+      if ('url' in block && typeof block.url === 'string') {
+        return { type: 'image_url', image_url: { url: block.url } };
+      }
+      return { ...block, mime_type: block.mime_type ?? block.mimeType };
+    });
+    const contentParts = contentToParts(contentBlocks).filter(
+      part => part.type !== 'tool_call' && part.type !== 'tool-call' && part.type !== 'tool_use'
+    );
+    const toolCallParts = isAIMessage(message)
+      ? (message.tool_calls ?? []).map((toolCall: ToolCall) => ({
+          type: 'tool_call',
+          id: toolCall.id ?? '',
+          name: toolCall.name,
+          arguments: toolCall.args,
+        }))
+      : [];
+    return [...contentParts, ...toolCallParts];
   }
 
   private static _normalizeFinishReason(raw: string): string {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
@@ -568,12 +568,12 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
         const isToolMessage = role === 'tool' && 'tool_call_id' in message && message.tool_call_id;
 
         if (role === 'system') {
-          systemInstructions.push(...OpenTelemetryCallbackHandler._contentToParts(message));
+          systemInstructions.push(...OpenTelemetryCallbackHandler._formatMessageParts(message));
           continue;
         }
 
         if (!isToolMessage) {
-          parts.push(...OpenTelemetryCallbackHandler._contentToParts(message));
+          parts.push(...OpenTelemetryCallbackHandler._formatMessageParts(message));
         }
 
         if (isToolMessage) {
@@ -623,7 +623,7 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
 
         if ('message' in generation) {
           const message = (generation as ChatGeneration).message;
-          parts.push(...OpenTelemetryCallbackHandler._contentToParts(message));
+          parts.push(...OpenTelemetryCallbackHandler._formatMessageParts(message));
 
           finishReason = OpenTelemetryCallbackHandler._extractFinishReason(generation);
         } else {
@@ -687,7 +687,7 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
     }
   }
 
-  private static _contentToParts(message: BaseMessage): Array<Record<string, unknown>> {
+  private static _formatMessageParts(message: BaseMessage): Array<Record<string, unknown>> {
     const contentBlocks = message.contentBlocks.map(block => {
       if (block.type !== 'image') return block;
       if ('url' in block && typeof block.url === 'string') {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
@@ -688,25 +688,29 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
   }
 
   private static _formatMessageParts(message: BaseMessage): Array<Record<string, unknown>> {
-    const contentBlocks = message.contentBlocks.map(block => {
-      if (block.type !== 'image') return block;
-      if ('url' in block && typeof block.url === 'string') {
-        return { type: 'image_url', image_url: { url: block.url } };
-      }
-      return { ...block, mime_type: block.mime_type ?? block.mimeType };
-    });
-    const contentParts = contentToParts(contentBlocks).filter(
-      part => part.type !== 'tool_call' && part.type !== 'tool-call' && part.type !== 'tool_use'
-    );
-    const toolCallParts = isAIMessage(message)
-      ? (message.tool_calls ?? []).map((toolCall: ToolCall) => ({
-          type: 'tool_call',
-          id: toolCall.id ?? '',
-          name: toolCall.name,
-          arguments: toolCall.args,
-        }))
-      : [];
-    return [...contentParts, ...toolCallParts];
+    try {
+      const contentBlocks = message.contentBlocks.map(block => {
+        if (block.type !== 'image') return block;
+        if ('url' in block && typeof block.url === 'string') {
+          return { type: 'image_url', image_url: { url: block.url } };
+        }
+        return { ...block, mime_type: block.mime_type ?? block.mimeType };
+      });
+      const contentParts = contentToParts(contentBlocks).filter(
+        part => part.type !== 'tool_call' && part.type !== 'tool-call' && part.type !== 'tool_use'
+      );
+      const toolCallParts = isAIMessage(message)
+        ? (message.tool_calls ?? []).map((toolCall: ToolCall) => ({
+            type: 'tool_call',
+            id: toolCall.id ?? '',
+            name: toolCall.name,
+            arguments: toolCall.args,
+          }))
+        : [];
+      return [...contentParts, ...toolCallParts];
+    } catch {
+      return [];
+    }
   }
 
   private static _normalizeFinishReason(raw: string): string {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/callback-handler.ts
@@ -576,12 +576,12 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
         const isToolMessage = role === 'tool' && 'tool_call_id' in message && message.tool_call_id;
 
         if (role === 'system') {
-          systemInstructions.push(...OpenTelemetryCallbackHandler._messageContentParts(message));
+          systemInstructions.push(...OpenTelemetryCallbackHandler._toOtelMessageParts(message));
           continue;
         }
 
         if (!isToolMessage) {
-          parts.push(...OpenTelemetryCallbackHandler._messageContentParts(message));
+          parts.push(...OpenTelemetryCallbackHandler._toOtelMessageParts(message));
         }
 
         if (isToolMessage) {
@@ -631,7 +631,7 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
 
         if ('message' in generation) {
           const message = (generation as ChatGeneration).message;
-          parts.push(...OpenTelemetryCallbackHandler._messageContentParts(message));
+          parts.push(...OpenTelemetryCallbackHandler._toOtelMessageParts(message));
 
           finishReason = OpenTelemetryCallbackHandler._extractFinishReason(generation);
         } else {
@@ -695,7 +695,7 @@ export class OpenTelemetryCallbackHandler extends BaseCallbackHandler {
     }
   }
 
-  private static _messageContentParts(message: BaseMessage): Array<Record<string, unknown>> {
+  private static _toOtelMessageParts(message: BaseMessage): Array<Record<string, unknown>> {
     // Provider translators, notably Bedrock Converse, can omit normalized
     // tool_calls from contentBlocks, while other providers expose them in both.
     // Convert both sources through the shared helper and collapse duplicates.

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
@@ -400,21 +400,25 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
   }
 
   private _formatMessageParts(content: unknown): Array<Record<string, unknown>> {
-    const blocks = Array.isArray(content) ? content : [content];
-    return blocks.flatMap(block => {
-      if (!block || typeof block !== 'object') return contentToParts(block);
-      const value = block as Record<string, unknown>;
-      if (value.type === 'input_text' || value.type === 'output_text') {
-        return contentToParts({ type: 'text', text: value.text });
-      }
-      if (value.type === 'reasoning_text' || value.type === 'summary_text') {
-        return contentToParts({ type: 'reasoning', reasoning: value.text });
-      }
-      if (value.type === 'input_image' && typeof value.image === 'string') {
-        return contentToParts({ type: 'image_url', image_url: { url: value.image } });
-      }
-      return contentToParts(value);
-    });
+    try {
+      const blocks = Array.isArray(content) ? content : [content];
+      return blocks.flatMap(block => {
+        if (!block || typeof block !== 'object') return contentToParts(block);
+        const value = block as Record<string, unknown>;
+        if (value.type === 'input_text' || value.type === 'output_text') {
+          return contentToParts({ type: 'text', text: value.text });
+        }
+        if (value.type === 'reasoning_text' || value.type === 'summary_text') {
+          return contentToParts({ type: 'reasoning', reasoning: value.text });
+        }
+        if (value.type === 'input_image' && typeof value.image === 'string') {
+          return contentToParts({ type: 'image_url', image_url: { url: value.image } });
+        }
+        return contentToParts(value);
+      });
+    } catch {
+      return [];
+    }
   }
 
   private _propagateModelToAgent(parentId: string | null, model: string): void {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
@@ -49,7 +49,6 @@ import {
 import {
   AttributeMapping,
   contentToParts,
-  normalizeFinishReason,
   serializeToJson,
   toToolAttributeValue,
   tryParseJson,
@@ -309,7 +308,9 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
 
   private _getFinishReasons(response: Record<string, any>): string[] {
     const incompleteReason = response.incomplete_details?.reason;
-    if (typeof incompleteReason === 'string') return [normalizeFinishReason(incompleteReason)];
+    if (typeof incompleteReason === 'string') {
+      return [incompleteReason === 'max_output_tokens' ? 'length' : incompleteReason];
+    }
     if (response.status === 'failed') return ['error'];
     if (!response.output || !Array.isArray(response.output)) return [];
 
@@ -328,7 +329,7 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
       if (item.type === 'message' || ('role' in item && 'content' in item)) {
         return {
           role: item.role ?? 'user',
-          parts: contentToParts(item.content),
+          parts: this._contentToParts(item.content),
         };
       }
       if (item.type === 'function_call') {
@@ -368,12 +369,14 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
     const parts: any[] = [];
     for (const item of output) {
       if (item.type === 'message' && item.content) {
-        parts.push(...contentToParts(item.content));
+        parts.push(...this._contentToParts(item.content));
       } else if (item.type === 'reasoning') {
-        const summary = contentToParts(item.summary).filter(part => part.type === 'reasoning');
+        const summary = this._contentToParts(item.summary).filter(part => part.type === 'reasoning');
         // Raw reasoning content is only a fallback when no provider-supplied summary exists.
         parts.push(
-          ...(summary.length > 0 ? summary : contentToParts(item.content).filter(part => part.type === 'reasoning'))
+          ...(summary.length > 0
+            ? summary
+            : this._contentToParts(item.content).filter(part => part.type === 'reasoning'))
         );
       } else if (item.type === 'function_call') {
         parts.push({
@@ -394,6 +397,24 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
         finish_reason: finishReasons[0] ?? 'stop',
       },
     ]);
+  }
+
+  private _contentToParts(content: unknown): Array<Record<string, unknown>> {
+    const blocks = Array.isArray(content) ? content : [content];
+    return blocks.flatMap(block => {
+      if (!block || typeof block !== 'object') return contentToParts(block);
+      const value = block as Record<string, unknown>;
+      if (value.type === 'input_text' || value.type === 'output_text') {
+        return contentToParts({ type: 'text', text: value.text });
+      }
+      if (value.type === 'reasoning_text' || value.type === 'summary_text') {
+        return contentToParts({ type: 'reasoning', reasoning: value.text });
+      }
+      if (value.type === 'input_image' && typeof value.image === 'string') {
+        return contentToParts({ type: 'image_url', image_url: { url: value.image } });
+      }
+      return contentToParts(value);
+    });
   }
 
   private _propagateModelToAgent(parentId: string | null, model: string): void {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
@@ -46,7 +46,14 @@ import {
   GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT,
   GEN_AI_PROVIDER_NAME_VALUE_OPENAI,
 } from '../common/semconv';
-import { AttributeMapping, serializeToJson, tryParseJson } from '../common/instrumentation-utils';
+import {
+  AttributeMapping,
+  contentToParts,
+  normalizeFinishReason,
+  serializeToJson,
+  toToolAttributeValue,
+  tryParseJson,
+} from '../common/instrumentation-utils';
 
 interface SpanEntry {
   otelSpan: OtelSpan;
@@ -243,10 +250,7 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
 
     if (this._captureMessageContent) {
       if (response.instructions) {
-        otelSpan.setAttribute(
-          ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
-          serializeToJson([{ type: 'text', content: response.instructions }])
-        );
+        otelSpan.setAttribute(ATTR_GEN_AI_SYSTEM_INSTRUCTIONS, serializeToJson(contentToParts(response.instructions)));
       }
 
       const inputMessages = this._formatInputMessages(spanData._input);
@@ -263,11 +267,13 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
 
   private _setFunctionEndAttributes(otelSpan: OtelSpan, spanData: FunctionSpanData): void {
     if (this._captureMessageContent) {
-      if (spanData.input) {
-        otelSpan.setAttribute(ATTR_GEN_AI_TOOL_CALL_ARGUMENTS, spanData.input);
+      const input = toToolAttributeValue(spanData.input);
+      if (input !== undefined && input !== '') {
+        otelSpan.setAttribute(ATTR_GEN_AI_TOOL_CALL_ARGUMENTS, input);
       }
-      if (spanData.output) {
-        otelSpan.setAttribute(ATTR_GEN_AI_TOOL_CALL_RESULT, spanData.output);
+      const output = toToolAttributeValue(spanData.output);
+      if (output !== undefined && output !== '') {
+        otelSpan.setAttribute(ATTR_GEN_AI_TOOL_CALL_RESULT, output);
       }
     }
   }
@@ -302,12 +308,15 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
   }
 
   private _getFinishReasons(response: Record<string, any>): string[] {
+    const incompleteReason = response.incomplete_details?.reason;
+    if (typeof incompleteReason === 'string') return [normalizeFinishReason(incompleteReason)];
+    if (response.status === 'failed') return ['error'];
     if (!response.output || !Array.isArray(response.output)) return [];
 
     const hasToolCalls = response.output.some((item: any) => item.type === 'function_call');
     const hasMessages = response.output.some((item: any) => item.type === 'message');
 
-    if (hasToolCalls) return ['tool_calls'];
+    if (hasToolCalls) return ['tool_call'];
     if (hasMessages) return ['stop'];
     return [];
   }
@@ -316,10 +325,10 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
     if (!input || !Array.isArray(input)) return undefined;
 
     const formatted = input.map((item: Record<string, any>) => {
-      if (item.type === 'message') {
+      if (item.type === 'message' || ('role' in item && 'content' in item)) {
         return {
           role: item.role ?? 'user',
-          parts: [{ type: 'text', content: item.content ?? '' }],
+          parts: contentToParts(item.content),
         };
       }
       if (item.type === 'function_call') {
@@ -347,7 +356,7 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
           ],
         };
       }
-      return { role: 'user', parts: [{ type: 'text', content: JSON.stringify(item) }] };
+      return { role: 'user', parts: contentToParts(serializeToJson(item)) };
     });
 
     return serializeToJson(formatted);
@@ -359,11 +368,13 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
     const parts: any[] = [];
     for (const item of output) {
       if (item.type === 'message' && item.content) {
-        for (const content of item.content) {
-          if (content.type === 'output_text') {
-            parts.push({ type: 'text', content: content.text ?? '' });
-          }
-        }
+        parts.push(...contentToParts(item.content));
+      } else if (item.type === 'reasoning') {
+        const summary = contentToParts(item.summary).filter(part => part.type === 'reasoning');
+        // Raw reasoning content is only a fallback when no provider-supplied summary exists.
+        parts.push(
+          ...(summary.length > 0 ? summary : contentToParts(item.content).filter(part => part.type === 'reasoning'))
+        );
       } else if (item.type === 'function_call') {
         parts.push({
           type: 'tool_call',

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
@@ -400,25 +400,21 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
   }
 
   private _formatMessageParts(content: unknown): Array<Record<string, unknown>> {
-    try {
-      const blocks = Array.isArray(content) ? content : [content];
-      return blocks.flatMap(block => {
-        if (!block || typeof block !== 'object') return contentToParts(block);
-        const value = block as Record<string, unknown>;
-        if (value.type === 'input_text' || value.type === 'output_text') {
-          return contentToParts({ type: 'text', text: value.text });
-        }
-        if (value.type === 'reasoning_text' || value.type === 'summary_text') {
-          return contentToParts({ type: 'reasoning', reasoning: value.text });
-        }
-        if (value.type === 'input_image' && typeof value.image === 'string') {
-          return contentToParts({ type: 'image_url', image_url: { url: value.image } });
-        }
-        return contentToParts(value);
-      });
-    } catch {
-      return [];
-    }
+    const blocks = Array.isArray(content) ? content : [content];
+    return blocks.flatMap(block => {
+      if (!block || typeof block !== 'object') return contentToParts(block);
+      const value = block as Record<string, unknown>;
+      if (value.type === 'input_text' || value.type === 'output_text') {
+        return contentToParts({ type: 'text', text: value.text });
+      }
+      if (value.type === 'reasoning_text' || value.type === 'summary_text') {
+        return contentToParts({ type: 'reasoning', reasoning: value.text });
+      }
+      if (value.type === 'input_image' && typeof value.image === 'string') {
+        return contentToParts({ type: 'image_url', image_url: { url: value.image } });
+      }
+      return contentToParts(value);
+    });
   }
 
   private _propagateModelToAgent(parentId: string | null, model: string): void {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/tracing-processor.ts
@@ -329,7 +329,7 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
       if (item.type === 'message' || ('role' in item && 'content' in item)) {
         return {
           role: item.role ?? 'user',
-          parts: this._contentToParts(item.content),
+          parts: this._formatMessageParts(item.content),
         };
       }
       if (item.type === 'function_call') {
@@ -369,14 +369,14 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
     const parts: any[] = [];
     for (const item of output) {
       if (item.type === 'message' && item.content) {
-        parts.push(...this._contentToParts(item.content));
+        parts.push(...this._formatMessageParts(item.content));
       } else if (item.type === 'reasoning') {
-        const summary = this._contentToParts(item.summary).filter(part => part.type === 'reasoning');
+        const summary = this._formatMessageParts(item.summary).filter(part => part.type === 'reasoning');
         // Raw reasoning content is only a fallback when no provider-supplied summary exists.
         parts.push(
           ...(summary.length > 0
             ? summary
-            : this._contentToParts(item.content).filter(part => part.type === 'reasoning'))
+            : this._formatMessageParts(item.content).filter(part => part.type === 'reasoning'))
         );
       } else if (item.type === 'function_call') {
         parts.push({
@@ -399,7 +399,7 @@ export class OpenTelemetryTracingProcessor implements TracingProcessor {
     ]);
   }
 
-  private _contentToParts(content: unknown): Array<Record<string, unknown>> {
+  private _formatMessageParts(content: unknown): Array<Record<string, unknown>> {
     const blocks = Array.isArray(content) ? content : [content];
     return blocks.flatMap(block => {
       if (!block || typeof block !== 'object') return contentToParts(block);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -101,6 +101,26 @@ export class VercelAISpanProcessor implements SpanProcessor {
       transform: (v: string) => VercelAISpanProcessor.formatInputMessages(v),
     },
     {
+      from: 'ai.response.text',
+      to: ATTR_GEN_AI_OUTPUT_MESSAGES,
+      transform: (_: unknown, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+    },
+    {
+      from: 'ai.response.object',
+      to: ATTR_GEN_AI_OUTPUT_MESSAGES,
+      transform: (_: unknown, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+    },
+    {
+      from: 'ai.response.reasoning',
+      to: ATTR_GEN_AI_OUTPUT_MESSAGES,
+      transform: (_: unknown, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+    },
+    {
+      from: 'ai.response.toolCalls',
+      to: ATTR_GEN_AI_OUTPUT_MESSAGES,
+      transform: (_: unknown, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+    },
+    {
       from: 'ai.prompt.tools',
       to: ATTR_GEN_AI_TOOL_DEFINITIONS,
       transform: (v: any) => VercelAISpanProcessor.formatToolDefinitions(v),
@@ -194,13 +214,6 @@ export class VercelAISpanProcessor implements SpanProcessor {
       }
     }
 
-    if (!Object.prototype.hasOwnProperty.call(mutableAttrs, ATTR_GEN_AI_OUTPUT_MESSAGES)) {
-      const outputMessages = VercelAISpanProcessor.formatOutputMessages(mutableAttrs);
-      if (outputMessages !== undefined) {
-        mutableAttrs[ATTR_GEN_AI_OUTPUT_MESSAGES] = outputMessages;
-      }
-    }
-
     if (operationId === 'ai.generateText' || operationId === 'ai.streamText') {
       mutableAttrs[ATTR_GEN_AI_OPERATION_NAME] = this.isAgentSpan(span)
         ? GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT
@@ -276,7 +289,7 @@ export class VercelAISpanProcessor implements SpanProcessor {
     }
   }
 
-  private static formatOutputMessages(attrs: Record<string, any>): string | undefined {
+  private static formatOutputMessages(attrs: Record<string, unknown>): string | undefined {
     const parts: Array<Record<string, unknown>> = [];
     const text = attrs['ai.response.text'] ?? attrs['ai.response.object'];
     if (text !== undefined && text !== null) {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -78,7 +78,7 @@ export class VercelAISpanProcessor implements SpanProcessor {
     {
       from: 'ai.response.finishReason',
       to: ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
-      transform: (v: string) => [VercelAISpanProcessor.mapFinishReason(v)],
+      transform: (v: string) => [normalizeFinishReason(v)],
     },
     { from: 'ai.response.id', to: ATTR_GEN_AI_RESPONSE_ID },
     { from: 'ai.response.model', to: ATTR_GEN_AI_RESPONSE_MODEL },
@@ -307,7 +307,7 @@ export class VercelAISpanProcessor implements SpanProcessor {
     if (parts.length === 0) return undefined;
     const finishReason =
       typeof attrs['ai.response.finishReason'] === 'string'
-        ? VercelAISpanProcessor.mapFinishReason(attrs['ai.response.finishReason'])
+        ? normalizeFinishReason(attrs['ai.response.finishReason'])
         : parts.some(part => part.type === 'tool_call')
         ? 'tool_call'
         : 'stop';
@@ -358,10 +358,6 @@ export class VercelAISpanProcessor implements SpanProcessor {
 
     const model = attrs[ATTR_GEN_AI_REQUEST_MODEL] as string | undefined;
     return model ? `${op} ${model}` : op;
-  }
-
-  private static mapFinishReason(reason: string): string {
-    return normalizeFinishReason(reason);
   }
 
   private static mapProviderName(provider: string): string {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -270,7 +270,7 @@ export class VercelAISpanProcessor implements SpanProcessor {
       const messages = typeof value === 'string' ? JSON.parse(value) : value;
       if (!Array.isArray(messages)) return value;
       const formatted = messages.map((msg: any) => {
-        return { role: msg.role, parts: VercelAISpanProcessor._contentToParts(msg.content) };
+        return { role: msg.role, parts: VercelAISpanProcessor._formatMessageParts(msg.content) };
       });
       return serializeToJson(formatted);
     } catch {
@@ -286,13 +286,13 @@ export class VercelAISpanProcessor implements SpanProcessor {
     return serializeToJson([
       {
         role: 'assistant',
-        parts: VercelAISpanProcessor._contentToParts(value),
+        parts: VercelAISpanProcessor._formatMessageParts(value),
         finish_reason: finishReason,
       },
     ]);
   }
 
-  private static _contentToParts(content: unknown): Array<Record<string, unknown>> {
+  private static _formatMessageParts(content: unknown): Array<Record<string, unknown>> {
     const blocks = Array.isArray(content) ? content : [content];
     return blocks.flatMap(block => {
       if (!block || typeof block !== 'object') return contentToParts(block);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -41,10 +41,17 @@ import {
   GEN_AI_OUTPUT_TYPE_VALUE_JSON,
   GEN_AI_OUTPUT_TYPE_VALUE_TEXT,
 } from '../common/semconv';
-import { PROVIDER_MAP, serializeToJson } from '../common/instrumentation-utils';
+import {
+  AttributeMapping,
+  contentToParts,
+  normalizeFinishReason,
+  PROVIDER_MAP,
+  serializeToJson,
+  toToolAttributeValue,
+  tryParseJson,
+} from '../common/instrumentation-utils';
 import { LIB_VERSION } from '../../version';
 import { INSTRUMENTATION_NAME } from './instrumentation';
-import { AttributeMapping } from '../common/instrumentation-utils';
 
 export class VercelAISpanProcessor implements SpanProcessor {
   // Span processor that translates VercelAI span attributes into OTel GenAI semantic conventions.
@@ -94,16 +101,6 @@ export class VercelAISpanProcessor implements SpanProcessor {
       transform: (v: string) => VercelAISpanProcessor.formatInputMessages(v),
     },
     {
-      from: 'ai.response.text',
-      to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (v: string, attrs: Record<string, any>) => VercelAISpanProcessor.formatOutputMessages(v, attrs),
-    },
-    {
-      from: 'ai.response.object',
-      to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (v: string, attrs: Record<string, any>) => VercelAISpanProcessor.formatOutputMessages(v, attrs),
-    },
-    {
       from: 'ai.prompt.tools',
       to: ATTR_GEN_AI_TOOL_DEFINITIONS,
       transform: (v: any) => VercelAISpanProcessor.formatToolDefinitions(v),
@@ -113,12 +110,12 @@ export class VercelAISpanProcessor implements SpanProcessor {
     {
       from: 'ai.toolCall.args',
       to: ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
-      transform: (v: string) => VercelAISpanProcessor.unwrapJsonString(v),
+      transform: (v: unknown) => toToolAttributeValue(typeof v === 'string' ? tryParseJson(v) : v),
     },
     {
       from: 'ai.toolCall.result',
       to: ATTR_GEN_AI_TOOL_CALL_RESULT,
-      transform: (v: string) => VercelAISpanProcessor.unwrapJsonString(v),
+      transform: (v: unknown) => toToolAttributeValue(typeof v === 'string' ? tryParseJson(v) : v),
     },
   ];
 
@@ -189,11 +186,18 @@ export class VercelAISpanProcessor implements SpanProcessor {
     for (const mapping of VercelAISpanProcessor.ATTRIBUTE_MAP) {
       if (!mapping.to) continue;
       const value = attrs[mapping.from];
-      if (value != null && !mutableAttrs[mapping.to]) {
+      if (value != null && !Object.prototype.hasOwnProperty.call(mutableAttrs, mapping.to)) {
         const mapped = mapping.transform ? mapping.transform(value, mutableAttrs) : value;
         if (mapped != null) {
           mutableAttrs[mapping.to] = mapped;
         }
+      }
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(mutableAttrs, ATTR_GEN_AI_OUTPUT_MESSAGES)) {
+      const outputMessages = VercelAISpanProcessor.formatOutputMessages(mutableAttrs);
+      if (outputMessages !== undefined) {
+        mutableAttrs[ATTR_GEN_AI_OUTPUT_MESSAGES] = outputMessages;
       }
     }
 
@@ -264,33 +268,7 @@ export class VercelAISpanProcessor implements SpanProcessor {
       const messages = typeof value === 'string' ? JSON.parse(value) : value;
       if (!Array.isArray(messages)) return value;
       const formatted = messages.map((msg: any) => {
-        const parts: Array<Record<string, unknown>> = [];
-        if (typeof msg.content === 'string') {
-          parts.push({ type: 'text', content: msg.content });
-        } else if (Array.isArray(msg.content)) {
-          for (const part of msg.content) {
-            if (part.type === 'text') {
-              parts.push({ type: 'text', content: part.text ?? part.content ?? '' });
-            } else if (part.type === 'tool-call' || part.type === 'tool_call') {
-              parts.push({
-                type: 'tool_call',
-                id: part.toolCallId ?? part.id ?? null,
-                name: part.toolName ?? part.name ?? '',
-                arguments:
-                  typeof part.args === 'string' ? VercelAISpanProcessor.unwrapJsonString(part.args) : part.args,
-              });
-            } else if (part.type === 'tool-result' || part.type === 'tool_call_response') {
-              parts.push({
-                type: 'tool_call_response',
-                id: part.toolCallId ?? part.id ?? null,
-                response: part.result ?? part.response ?? '',
-              });
-            } else {
-              parts.push(part);
-            }
-          }
-        }
-        return { role: msg.role, parts };
+        return { role: msg.role, parts: contentToParts(msg.content) };
       });
       return serializeToJson(formatted);
     } catch {
@@ -298,15 +276,45 @@ export class VercelAISpanProcessor implements SpanProcessor {
     }
   }
 
-  private static formatOutputMessages(value: string, attrs: Record<string, any>): string {
+  private static formatOutputMessages(attrs: Record<string, any>): string | undefined {
+    const parts: Array<Record<string, unknown>> = [];
+    const text = attrs['ai.response.text'] ?? attrs['ai.response.object'];
+    if (text !== undefined && text !== null) {
+      parts.push(...contentToParts(text));
+    }
+
+    const reasoning = attrs['ai.response.reasoning'];
+    if (reasoning !== undefined && reasoning !== null && reasoning !== '') {
+      parts.push({ type: 'reasoning', content: String(reasoning) });
+    }
+
+    const rawToolCalls = attrs['ai.response.toolCalls'];
+    const toolCalls = typeof rawToolCalls === 'string' ? tryParseJson(rawToolCalls) : rawToolCalls;
+    if (Array.isArray(toolCalls)) {
+      for (const toolCall of toolCalls) {
+        if (!toolCall || typeof toolCall !== 'object') continue;
+        const call = toolCall as Record<string, unknown>;
+        const args = call.input ?? call.args ?? call.arguments ?? {};
+        parts.push({
+          type: 'tool_call',
+          id: call.toolCallId ?? call.id ?? null,
+          name: call.toolName ?? call.name ?? '',
+          arguments: typeof args === 'string' ? tryParseJson(args) : args,
+        });
+      }
+    }
+
+    if (parts.length === 0) return undefined;
     const finishReason =
       typeof attrs['ai.response.finishReason'] === 'string'
         ? VercelAISpanProcessor.mapFinishReason(attrs['ai.response.finishReason'])
+        : parts.some(part => part.type === 'tool_call')
+        ? 'tool_call'
         : 'stop';
     return serializeToJson([
       {
         role: 'assistant',
-        parts: [{ type: 'text', content: value }],
+        parts,
         finish_reason: finishReason,
       },
     ]);
@@ -353,23 +361,7 @@ export class VercelAISpanProcessor implements SpanProcessor {
   }
 
   private static mapFinishReason(reason: string): string {
-    switch (reason) {
-      case 'stop':
-        return 'stop';
-      case 'length':
-        return 'length';
-      case 'content-filter':
-        return 'content_filter';
-      case 'tool-calls':
-        return 'tool_call';
-      case 'error':
-        return 'error';
-      case 'other':
-      case 'unknown':
-        return 'stop';
-      default:
-        return reason;
-    }
+    return normalizeFinishReason(reason);
   }
 
   private static mapProviderName(provider: string): string {
@@ -395,16 +387,5 @@ export class VercelAISpanProcessor implements SpanProcessor {
       return GEN_AI_OUTPUT_TYPE_VALUE_JSON;
     }
     return undefined;
-  }
-
-  private static unwrapJsonString(value: string): string {
-    try {
-      const parsed = JSON.parse(value);
-      if (typeof parsed === 'string') return parsed;
-      if (typeof parsed === 'object' && parsed !== null) return JSON.stringify(parsed);
-      return value;
-    } catch {
-      return value;
-    }
   }
 }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -270,7 +270,7 @@ export class VercelAISpanProcessor implements SpanProcessor {
       const messages = typeof value === 'string' ? JSON.parse(value) : value;
       if (!Array.isArray(messages)) return value;
       const formatted = messages.map((msg: any) => {
-        return { role: msg.role, parts: VercelAISpanProcessor.contentToParts(msg.content) };
+        return { role: msg.role, parts: VercelAISpanProcessor._contentToParts(msg.content) };
       });
       return serializeToJson(formatted);
     } catch {
@@ -286,13 +286,13 @@ export class VercelAISpanProcessor implements SpanProcessor {
     return serializeToJson([
       {
         role: 'assistant',
-        parts: VercelAISpanProcessor.contentToParts(value),
+        parts: VercelAISpanProcessor._contentToParts(value),
         finish_reason: finishReason,
       },
     ]);
   }
 
-  private static contentToParts(content: unknown): Array<Record<string, unknown>> {
+  private static _contentToParts(content: unknown): Array<Record<string, unknown>> {
     const blocks = Array.isArray(content) ? content : [content];
     return blocks.flatMap(block => {
       if (!block || typeof block !== 'object') return contentToParts(block);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -103,22 +103,22 @@ export class VercelAISpanProcessor implements SpanProcessor {
     {
       from: 'ai.response.text',
       to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (_: unknown, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+      transform: (_: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
     },
     {
       from: 'ai.response.object',
       to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (_: unknown, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+      transform: (_: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
     },
     {
       from: 'ai.response.reasoning',
       to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (_: unknown, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+      transform: (_: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
     },
     {
       from: 'ai.response.toolCalls',
       to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (_: unknown, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+      transform: (_: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
     },
     {
       from: 'ai.prompt.tools',

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -44,7 +44,6 @@ import {
 import {
   AttributeMapping,
   contentToParts,
-  normalizeFinishReason,
   PROVIDER_MAP,
   serializeToJson,
   toToolAttributeValue,
@@ -78,7 +77,7 @@ export class VercelAISpanProcessor implements SpanProcessor {
     {
       from: 'ai.response.finishReason',
       to: ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
-      transform: (v: string) => [normalizeFinishReason(v)],
+      transform: (v: string) => [VercelAISpanProcessor.mapFinishReason(v)],
     },
     { from: 'ai.response.id', to: ATTR_GEN_AI_RESPONSE_ID },
     { from: 'ai.response.model', to: ATTR_GEN_AI_RESPONSE_MODEL },
@@ -103,22 +102,12 @@ export class VercelAISpanProcessor implements SpanProcessor {
     {
       from: 'ai.response.text',
       to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (_: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+      transform: (v: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(v, attrs),
     },
     {
       from: 'ai.response.object',
       to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (_: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
-    },
-    {
-      from: 'ai.response.reasoning',
-      to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (_: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
-    },
-    {
-      from: 'ai.response.toolCalls',
-      to: ATTR_GEN_AI_OUTPUT_MESSAGES,
-      transform: (_: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(attrs),
+      transform: (v: string, attrs: Record<string, unknown>) => VercelAISpanProcessor.formatOutputMessages(v, attrs),
     },
     {
       from: 'ai.prompt.tools',
@@ -281,7 +270,7 @@ export class VercelAISpanProcessor implements SpanProcessor {
       const messages = typeof value === 'string' ? JSON.parse(value) : value;
       if (!Array.isArray(messages)) return value;
       const formatted = messages.map((msg: any) => {
-        return { role: msg.role, parts: contentToParts(msg.content) };
+        return { role: msg.role, parts: VercelAISpanProcessor.contentToParts(msg.content) };
       });
       return serializeToJson(formatted);
     } catch {
@@ -289,48 +278,59 @@ export class VercelAISpanProcessor implements SpanProcessor {
     }
   }
 
-  private static formatOutputMessages(attrs: Record<string, unknown>): string | undefined {
-    const parts: Array<Record<string, unknown>> = [];
-    const text = attrs['ai.response.text'] ?? attrs['ai.response.object'];
-    if (text !== undefined && text !== null) {
-      parts.push(...contentToParts(text));
-    }
-
-    const reasoning = attrs['ai.response.reasoning'];
-    if (reasoning !== undefined && reasoning !== null && reasoning !== '') {
-      parts.push({ type: 'reasoning', content: String(reasoning) });
-    }
-
-    const rawToolCalls = attrs['ai.response.toolCalls'];
-    const toolCalls = typeof rawToolCalls === 'string' ? tryParseJson(rawToolCalls) : rawToolCalls;
-    if (Array.isArray(toolCalls)) {
-      for (const toolCall of toolCalls) {
-        if (!toolCall || typeof toolCall !== 'object') continue;
-        const call = toolCall as Record<string, unknown>;
-        const args = call.input ?? call.args ?? call.arguments ?? {};
-        parts.push({
-          type: 'tool_call',
-          id: call.toolCallId ?? call.id ?? null,
-          name: call.toolName ?? call.name ?? '',
-          arguments: typeof args === 'string' ? tryParseJson(args) : args,
-        });
-      }
-    }
-
-    if (parts.length === 0) return undefined;
+  private static formatOutputMessages(value: unknown, attrs: Record<string, unknown>): string {
     const finishReason =
       typeof attrs['ai.response.finishReason'] === 'string'
-        ? normalizeFinishReason(attrs['ai.response.finishReason'])
-        : parts.some(part => part.type === 'tool_call')
-        ? 'tool_call'
+        ? VercelAISpanProcessor.mapFinishReason(attrs['ai.response.finishReason'])
         : 'stop';
     return serializeToJson([
       {
         role: 'assistant',
-        parts,
+        parts: VercelAISpanProcessor.contentToParts(value),
         finish_reason: finishReason,
       },
     ]);
+  }
+
+  private static contentToParts(content: unknown): Array<Record<string, unknown>> {
+    const blocks = Array.isArray(content) ? content : [content];
+    return blocks.flatMap(block => {
+      if (!block || typeof block !== 'object') return contentToParts(block);
+      const value = block as Record<string, unknown>;
+      if (value.type === 'tool-call' || value.type === 'tool_call') {
+        const args = value.args ?? value.arguments ?? {};
+        return [
+          {
+            type: 'tool_call',
+            id: value.toolCallId ?? value.id ?? null,
+            name: value.toolName ?? value.name ?? '',
+            arguments: typeof args === 'string' ? tryParseJson(args) : args,
+          },
+        ];
+      }
+      if (value.type === 'tool-result' || value.type === 'tool_call_response') {
+        return [
+          {
+            type: 'tool_call_response',
+            id: value.toolCallId ?? value.id ?? null,
+            response: value.result ?? value.response ?? '',
+          },
+        ];
+      }
+      if (
+        value.type === 'file' &&
+        typeof value.mediaType === 'string' &&
+        value.mediaType.startsWith('image/') &&
+        typeof value.data === 'string'
+      ) {
+        return contentToParts(
+          value.data.startsWith('data:') || value.data.includes('://')
+            ? { type: 'image_url', image_url: { url: value.data } }
+            : { type: 'image', media_type: value.mediaType, data: value.data }
+        );
+      }
+      return contentToParts(value);
+    });
   }
 
   private static formatToolDefinitions(tools: any): string | undefined {
@@ -371,6 +371,26 @@ export class VercelAISpanProcessor implements SpanProcessor {
 
     const model = attrs[ATTR_GEN_AI_REQUEST_MODEL] as string | undefined;
     return model ? `${op} ${model}` : op;
+  }
+
+  private static mapFinishReason(reason: string): string {
+    switch (reason) {
+      case 'stop':
+        return 'stop';
+      case 'length':
+        return 'length';
+      case 'content-filter':
+        return 'content_filter';
+      case 'tool-calls':
+        return 'tool_call';
+      case 'error':
+        return 'error';
+      case 'other':
+      case 'unknown':
+        return 'stop';
+      default:
+        return reason;
+    }
   }
 
   private static mapProviderName(provider: string): string {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -293,48 +293,44 @@ export class VercelAISpanProcessor implements SpanProcessor {
   }
 
   private static _formatMessageParts(content: unknown): Array<Record<string, unknown>> {
-    try {
-      const blocks = Array.isArray(content) ? content : [content];
-      return blocks.flatMap(block => {
-        if (!block || typeof block !== 'object') return contentToParts(block);
-        const value = block as Record<string, unknown>;
-        if (value.type === 'tool-call' || value.type === 'tool_call') {
-          const args = value.args ?? value.arguments ?? {};
-          return [
-            {
-              type: 'tool_call',
-              id: value.toolCallId ?? value.id ?? null,
-              name: value.toolName ?? value.name ?? '',
-              arguments: typeof args === 'string' ? tryParseJson(args) : args,
-            },
-          ];
-        }
-        if (value.type === 'tool-result' || value.type === 'tool_call_response') {
-          return [
-            {
-              type: 'tool_call_response',
-              id: value.toolCallId ?? value.id ?? null,
-              response: value.result ?? value.response ?? '',
-            },
-          ];
-        }
-        if (
-          value.type === 'file' &&
-          typeof value.mediaType === 'string' &&
-          value.mediaType.startsWith('image/') &&
-          typeof value.data === 'string'
-        ) {
-          return contentToParts(
-            value.data.startsWith('data:') || value.data.includes('://')
-              ? { type: 'image_url', image_url: { url: value.data } }
-              : { type: 'image', media_type: value.mediaType, data: value.data }
-          );
-        }
-        return contentToParts(value);
-      });
-    } catch {
-      return [];
-    }
+    const blocks = Array.isArray(content) ? content : [content];
+    return blocks.flatMap(block => {
+      if (!block || typeof block !== 'object') return contentToParts(block);
+      const value = block as Record<string, unknown>;
+      if (value.type === 'tool-call' || value.type === 'tool_call') {
+        const args = value.args ?? value.arguments ?? {};
+        return [
+          {
+            type: 'tool_call',
+            id: value.toolCallId ?? value.id ?? null,
+            name: value.toolName ?? value.name ?? '',
+            arguments: typeof args === 'string' ? tryParseJson(args) : args,
+          },
+        ];
+      }
+      if (value.type === 'tool-result' || value.type === 'tool_call_response') {
+        return [
+          {
+            type: 'tool_call_response',
+            id: value.toolCallId ?? value.id ?? null,
+            response: value.result ?? value.response ?? '',
+          },
+        ];
+      }
+      if (
+        value.type === 'file' &&
+        typeof value.mediaType === 'string' &&
+        value.mediaType.startsWith('image/') &&
+        typeof value.data === 'string'
+      ) {
+        return contentToParts(
+          value.data.startsWith('data:') || value.data.includes('://')
+            ? { type: 'image_url', image_url: { url: value.data } }
+            : { type: 'image', media_type: value.mediaType, data: value.data }
+        );
+      }
+      return contentToParts(value);
+    });
   }
 
   private static formatToolDefinitions(tools: any): string | undefined {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -293,44 +293,48 @@ export class VercelAISpanProcessor implements SpanProcessor {
   }
 
   private static _formatMessageParts(content: unknown): Array<Record<string, unknown>> {
-    const blocks = Array.isArray(content) ? content : [content];
-    return blocks.flatMap(block => {
-      if (!block || typeof block !== 'object') return contentToParts(block);
-      const value = block as Record<string, unknown>;
-      if (value.type === 'tool-call' || value.type === 'tool_call') {
-        const args = value.args ?? value.arguments ?? {};
-        return [
-          {
-            type: 'tool_call',
-            id: value.toolCallId ?? value.id ?? null,
-            name: value.toolName ?? value.name ?? '',
-            arguments: typeof args === 'string' ? tryParseJson(args) : args,
-          },
-        ];
-      }
-      if (value.type === 'tool-result' || value.type === 'tool_call_response') {
-        return [
-          {
-            type: 'tool_call_response',
-            id: value.toolCallId ?? value.id ?? null,
-            response: value.result ?? value.response ?? '',
-          },
-        ];
-      }
-      if (
-        value.type === 'file' &&
-        typeof value.mediaType === 'string' &&
-        value.mediaType.startsWith('image/') &&
-        typeof value.data === 'string'
-      ) {
-        return contentToParts(
-          value.data.startsWith('data:') || value.data.includes('://')
-            ? { type: 'image_url', image_url: { url: value.data } }
-            : { type: 'image', media_type: value.mediaType, data: value.data }
-        );
-      }
-      return contentToParts(value);
-    });
+    try {
+      const blocks = Array.isArray(content) ? content : [content];
+      return blocks.flatMap(block => {
+        if (!block || typeof block !== 'object') return contentToParts(block);
+        const value = block as Record<string, unknown>;
+        if (value.type === 'tool-call' || value.type === 'tool_call') {
+          const args = value.args ?? value.arguments ?? {};
+          return [
+            {
+              type: 'tool_call',
+              id: value.toolCallId ?? value.id ?? null,
+              name: value.toolName ?? value.name ?? '',
+              arguments: typeof args === 'string' ? tryParseJson(args) : args,
+            },
+          ];
+        }
+        if (value.type === 'tool-result' || value.type === 'tool_call_response') {
+          return [
+            {
+              type: 'tool_call_response',
+              id: value.toolCallId ?? value.id ?? null,
+              response: value.result ?? value.response ?? '',
+            },
+          ];
+        }
+        if (
+          value.type === 'file' &&
+          typeof value.mediaType === 'string' &&
+          value.mediaType.startsWith('image/') &&
+          typeof value.data === 'string'
+        ) {
+          return contentToParts(
+            value.data.startsWith('data:') || value.data.includes('://')
+              ? { type: 'image_url', image_url: { url: value.data } }
+              : { type: 'image', media_type: value.mediaType, data: value.data }
+          );
+        }
+        return contentToParts(value);
+      });
+    } catch {
+      return [];
+    }
   }
 
   private static formatToolDefinitions(tools: any): string | undefined {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/common/instrumentation-utils.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/common/instrumentation-utils.test.ts
@@ -4,11 +4,9 @@
 import { expect } from 'expect';
 import {
   contentToParts,
-  normalizeFinishReason,
   serializeToJson,
   toToolAttributeValue,
 } from '../../../src/instrumentation/common/instrumentation-utils';
-import { validateOtelGenaiSchema } from '../otel-schema-validator';
 
 describe('serializeToJson', function () {
   it('handles circular references', function () {
@@ -31,8 +29,7 @@ describe('serializeToJson', function () {
 
   it('handles null and undefined', function () {
     expect(serializeToJson(null)).toBe('null');
-    expect(serializeToJson(undefined)).toBe('"undefined"');
-    expect(serializeToJson(undefined)).not.toBe(serializeToJson(null));
+    expect(serializeToJson(undefined)).toBe(undefined as unknown as string);
   });
 
   it('handles arrays with circular references', function () {
@@ -92,68 +89,6 @@ describe('serializeToJson', function () {
       bytes: 'AQID',
     });
   });
-
-  it('sanitizes Date, Error, Map, and Set values', function () {
-    const error = new TypeError('bad input');
-    const result = JSON.parse(
-      serializeToJson({
-        date: new Date('2026-08-18T12:00:00.000Z'),
-        error,
-        map: new Map([
-          ['one', 1],
-          ['two', 2],
-        ]),
-        set: new Set(['a', 'b']),
-      })
-    );
-    expect(result).toEqual({
-      date: '2026-08-18T12:00:00.000Z',
-      error: {
-        name: 'TypeError',
-        message: 'bad input',
-        stack: error.stack,
-      },
-      map: [
-        ['one', 1],
-        ['two', 2],
-      ],
-      set: ['a', 'b'],
-    });
-  });
-
-  it('serializes shared aliases without marking them circular', function () {
-    const shared = { value: 1 };
-    expect(JSON.parse(serializeToJson({ first: shared, second: shared }))).toEqual({
-      first: { value: 1 },
-      second: { value: 1 },
-    });
-  });
-
-  it('uses a constant terminal fallback without coercing the user object', function () {
-    let primitiveCalled = false;
-    let toStringCalled = false;
-    const value = new Proxy(
-      {
-        [Symbol.toPrimitive]: () => {
-          primitiveCalled = true;
-          throw new Error('do not coerce');
-        },
-        toString: () => {
-          toStringCalled = true;
-          throw new Error('do not stringify');
-        },
-      },
-      {
-        ownKeys: () => {
-          throw new Error('cannot inspect');
-        },
-      }
-    );
-
-    expect(serializeToJson(value)).toBe('"[Unserializable]"');
-    expect(primitiveCalled).toBe(false);
-    expect(toStringCalled).toBe(false);
-  });
 });
 
 describe('toToolAttributeValue', function () {
@@ -162,7 +97,7 @@ describe('toToolAttributeValue', function () {
     expect(toToolAttributeValue('result')).toBe('result');
     expect(toToolAttributeValue(42)).toBe(42);
     expect(toToolAttributeValue(true)).toBe(true);
-    expect(toToolAttributeValue(null)).toBe('null');
+    expect(toToolAttributeValue(null)).toBeUndefined();
     expect(toToolAttributeValue(undefined)).toBeUndefined();
   });
 
@@ -174,25 +109,23 @@ describe('toToolAttributeValue', function () {
   it('omits values that cannot be serialized', function () {
     const revoked = Proxy.revocable({}, {});
     revoked.revoke();
-
     expect(toToolAttributeValue(revoked.proxy)).toBeUndefined();
   });
 });
 
 describe('contentToParts', function () {
-  it('maps refusal and typeless blocks to generic parts without losing fields', async function () {
+  it('preserves unrecognized and typeless blocks', function () {
     const parts = contentToParts([
       { type: 'refusal', refusal: 'I cannot do that.' },
       { payload: { answer: 42 }, label: 'structured' },
     ]);
     expect(parts).toEqual([
       { type: 'refusal', refusal: 'I cannot do that.' },
-      { type: 'unknown', payload: { answer: 42 }, label: 'structured' },
+      { type: 'text', payload: { answer: 42 }, label: 'structured' },
     ]);
-    await validateOtelGenaiSchema([{ role: 'assistant', parts, finish_reason: 'stop' }], 'gen-ai-output-messages');
   });
 
-  it('maps multimodal and reasoning blocks to exact typed parts', async function () {
+  it('maps multimodal and reasoning blocks to typed parts', function () {
     const parts = contentToParts([
       { type: 'text', text: 'describe' },
       { type: 'thinking', thinking: 'reasoning' },
@@ -205,172 +138,12 @@ describe('contentToParts', function () {
       { type: 'uri', modality: 'image', uri: 'https://example.com/cat.png' },
       { type: 'blob', modality: 'image', mime_type: 'image/png', content: 'AAAA' },
     ]);
-    await validateOtelGenaiSchema([{ role: 'user', parts }], 'gen-ai-input-messages');
   });
 
-  it('converts percent-encoded and case-insensitive base64 data URLs to canonical blobs', function () {
-    expect(
-      contentToParts([
-        { type: 'image', image: 'data:image/svg+xml,%3Csvg%3E' },
-        { type: 'image', image: 'data:application/octet-stream,%FF' },
-        { type: 'image', image: 'data:image/png;BASE64,AAAA' },
-      ])
-    ).toEqual([
-      { type: 'blob', modality: 'image', mime_type: 'image/svg+xml', content: 'PHN2Zz4=' },
-      { type: 'blob', modality: 'image', mime_type: 'application/octet-stream', content: '/w==' },
-      { type: 'blob', modality: 'image', mime_type: 'image/png', content: 'AAAA' },
-    ]);
-  });
-
-  it('uses field contracts for base64, URLs, binary data, and file IDs', function () {
-    expect(
-      contentToParts([
-        { type: 'file', data: 'https://base64-by-contract.example', mediaType: 'application/pdf' },
-        { type: 'file', data: new URL('https://example.com/report.pdf'), mediaType: 'application/pdf' },
-        { type: 'image', image: { id: 'image-file' } },
-        { type: 'input_file', file: { id: 'document-file' }, filename: 'report.pdf' },
-        { type: 'audio', audio: { id: 'audio-file' }, format: 'mp3' },
-        { type: 'image', source_type: 'id', id: 'legacy-file' },
-        { type: 'image', id: 'block-id', data: Buffer.from('image'), mimeType: 'image/png' },
-      ])
-    ).toEqual([
-      {
-        type: 'blob',
-        modality: 'document',
-        content: 'https://base64-by-contract.example',
-        mime_type: 'application/pdf',
-      },
-      {
-        type: 'uri',
-        modality: 'document',
-        uri: 'https://example.com/report.pdf',
-        mime_type: 'application/pdf',
-      },
-      { type: 'file', modality: 'image', file_id: 'image-file' },
-      { type: 'file', modality: 'document', file_id: 'document-file', filename: 'report.pdf' },
-      { type: 'file', modality: 'audio', file_id: 'audio-file', mime_type: 'audio/mp3', format: 'mp3' },
-      { type: 'file', modality: 'image', file_id: 'legacy-file' },
-      { type: 'blob', modality: 'image', content: 'aW1hZ2U=', mime_type: 'image/png' },
-    ]);
-  });
-
-  it('normalizes audio, file, video, text, and camelCase MIME metadata', function () {
-    expect(
-      contentToParts([
-        {
-          type: 'input_audio',
-          input_audio: { data: 'AAAA', format: 'wav' },
-          transcript: 'hello',
-          providerData: { request: 'audio' },
-        },
-        { type: 'input_file', file_data: 'BBBB', filename: 'notes.txt', mimeType: 'text/plain' },
-        { type: 'video', data: new Uint8Array([1, 2, 3]), mimeType: 'video/mp4' },
-        {
-          type: 'text-plain',
-          text: 'inline text',
-          title: 'Title',
-          context: 'Context',
-          providerMetadata: { provider: { id: 'text-1' } },
-        },
-        { type: 'text-plain', data: 'dGV4dA==', mimeType: 'text/plain' },
-      ])
-    ).toEqual([
-      {
-        type: 'blob',
-        modality: 'audio',
-        content: 'AAAA',
-        mime_type: 'audio/wav',
-        transcript: 'hello',
-        format: 'wav',
-        providerData: { request: 'audio' },
-      },
-      {
-        type: 'blob',
-        modality: 'document',
-        content: 'BBBB',
-        mime_type: 'text/plain',
-        filename: 'notes.txt',
-      },
-      { type: 'blob', modality: 'video', content: 'AQID', mime_type: 'video/mp4' },
-      {
-        type: 'text',
-        content: 'inline text',
-        title: 'Title',
-        context: 'Context',
-        providerMetadata: { provider: { id: 'text-1' } },
-      },
-      { type: 'blob', modality: 'text', content: 'dGV4dA==', mime_type: 'text/plain' },
-    ]);
-  });
-
-  it('returns the exact safe fallback for exceptional content', function () {
-    const revoked = Proxy.revocable({}, {});
-    revoked.revoke();
-    const throwingType = Object.defineProperty({}, 'type', {
-      get() {
-        throw new Error('cannot read type');
-      },
-    });
-
-    expect(contentToParts(revoked.proxy)).toEqual([{ type: 'text', content: '[Unserializable]' }]);
-    expect(contentToParts(throwingType)).toEqual([{ type: 'text', content: '[Unserializable]' }]);
-  });
-});
-
-describe('normalizeFinishReason', function () {
-  it('canonicalizes known reasons and preserves ambiguous values', function () {
-    expect(
-      [
-        'stop',
-        'end_turn',
-        'stop_sequence',
-        'STOP_SEQUENCE',
-        'COMPLETE',
-        'length',
-        'max_tokens',
-        'MAX_TOKENS',
-        'ERROR_LIMIT',
-        'content_filter',
-        'content_filtered',
-        'SAFETY',
-        'RECITATION',
-        'ERROR_TOXIC',
-        'refusal',
-        'tool_use',
-        'tool_calls',
-        'function_call',
-        'TOOL_CALL',
-        'error',
-        'ERROR',
-        'TIMEOUT',
-        'pause_turn',
-        'USER_CANCEL',
-      ].map(normalizeFinishReason)
-    ).toEqual([
-      'stop',
-      'stop',
-      'stop',
-      'stop',
-      'stop',
-      'length',
-      'length',
-      'length',
-      'length',
-      'content_filter',
-      'content_filter',
-      'content_filter',
-      'content_filter',
-      'content_filter',
-      'content_filter',
-      'tool_call',
-      'tool_call',
-      'tool_call',
-      'tool_call',
-      'error',
-      'error',
-      'error',
-      'pause_turn',
-      'USER_CANCEL',
+  it('keeps binary image data for JSON base64 serialization', function () {
+    const parts = contentToParts([{ type: 'image', media_type: 'image/png', data: Buffer.from('image') }]);
+    expect(JSON.parse(serializeToJson(parts))).toEqual([
+      { type: 'blob', modality: 'image', mime_type: 'image/png', content: 'aW1hZ2U=' },
     ]);
   });
 });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/common/instrumentation-utils.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/common/instrumentation-utils.test.ts
@@ -146,4 +146,10 @@ describe('contentToParts', function () {
       { type: 'blob', modality: 'image', mime_type: 'image/png', content: 'aW1hZ2U=' },
     ]);
   });
+
+  it('does not throw for hostile content objects', function () {
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    expect(contentToParts(revoked.proxy)).toEqual([]);
+  });
 });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/common/instrumentation-utils.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/common/instrumentation-utils.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect } from 'expect';
-import { serializeToJson } from '../../../src/instrumentation/common/instrumentation-utils';
+import {
+  contentToParts,
+  normalizeFinishReason,
+  serializeToJson,
+  toToolAttributeValue,
+} from '../../../src/instrumentation/common/instrumentation-utils';
+import { validateOtelGenaiSchema } from '../otel-schema-validator';
 
 describe('serializeToJson', function () {
   it('handles circular references', function () {
@@ -25,7 +31,8 @@ describe('serializeToJson', function () {
 
   it('handles null and undefined', function () {
     expect(serializeToJson(null)).toBe('null');
-    expect(serializeToJson(undefined)).toBe(undefined as unknown as string);
+    expect(serializeToJson(undefined)).toBe('"undefined"');
+    expect(serializeToJson(undefined)).not.toBe(serializeToJson(null));
   });
 
   it('handles arrays with circular references', function () {
@@ -73,5 +80,290 @@ describe('serializeToJson', function () {
   it('truncates at maxDepth=0', function () {
     const result = serializeToJson({ a: 1 }, 0);
     expect(result).toBe('"..."');
+  });
+
+  it('base64-encodes binary values', function () {
+    const result = serializeToJson({
+      buffer: Buffer.from('hello'),
+      bytes: new Uint8Array([1, 2, 3]),
+    });
+    expect(JSON.parse(result)).toEqual({
+      buffer: 'aGVsbG8=',
+      bytes: 'AQID',
+    });
+  });
+
+  it('sanitizes Date, Error, Map, and Set values', function () {
+    const error = new TypeError('bad input');
+    const result = JSON.parse(
+      serializeToJson({
+        date: new Date('2026-08-18T12:00:00.000Z'),
+        error,
+        map: new Map([
+          ['one', 1],
+          ['two', 2],
+        ]),
+        set: new Set(['a', 'b']),
+      })
+    );
+    expect(result).toEqual({
+      date: '2026-08-18T12:00:00.000Z',
+      error: {
+        name: 'TypeError',
+        message: 'bad input',
+        stack: error.stack,
+      },
+      map: [
+        ['one', 1],
+        ['two', 2],
+      ],
+      set: ['a', 'b'],
+    });
+  });
+
+  it('serializes shared aliases without marking them circular', function () {
+    const shared = { value: 1 };
+    expect(JSON.parse(serializeToJson({ first: shared, second: shared }))).toEqual({
+      first: { value: 1 },
+      second: { value: 1 },
+    });
+  });
+
+  it('uses a constant terminal fallback without coercing the user object', function () {
+    let primitiveCalled = false;
+    let toStringCalled = false;
+    const value = new Proxy(
+      {
+        [Symbol.toPrimitive]: () => {
+          primitiveCalled = true;
+          throw new Error('do not coerce');
+        },
+        toString: () => {
+          toStringCalled = true;
+          throw new Error('do not stringify');
+        },
+      },
+      {
+        ownKeys: () => {
+          throw new Error('cannot inspect');
+        },
+      }
+    );
+
+    expect(serializeToJson(value)).toBe('"[Unserializable]"');
+    expect(primitiveCalled).toBe(false);
+    expect(toStringCalled).toBe(false);
+  });
+});
+
+describe('toToolAttributeValue', function () {
+  it('keeps primitive values native', function () {
+    expect(toToolAttributeValue('')).toBe('');
+    expect(toToolAttributeValue('result')).toBe('result');
+    expect(toToolAttributeValue(42)).toBe(42);
+    expect(toToolAttributeValue(true)).toBe(true);
+    expect(toToolAttributeValue(null)).toBe('null');
+    expect(toToolAttributeValue(undefined)).toBeUndefined();
+  });
+
+  it('serializes structured and binary values', function () {
+    expect(toToolAttributeValue({ result: 3 })).toBe('{"result":3}');
+    expect(toToolAttributeValue(Buffer.from('hello'))).toBe('aGVsbG8=');
+  });
+});
+
+describe('contentToParts', function () {
+  it('maps refusal and typeless blocks to generic parts without losing fields', async function () {
+    const parts = contentToParts([
+      { type: 'refusal', refusal: 'I cannot do that.' },
+      { payload: { answer: 42 }, label: 'structured' },
+    ]);
+    expect(parts).toEqual([
+      { type: 'refusal', refusal: 'I cannot do that.' },
+      { type: 'unknown', payload: { answer: 42 }, label: 'structured' },
+    ]);
+    await validateOtelGenaiSchema([{ role: 'assistant', parts, finish_reason: 'stop' }], 'gen-ai-output-messages');
+  });
+
+  it('maps multimodal and reasoning blocks to exact typed parts', async function () {
+    const parts = contentToParts([
+      { type: 'text', text: 'describe' },
+      { type: 'thinking', thinking: 'reasoning' },
+      { type: 'image_url', image_url: { url: 'https://example.com/cat.png' } },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+    ]);
+    expect(parts).toEqual([
+      { type: 'text', content: 'describe' },
+      { type: 'reasoning', content: 'reasoning' },
+      { type: 'uri', modality: 'image', uri: 'https://example.com/cat.png' },
+      { type: 'blob', modality: 'image', mime_type: 'image/png', content: 'AAAA' },
+    ]);
+    await validateOtelGenaiSchema([{ role: 'user', parts }], 'gen-ai-input-messages');
+  });
+
+  it('converts percent-encoded and case-insensitive base64 data URLs to canonical blobs', function () {
+    expect(
+      contentToParts([
+        { type: 'image', image: 'data:image/svg+xml,%3Csvg%3E' },
+        { type: 'image', image: 'data:application/octet-stream,%FF' },
+        { type: 'image', image: 'data:image/png;BASE64,AAAA' },
+      ])
+    ).toEqual([
+      { type: 'blob', modality: 'image', mime_type: 'image/svg+xml', content: 'PHN2Zz4=' },
+      { type: 'blob', modality: 'image', mime_type: 'application/octet-stream', content: '/w==' },
+      { type: 'blob', modality: 'image', mime_type: 'image/png', content: 'AAAA' },
+    ]);
+  });
+
+  it('uses field contracts for base64, URLs, binary data, and file IDs', function () {
+    expect(
+      contentToParts([
+        { type: 'file', data: 'https://base64-by-contract.example', mediaType: 'application/pdf' },
+        { type: 'file', data: new URL('https://example.com/report.pdf'), mediaType: 'application/pdf' },
+        { type: 'image', image: { id: 'image-file' } },
+        { type: 'input_file', file: { id: 'document-file' }, filename: 'report.pdf' },
+        { type: 'audio', audio: { id: 'audio-file' }, format: 'mp3' },
+        { type: 'image', source_type: 'id', id: 'legacy-file' },
+        { type: 'image', id: 'block-id', data: Buffer.from('image'), mimeType: 'image/png' },
+      ])
+    ).toEqual([
+      {
+        type: 'blob',
+        modality: 'document',
+        content: 'https://base64-by-contract.example',
+        mime_type: 'application/pdf',
+      },
+      {
+        type: 'uri',
+        modality: 'document',
+        uri: 'https://example.com/report.pdf',
+        mime_type: 'application/pdf',
+      },
+      { type: 'file', modality: 'image', file_id: 'image-file' },
+      { type: 'file', modality: 'document', file_id: 'document-file', filename: 'report.pdf' },
+      { type: 'file', modality: 'audio', file_id: 'audio-file', mime_type: 'audio/mp3', format: 'mp3' },
+      { type: 'file', modality: 'image', file_id: 'legacy-file' },
+      { type: 'blob', modality: 'image', content: 'aW1hZ2U=', mime_type: 'image/png' },
+    ]);
+  });
+
+  it('normalizes audio, file, video, text, and camelCase MIME metadata', function () {
+    expect(
+      contentToParts([
+        {
+          type: 'input_audio',
+          input_audio: { data: 'AAAA', format: 'wav' },
+          transcript: 'hello',
+          providerData: { request: 'audio' },
+        },
+        { type: 'input_file', file_data: 'BBBB', filename: 'notes.txt', mimeType: 'text/plain' },
+        { type: 'video', data: new Uint8Array([1, 2, 3]), mimeType: 'video/mp4' },
+        {
+          type: 'text-plain',
+          text: 'inline text',
+          title: 'Title',
+          context: 'Context',
+          providerMetadata: { provider: { id: 'text-1' } },
+        },
+        { type: 'text-plain', data: 'dGV4dA==', mimeType: 'text/plain' },
+      ])
+    ).toEqual([
+      {
+        type: 'blob',
+        modality: 'audio',
+        content: 'AAAA',
+        mime_type: 'audio/wav',
+        transcript: 'hello',
+        format: 'wav',
+        providerData: { request: 'audio' },
+      },
+      {
+        type: 'blob',
+        modality: 'document',
+        content: 'BBBB',
+        mime_type: 'text/plain',
+        filename: 'notes.txt',
+      },
+      { type: 'blob', modality: 'video', content: 'AQID', mime_type: 'video/mp4' },
+      {
+        type: 'text',
+        content: 'inline text',
+        title: 'Title',
+        context: 'Context',
+        providerMetadata: { provider: { id: 'text-1' } },
+      },
+      { type: 'blob', modality: 'text', content: 'dGV4dA==', mime_type: 'text/plain' },
+    ]);
+  });
+
+  it('returns the exact safe fallback for exceptional content', function () {
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    const throwingType = Object.defineProperty({}, 'type', {
+      get() {
+        throw new Error('cannot read type');
+      },
+    });
+
+    expect(contentToParts(revoked.proxy)).toEqual([{ type: 'text', content: '[Unserializable]' }]);
+    expect(contentToParts(throwingType)).toEqual([{ type: 'text', content: '[Unserializable]' }]);
+  });
+});
+
+describe('normalizeFinishReason', function () {
+  it('canonicalizes known reasons and preserves ambiguous values', function () {
+    expect(
+      [
+        'stop',
+        'end_turn',
+        'stop_sequence',
+        'STOP_SEQUENCE',
+        'COMPLETE',
+        'length',
+        'max_tokens',
+        'MAX_TOKENS',
+        'ERROR_LIMIT',
+        'content_filter',
+        'content_filtered',
+        'SAFETY',
+        'RECITATION',
+        'ERROR_TOXIC',
+        'refusal',
+        'tool_use',
+        'tool_calls',
+        'function_call',
+        'TOOL_CALL',
+        'error',
+        'ERROR',
+        'TIMEOUT',
+        'pause_turn',
+        'USER_CANCEL',
+      ].map(normalizeFinishReason)
+    ).toEqual([
+      'stop',
+      'stop',
+      'stop',
+      'stop',
+      'stop',
+      'length',
+      'length',
+      'length',
+      'length',
+      'content_filter',
+      'content_filter',
+      'content_filter',
+      'content_filter',
+      'content_filter',
+      'content_filter',
+      'tool_call',
+      'tool_call',
+      'tool_call',
+      'tool_call',
+      'error',
+      'error',
+      'error',
+      'pause_turn',
+      'USER_CANCEL',
+    ]);
   });
 });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/common/instrumentation-utils.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/common/instrumentation-utils.test.ts
@@ -170,6 +170,13 @@ describe('toToolAttributeValue', function () {
     expect(toToolAttributeValue({ result: 3 })).toBe('{"result":3}');
     expect(toToolAttributeValue(Buffer.from('hello'))).toBe('aGVsbG8=');
   });
+
+  it('omits values that cannot be serialized', function () {
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+
+    expect(toToolAttributeValue(revoked.proxy)).toBeUndefined();
+  });
 });
 
 describe('contentToParts', function () {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
@@ -1180,12 +1180,6 @@ describe('message formatting edge cases', function () {
     ]);
   });
 
-  it('does not throw when message content cannot be read', function () {
-    const revoked = Proxy.revocable({}, {});
-    revoked.revoke();
-    expect((OpenTelemetryCallbackHandler as any)._formatMessageParts(revoked.proxy)).toEqual([]);
-  });
-
   it('serializes multimodal and reasoning content as typed parts', async () => {
     contentCaptureInstrumentation.enable();
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
@@ -1180,6 +1180,12 @@ describe('message formatting edge cases', function () {
     ]);
   });
 
+  it('does not throw when message content cannot be read', function () {
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    expect((OpenTelemetryCallbackHandler as any)._formatMessageParts(revoked.proxy)).toEqual([]);
+  });
+
   it('serializes multimodal and reasoning content as typed parts', async () => {
     contentCaptureInstrumentation.enable();
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
@@ -658,8 +658,61 @@ describe('tool spans', function () {
     expect(span.name).toContain('execute_tool');
     expect(span.attributes[ATTR_GEN_AI_TOOL_NAME]).toBe('add_numbers');
     expect(span.attributes[ATTR_GEN_AI_TOOL_TYPE]).toBe('function');
-    expect(span.attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]).toBeDefined();
+    expect(span.attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]).toBe('{"a":1,"b":2}');
     expect(span.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe('3');
+  });
+
+  it('serializes semantic ToolMessage fields for content_and_artifact results', async () => {
+    contentCaptureInstrumentation.enable();
+
+    const structuredTool = tool(
+      async (input: { a: number; b: number }) => [String(input.a + input.b), { bytes: Buffer.from('ok') }],
+      {
+        name: 'structured_add',
+        description: 'Add two numbers with an artifact',
+        schema: z.object({ a: z.number(), b: z.number() }),
+        responseFormat: 'content_and_artifact',
+      }
+    );
+
+    const result = (await structuredTool.invoke({
+      type: 'tool_call',
+      id: 'call_structured',
+      name: 'structured_add',
+      args: { a: 1, b: 2 },
+    })) as ToolMessage;
+
+    const spans = getTestSpans();
+    const toolSpans = spans.filter((s: ReadableSpan) => s.attributes[ATTR_GEN_AI_OPERATION_NAME] === 'execute_tool');
+    expect(toolSpans.length).toBe(1);
+
+    const span = toolSpans[0];
+    expect(JSON.parse(span.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT] as string)).toEqual({
+      content: '3',
+      tool_call_id: 'call_structured',
+      artifact: { bytes: 'b2s=' },
+      status: 'success',
+      name: 'structured_add',
+      metadata: result.metadata,
+    });
+  });
+
+  it('retains LangChain empty-string omission for tool results', async () => {
+    contentCaptureInstrumentation.enable();
+
+    const emptyTool = tool(async () => '', {
+      name: 'empty_tool',
+      description: 'Return an empty result',
+      schema: z.object({}),
+    });
+
+    await emptyTool.invoke({});
+
+    const toolSpan = getTestSpans().find(
+      (span: ReadableSpan) => span.attributes[ATTR_GEN_AI_TOOL_NAME] === 'empty_tool'
+    );
+    expect(toolSpan).toBeDefined();
+    expect(toolSpan!.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBeUndefined();
   });
 
   it('records error status on tool failure', async () => {
@@ -1093,6 +1146,36 @@ describe('message formatting edge cases', function () {
     expect(textParts.length).toBe(0);
   });
 
+  it('deduplicates Anthropic tool_use content against normalized tool calls', async () => {
+    contentCaptureInstrumentation.enable();
+
+    const llm = new FakeListChatModel({ responses: ['Done.'] });
+    await llm.invoke([
+      new HumanMessage('Look this up'),
+      new AIMessage({
+        content: [{ type: 'tool_use', id: 'call_123', name: 'lookup', input: { query: 'otel' } }] as any,
+        tool_calls: [{ name: 'lookup', args: { query: 'otel' }, id: 'call_123', type: 'tool_call' }],
+      }),
+    ]);
+
+    const chatSpan = getTestSpans().find(
+      (span: ReadableSpan) =>
+        span.attributes[ATTR_GEN_AI_OPERATION_NAME] === 'chat' &&
+        span.instrumentationScope.name === INSTRUMENTATION_NAME
+    );
+    expect(chatSpan).toBeDefined();
+    const inputMessages = JSON.parse(chatSpan!.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
+    const assistant = inputMessages.find((message: any) => message.role === 'assistant');
+    expect(assistant.parts).toEqual([
+      {
+        type: 'tool_call',
+        id: 'call_123',
+        name: 'lookup',
+        arguments: { query: 'otel' },
+      },
+    ]);
+  });
+
   it('handles AI messages with array content blocks', async () => {
     contentCaptureInstrumentation.enable();
 
@@ -1114,8 +1197,78 @@ describe('message formatting edge cases', function () {
     expect(chatSpans.length).toBe(1);
 
     const inputMessages = JSON.parse(chatSpans[0].attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
-    expect(inputMessages[0].parts[0].content).toContain('First part.');
-    expect(inputMessages[0].parts[0].content).toContain('Second part.');
+    expect(inputMessages[0].parts).toEqual([
+      { type: 'text', content: 'First part.' },
+      { type: 'text', content: ' Second part.' },
+    ]);
+  });
+
+  it('serializes multimodal and reasoning content as typed parts', async () => {
+    contentCaptureInstrumentation.enable();
+
+    const llm = new FakeListChatModel({ responses: ['ok'] });
+    const proto = Object.getPrototypeOf(llm);
+    const original = proto._generate;
+    proto._generate = async function (): Promise<ChatResult> {
+      return {
+        generations: [
+          {
+            message: new AIMessage({
+              content: [
+                { type: 'text', text: 'The answer is blue.' },
+                { type: 'thinking', thinking: 'Let me reason about this.' },
+                { type: 'image_url', image_url: { url: 'https://example.com/cat.png' } },
+                { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+              ] as any,
+              response_metadata: { finish_reason: 'stop' },
+            }),
+            text: 'The answer is blue.',
+            generationInfo: { finish_reason: 'stop' },
+          },
+        ],
+        llmOutput: { model_name: 'test' },
+      };
+    };
+
+    try {
+      await llm.invoke([
+        new HumanMessage({
+          content: [
+            { type: 'text', text: 'describe' },
+            { type: 'image_url', image_url: { url: 'https://example.com/cat.png' } },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+            { type: 'image', data: 'BBBB', mimeType: 'image/webp' },
+          ] as any,
+        }),
+      ]);
+    } finally {
+      proto._generate = original;
+    }
+
+    const spans = getTestSpans();
+    const chatSpans = spans.filter(
+      (s: ReadableSpan) =>
+        s.attributes[ATTR_GEN_AI_OPERATION_NAME] === 'chat' && s.instrumentationScope.name === INSTRUMENTATION_NAME
+    );
+    expect(chatSpans.length).toBe(1);
+
+    const inputMessages = JSON.parse(chatSpans[0].attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
+    await validateOtelGenaiSchema(inputMessages, 'gen-ai-input-messages');
+    expect(inputMessages[0].parts).toEqual([
+      { type: 'text', content: 'describe' },
+      { type: 'uri', modality: 'image', uri: 'https://example.com/cat.png' },
+      { type: 'blob', modality: 'image', mime_type: 'image/png', content: 'AAAA' },
+      { type: 'blob', modality: 'image', content: 'BBBB', mime_type: 'image/webp' },
+    ]);
+
+    const outputMessages = JSON.parse(chatSpans[0].attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string);
+    await validateOtelGenaiSchema(outputMessages, 'gen-ai-output-messages');
+    expect(outputMessages[0].parts).toEqual([
+      { type: 'text', content: 'The answer is blue.' },
+      { type: 'reasoning', content: 'Let me reason about this.' },
+      { type: 'uri', modality: 'image', uri: 'https://example.com/cat.png' },
+      { type: 'blob', modality: 'image', mime_type: 'image/png', content: 'AAAA' },
+    ]);
   });
 
   it('suppresses chains with langgraph metadata', async () => {
@@ -1333,6 +1486,18 @@ describe('finish reason normalization', function () {
   afterEach(() => {
     contentCaptureInstrumentation.disable();
     nock.cleanAll();
+  });
+
+  it('reads camelCase finishReason and non-chat generation metadata', function () {
+    const extractFinishReason = (OpenTelemetryCallbackHandler as any)._extractFinishReason;
+    expect(
+      extractFinishReason({
+        message: new AIMessage('done'),
+        text: 'done',
+        generationInfo: { finishReason: 'TOOL_CALL' },
+      })
+    ).toBe('tool_call');
+    expect(extractFinishReason({ text: 'done', generationInfo: { finishReason: 'MAX_TOKENS' } })).toBe('length');
   });
 
   for (const pc of providerCases) {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-langchain/instrumentation.test.ts
@@ -662,41 +662,6 @@ describe('tool spans', function () {
     expect(span.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe('3');
   });
 
-  it('serializes semantic ToolMessage fields for content_and_artifact results', async () => {
-    contentCaptureInstrumentation.enable();
-
-    const structuredTool = tool(
-      async (input: { a: number; b: number }) => [String(input.a + input.b), { bytes: Buffer.from('ok') }],
-      {
-        name: 'structured_add',
-        description: 'Add two numbers with an artifact',
-        schema: z.object({ a: z.number(), b: z.number() }),
-        responseFormat: 'content_and_artifact',
-      }
-    );
-
-    const result = (await structuredTool.invoke({
-      type: 'tool_call',
-      id: 'call_structured',
-      name: 'structured_add',
-      args: { a: 1, b: 2 },
-    })) as ToolMessage;
-
-    const spans = getTestSpans();
-    const toolSpans = spans.filter((s: ReadableSpan) => s.attributes[ATTR_GEN_AI_OPERATION_NAME] === 'execute_tool');
-    expect(toolSpans.length).toBe(1);
-
-    const span = toolSpans[0];
-    expect(JSON.parse(span.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT] as string)).toEqual({
-      content: '3',
-      tool_call_id: 'call_structured',
-      artifact: { bytes: 'b2s=' },
-      status: 'success',
-      name: 'structured_add',
-      metadata: result.metadata,
-    });
-  });
-
   it('retains LangChain empty-string omission for tool results', async () => {
     contentCaptureInstrumentation.enable();
 
@@ -1146,15 +1111,23 @@ describe('message formatting edge cases', function () {
     expect(textParts.length).toBe(0);
   });
 
-  it('deduplicates Anthropic tool_use content against normalized tool calls', async () => {
+  it('uses canonical tool_calls without dropping distinct calls', async () => {
     contentCaptureInstrumentation.enable();
 
     const llm = new FakeListChatModel({ responses: ['Done.'] });
     await llm.invoke([
-      new HumanMessage('Look this up'),
+      new HumanMessage('Run these'),
       new AIMessage({
         content: [{ type: 'tool_use', id: 'call_123', name: 'lookup', input: { query: 'otel' } }] as any,
-        tool_calls: [{ name: 'lookup', args: { query: 'otel' }, id: 'call_123', type: 'tool_call' }],
+        tool_calls: [
+          { name: 'lookup', args: { query: 'otel' }, id: 'call_123', type: 'tool_call' },
+          { name: 'lookup', args: { q: 'first' }, id: 'call_a' },
+          { name: 'lookup', args: { q: 'second' }, id: 'call_b' },
+          { name: 'c', args: { q: 1 }, id: 'a:b', type: 'tool_call' },
+          { name: 'b:c', args: { q: 2 }, id: 'a', type: 'tool_call' },
+          { name: 'lookup', args: { q: 'first' } },
+          { name: 'lookup', args: { q: 'second' } },
+        ] as any,
       }),
     ]);
 
@@ -1166,14 +1139,18 @@ describe('message formatting edge cases', function () {
     expect(chatSpan).toBeDefined();
     const inputMessages = JSON.parse(chatSpan!.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
     const assistant = inputMessages.find((message: any) => message.role === 'assistant');
-    expect(assistant.parts).toEqual([
-      {
-        type: 'tool_call',
-        id: 'call_123',
-        name: 'lookup',
-        arguments: { query: 'otel' },
-      },
+    const toolCallParts = assistant.parts.filter((p: any) => p.type === 'tool_call');
+    expect(assistant.parts.every((part: any) => part.type === 'tool_call')).toBe(true);
+    expect(toolCallParts.map((part: any) => `${part.id}/${part.name}`)).toEqual([
+      'call_123/lookup',
+      'call_a/lookup',
+      'call_b/lookup',
+      'a:b/c',
+      'a/b:c',
+      '/lookup',
+      '/lookup',
     ]);
+    expect(toolCallParts.slice(-2).map((part: any) => part.arguments)).toEqual([{ q: 'first' }, { q: 'second' }]);
   });
 
   it('handles AI messages with array content blocks', async () => {
@@ -1237,7 +1214,7 @@ describe('message formatting edge cases', function () {
             { type: 'text', text: 'describe' },
             { type: 'image_url', image_url: { url: 'https://example.com/cat.png' } },
             { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
-            { type: 'image', data: 'BBBB', mimeType: 'image/webp' },
+            { type: 'image', data: 'BBBB', media_type: 'image/webp' },
           ] as any,
         }),
       ]);
@@ -1486,18 +1463,6 @@ describe('finish reason normalization', function () {
   afterEach(() => {
     contentCaptureInstrumentation.disable();
     nock.cleanAll();
-  });
-
-  it('reads camelCase finishReason and non-chat generation metadata', function () {
-    const extractFinishReason = (OpenTelemetryCallbackHandler as any)._extractFinishReason;
-    expect(
-      extractFinishReason({
-        message: new AIMessage('done'),
-        text: 'done',
-        generationInfo: { finishReason: 'TOOL_CALL' },
-      })
-    ).toBe('tool_call');
-    expect(extractFinishReason({ text: 'done', generationInfo: { finishReason: 'MAX_TOKENS' } })).toBe('length');
   });
 
   for (const pc of providerCases) {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
@@ -326,7 +326,7 @@ describe('OpenAI Agents Instrumentation', function () {
     it('normalizes Responses API text, image, refusal, and reasoning blocks', function () {
       const processor = new OpenTelemetryTracingProcessor(trace.getTracer('openai-agents-content-test'), true) as any;
       expect(
-        processor._contentToParts([
+        processor._formatMessageParts([
           { type: 'input_text', text: 'describe' },
           { type: 'input_image', image: 'data:image/png;base64,AAAA' },
         ])

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
@@ -335,10 +335,6 @@ describe('OpenAI Agents Instrumentation', function () {
         { type: 'blob', modality: 'image', content: 'AAAA', mime_type: 'image/png' },
       ]);
 
-      const revoked = Proxy.revocable({}, {});
-      revoked.revoke();
-      expect(processor._formatMessageParts(revoked.proxy)).toEqual([]);
-
       const outputMessages = JSON.parse(
         processor._formatOutputMessages(
           [

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
@@ -323,89 +323,38 @@ describe('OpenAI Agents Instrumentation', function () {
       expect(parsedOutput[0].parts[0].content).toBe('The answer is 4');
     });
 
-    it('normalizes real Responses API multimodal, refusal, and reasoning items', async () => {
-      const processor = new OpenTelemetryTracingProcessor(trace.getTracer('openai-agents-content-test'), true);
-      const sdkSpan = {
-        spanId: 'multimodal-response-span',
-        parentId: null,
-        spanData: {
-          type: 'response',
-          response_id: 'resp_multimodal',
-          _input: [
+    it('normalizes Responses API text, image, refusal, and reasoning blocks', function () {
+      const processor = new OpenTelemetryTracingProcessor(trace.getTracer('openai-agents-content-test'), true) as any;
+      expect(
+        processor._contentToParts([
+          { type: 'input_text', text: 'describe' },
+          { type: 'input_image', image: 'data:image/png;base64,AAAA' },
+        ])
+      ).toEqual([
+        { type: 'text', content: 'describe' },
+        { type: 'blob', modality: 'image', content: 'AAAA', mime_type: 'image/png' },
+      ]);
+
+      const outputMessages = JSON.parse(
+        processor._formatOutputMessages(
+          [
             {
-              role: 'user',
+              type: 'reasoning',
+              summary: [{ type: 'summary_text', text: 'A concise reasoning summary.' }],
+            },
+            {
+              type: 'message',
               content: [
-                { type: 'input_text', text: 'describe' },
-                { type: 'input_image', image: { id: 'image-file' } },
-                { type: 'input_image', image: 'data:image/png;base64,AAAA' },
-                { type: 'input_file', file: { id: 'document-file' }, filename: 'report.pdf' },
-                { type: 'audio', audio: { id: 'audio-file' }, format: 'mp3' },
-                {
-                  type: 'input_audio',
-                  input_audio: { data: 'AAAA', format: 'wav' },
-                  transcript: 'hello',
-                },
+                { type: 'output_text', text: 'The answer is blue.' },
+                { type: 'refusal', refusal: 'I cannot provide another detail.' },
               ],
             },
           ],
-          _response: {
-            model: OPENAI_MODEL,
-            output: [
-              {
-                type: 'reasoning',
-                id: 'reasoning_summary',
-                summary: [{ type: 'summary_text', text: 'A concise reasoning summary.' }],
-                content: [{ type: 'reasoning_text', text: 'Raw reasoning that should not be captured.' }],
-              },
-              {
-                type: 'reasoning',
-                id: 'reasoning_content',
-                summary: [],
-                content: [{ type: 'reasoning_text', text: 'Fallback reasoning content.' }],
-              },
-              {
-                type: 'message',
-                role: 'assistant',
-                content: [
-                  { type: 'output_text', text: 'The answer is blue.' },
-                  { type: 'refusal', refusal: 'I cannot provide another detail.' },
-                ],
-              },
-            ],
-          },
-        },
-        error: null,
-      };
-
-      await processor.onSpanStart(sdkSpan as any);
-      await processor.onSpanEnd(sdkSpan as any);
-
-      const chatSpan = getTestSpans().find((s: ReadableSpan) => s.attributes[ATTR_GEN_AI_OPERATION_NAME] === 'chat');
-      expect(chatSpan).toBeDefined();
-
-      const inputMessages = JSON.parse(chatSpan!.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
-      await validateOtelGenaiSchema(inputMessages, 'gen-ai-input-messages');
-      expect(inputMessages[0].parts).toEqual([
-        { type: 'text', content: 'describe' },
-        { type: 'file', modality: 'image', file_id: 'image-file' },
-        { type: 'blob', modality: 'image', content: 'AAAA', mime_type: 'image/png' },
-        { type: 'file', modality: 'document', file_id: 'document-file', filename: 'report.pdf' },
-        { type: 'file', modality: 'audio', file_id: 'audio-file', mime_type: 'audio/mp3', format: 'mp3' },
-        {
-          type: 'blob',
-          modality: 'audio',
-          content: 'AAAA',
-          mime_type: 'audio/wav',
-          transcript: 'hello',
-          format: 'wav',
-        },
-      ]);
-
-      const outputMessages = JSON.parse(chatSpan!.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string);
-      await validateOtelGenaiSchema(outputMessages, 'gen-ai-output-messages');
+          ['stop']
+        )
+      );
       expect(outputMessages[0].parts).toEqual([
         { type: 'reasoning', content: 'A concise reasoning summary.' },
-        { type: 'reasoning', content: 'Fallback reasoning content.' },
         { type: 'text', content: 'The answer is blue.' },
         { type: 'refusal', refusal: 'I cannot provide another detail.' },
       ]);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
@@ -335,6 +335,10 @@ describe('OpenAI Agents Instrumentation', function () {
         { type: 'blob', modality: 'image', content: 'AAAA', mime_type: 'image/png' },
       ]);
 
+      const revoked = Proxy.revocable({}, {});
+      revoked.revoke();
+      expect(processor._formatMessageParts(revoked.proxy)).toEqual([]);
+
       const outputMessages = JSON.parse(
         processor._formatOutputMessages(
           [

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-openai-agents/instrumentation.test.ts
@@ -5,10 +5,11 @@
 
 import { instrumentation } from './load-instrumentation';
 import { OpenAIAgentsInstrumentation } from '../../../src/instrumentation/instrumentation-openai-agents/instrumentation';
+import { OpenTelemetryTracingProcessor } from '../../../src/instrumentation/instrumentation-openai-agents/tracing-processor';
 import { getTestSpans, resetMemoryExporter } from '@opentelemetry/contrib-test-utils';
 import * as sinon from 'sinon';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
 import {
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_INPUT_MESSAGES,
@@ -174,7 +175,7 @@ describe('OpenAI Agents Instrumentation', function () {
       const spans = getTestSpans();
       const chatSpans = spans.filter((s: ReadableSpan) => s.attributes[ATTR_GEN_AI_OPERATION_NAME] === 'chat');
       const toolCallSpan = chatSpans.find((s: ReadableSpan) =>
-        (s.attributes[ATTR_GEN_AI_RESPONSE_FINISH_REASONS] as string[] | undefined)?.includes('tool_calls')
+        (s.attributes[ATTR_GEN_AI_RESPONSE_FINISH_REASONS] as string[] | undefined)?.includes('tool_call')
       );
       expect(toolCallSpan).toBeDefined();
     });
@@ -208,6 +209,43 @@ describe('OpenAI Agents Instrumentation', function () {
       expect(toolSpan!.attributes[ATTR_GEN_AI_TOOL_TYPE]).toBe('function');
       expect(toolSpan!.attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]).toBe('{"city":"Tokyo"}');
       expect(toolSpan!.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe('Sunny in Tokyo');
+    });
+
+    it('omits an empty SDK placeholder result from a real Runner tool span', async () => {
+      const emptyTool = tool({
+        name: 'empty_tool',
+        description: 'Return an empty result',
+        parameters: z.object({}),
+        execute: async () => '',
+      });
+      const agent = new Agent({
+        name: 'EmptyToolAgent',
+        instructions: 'Use the empty tool.',
+        model: OPENAI_MODEL,
+        tools: [emptyTool],
+      });
+      const toolCallResponse = {
+        ...OPENAI_RESPONSES_API_TOOL_CALL_RESPONSE,
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_empty',
+            call_id: 'call_empty',
+            name: 'empty_tool',
+            arguments: '{}',
+            status: 'completed',
+          },
+        ],
+      };
+
+      await createRunner([toolCallResponse, OPENAI_RESPONSES_API_CHAT_RESPONSE]).run(agent, 'Run the empty tool');
+
+      const toolSpan = getTestSpans().find(
+        (span: ReadableSpan) => span.attributes[ATTR_GEN_AI_TOOL_NAME] === 'empty_tool'
+      );
+      expect(toolSpan).toBeDefined();
+      expect(toolSpan!.attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]).toBe('{}');
+      expect(toolSpan!.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBeUndefined();
     });
 
     it('does not capture tool arguments/result when captureMessageContent is false', async () => {
@@ -283,6 +321,103 @@ describe('OpenAI Agents Instrumentation', function () {
       await validateOtelGenaiSchema(parsedOutput, 'gen-ai-output-messages');
       expect(parsedOutput[0].role).toBe('assistant');
       expect(parsedOutput[0].parts[0].content).toBe('The answer is 4');
+    });
+
+    it('normalizes real Responses API multimodal, refusal, and reasoning items', async () => {
+      const processor = new OpenTelemetryTracingProcessor(trace.getTracer('openai-agents-content-test'), true);
+      const sdkSpan = {
+        spanId: 'multimodal-response-span',
+        parentId: null,
+        spanData: {
+          type: 'response',
+          response_id: 'resp_multimodal',
+          _input: [
+            {
+              role: 'user',
+              content: [
+                { type: 'input_text', text: 'describe' },
+                { type: 'input_image', image: { id: 'image-file' } },
+                { type: 'input_image', image: 'data:image/png;base64,AAAA' },
+                { type: 'input_file', file: { id: 'document-file' }, filename: 'report.pdf' },
+                { type: 'audio', audio: { id: 'audio-file' }, format: 'mp3' },
+                {
+                  type: 'input_audio',
+                  input_audio: { data: 'AAAA', format: 'wav' },
+                  transcript: 'hello',
+                },
+              ],
+            },
+          ],
+          _response: {
+            model: OPENAI_MODEL,
+            output: [
+              {
+                type: 'reasoning',
+                id: 'reasoning_summary',
+                summary: [{ type: 'summary_text', text: 'A concise reasoning summary.' }],
+                content: [{ type: 'reasoning_text', text: 'Raw reasoning that should not be captured.' }],
+              },
+              {
+                type: 'reasoning',
+                id: 'reasoning_content',
+                summary: [],
+                content: [{ type: 'reasoning_text', text: 'Fallback reasoning content.' }],
+              },
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [
+                  { type: 'output_text', text: 'The answer is blue.' },
+                  { type: 'refusal', refusal: 'I cannot provide another detail.' },
+                ],
+              },
+            ],
+          },
+        },
+        error: null,
+      };
+
+      await processor.onSpanStart(sdkSpan as any);
+      await processor.onSpanEnd(sdkSpan as any);
+
+      const chatSpan = getTestSpans().find((s: ReadableSpan) => s.attributes[ATTR_GEN_AI_OPERATION_NAME] === 'chat');
+      expect(chatSpan).toBeDefined();
+
+      const inputMessages = JSON.parse(chatSpan!.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
+      await validateOtelGenaiSchema(inputMessages, 'gen-ai-input-messages');
+      expect(inputMessages[0].parts).toEqual([
+        { type: 'text', content: 'describe' },
+        { type: 'file', modality: 'image', file_id: 'image-file' },
+        { type: 'blob', modality: 'image', content: 'AAAA', mime_type: 'image/png' },
+        { type: 'file', modality: 'document', file_id: 'document-file', filename: 'report.pdf' },
+        { type: 'file', modality: 'audio', file_id: 'audio-file', mime_type: 'audio/mp3', format: 'mp3' },
+        {
+          type: 'blob',
+          modality: 'audio',
+          content: 'AAAA',
+          mime_type: 'audio/wav',
+          transcript: 'hello',
+          format: 'wav',
+        },
+      ]);
+
+      const outputMessages = JSON.parse(chatSpan!.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string);
+      await validateOtelGenaiSchema(outputMessages, 'gen-ai-output-messages');
+      expect(outputMessages[0].parts).toEqual([
+        { type: 'reasoning', content: 'A concise reasoning summary.' },
+        { type: 'reasoning', content: 'Fallback reasoning content.' },
+        { type: 'text', content: 'The answer is blue.' },
+        { type: 'refusal', refusal: 'I cannot provide another detail.' },
+      ]);
+    });
+
+    it('maps incomplete response details to canonical finish reasons', function () {
+      const processor = new OpenTelemetryTracingProcessor(trace.getTracer('openai-agents-finish-test'), true) as any;
+      expect(processor._getFinishReasons({ incomplete_details: { reason: 'max_output_tokens' } })).toEqual(['length']);
+      expect(processor._getFinishReasons({ incomplete_details: { reason: 'content_filter' } })).toEqual([
+        'content_filter',
+      ]);
+      expect(processor._getFinishReasons({ status: 'failed' })).toEqual(['error']);
     });
 
     it('does not capture messages when disabled', async () => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
@@ -250,7 +250,7 @@ describe('generateText content capture', function () {
 
   it('normalizes image and tool content with the Vercel adapter', function () {
     expect(
-      (VercelAISpanProcessor as any).contentToParts([
+      (VercelAISpanProcessor as any)._contentToParts([
         { type: 'text', text: 'describe' },
         { type: 'file', data: 'AAAA', mediaType: 'image/png' },
         { type: 'tool-call', toolCallId: 'call_1', toolName: 'lookup', args: '{"city":"Tokyo"}' },

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
@@ -272,6 +272,10 @@ describe('generateText content capture', function () {
       },
       { type: 'tool_call_response', id: 'call_1', response: { forecast: 'sunny' } },
     ]);
+
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+    expect((VercelAISpanProcessor as any)._formatMessageParts(revoked.proxy)).toEqual([]);
   });
 });
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
@@ -272,10 +272,6 @@ describe('generateText content capture', function () {
       },
       { type: 'tool_call_response', id: 'call_1', response: { forecast: 'sunny' } },
     ]);
-
-    const revoked = Proxy.revocable({}, {});
-    revoked.revoke();
-    expect((VercelAISpanProcessor as any)._formatMessageParts(revoked.proxy)).toEqual([]);
   });
 });
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
@@ -248,124 +248,29 @@ describe('generateText content capture', function () {
     expect(chatSpans[0].attributes[ATTR_GEN_AI_OUTPUT_MESSAGES]).toBeUndefined();
   });
 
-  it('normalizes multimodal and tool content through shared helpers', async () => {
-    const attributes: Record<string, unknown> = {
-      'ai.operationId': 'ai.generateText.doGenerate',
-      'ai.model.provider': 'openai',
-      'ai.model.id': OPENAI_MODEL,
-      'ai.prompt.messages': [
-        {
-          role: 'user',
-          content: [
-            { type: 'text', text: 'describe' },
-            {
-              type: 'file',
-              data: 'https://base64-by-contract.example',
-              mediaType: 'image/png',
-              filename: 'generated.png',
-            },
-            {
-              type: 'file',
-              data: new URL('https://example.com/report.pdf'),
-              mediaType: 'application/pdf',
-            },
-          ],
-        },
-        {
-          role: 'assistant',
-          content: [{ type: 'tool-call', toolCallId: 'call_1', toolName: 'lookup', args: '{"city":"Tokyo"}' }],
-        },
-        {
-          role: 'tool',
-          content: [{ type: 'tool-result', toolCallId: 'call_1', result: { forecast: 'sunny' } }],
-        },
-      ],
-      'ai.response.text': 'The answer is blue.',
-      'ai.response.reasoning': 'Reasoning summary.',
-      'ai.response.toolCalls': JSON.stringify([
-        { toolCallId: 'call_2', toolName: 'lookup', input: { city: 'Seattle' } },
-      ]),
-      'ai.response.finishReason': 'stop',
-    };
-
-    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
-
-    const inputMessages = JSON.parse(attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
-    await validateOtelGenaiSchema(inputMessages, 'gen-ai-input-messages');
-    expect(inputMessages[0].parts).toEqual([
+  it('normalizes image and tool content with the Vercel adapter', function () {
+    expect(
+      (VercelAISpanProcessor as any).contentToParts([
+        { type: 'text', text: 'describe' },
+        { type: 'file', data: 'AAAA', mediaType: 'image/png' },
+        { type: 'tool-call', toolCallId: 'call_1', toolName: 'lookup', args: '{"city":"Tokyo"}' },
+        { type: 'tool-result', toolCallId: 'call_1', result: { forecast: 'sunny' } },
+      ])
+    ).toEqual([
       { type: 'text', content: 'describe' },
       {
         type: 'blob',
-        modality: 'document',
-        content: 'https://base64-by-contract.example',
+        modality: 'image',
         mime_type: 'image/png',
-        filename: 'generated.png',
+        content: 'AAAA',
       },
       {
-        type: 'uri',
-        modality: 'document',
-        uri: 'https://example.com/report.pdf',
-        mime_type: 'application/pdf',
+        type: 'tool_call',
+        id: 'call_1',
+        name: 'lookup',
+        arguments: { city: 'Tokyo' },
       },
-    ]);
-    expect(inputMessages[1].parts[0]).toEqual({
-      type: 'tool_call',
-      id: 'call_1',
-      name: 'lookup',
-      arguments: { city: 'Tokyo' },
-    });
-    expect(inputMessages[2].parts[0]).toEqual({
-      type: 'tool_call_response',
-      id: 'call_1',
-      response: { forecast: 'sunny' },
-    });
-
-    const outputMessages = JSON.parse(attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string);
-    await validateOtelGenaiSchema(outputMessages, 'gen-ai-output-messages');
-    expect(outputMessages).toEqual([
-      {
-        role: 'assistant',
-        parts: [
-          { type: 'text', content: 'The answer is blue.' },
-          { type: 'reasoning', content: 'Reasoning summary.' },
-          {
-            type: 'tool_call',
-            id: 'call_2',
-            name: 'lookup',
-            arguments: { city: 'Seattle' },
-          },
-        ],
-        finish_reason: 'stop',
-      },
-    ]);
-  });
-
-  it('emits a tool-call-only output message with a canonical finish reason', async () => {
-    const attributes: Record<string, unknown> = {
-      'ai.operationId': 'ai.generateText.doGenerate',
-      'ai.response.toolCalls': JSON.stringify([
-        { toolCallId: 'call_only', toolName: 'lookup', input: '{"city":"Tokyo"}' },
-      ]),
-      'ai.response.finishReason': 'tool-calls',
-    };
-
-    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
-
-    const outputMessages = JSON.parse(attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string);
-    await validateOtelGenaiSchema(outputMessages, 'gen-ai-output-messages');
-    expect(outputMessages).toEqual([
-      {
-        role: 'assistant',
-        parts: [
-          {
-            type: 'tool_call',
-            id: 'call_only',
-            name: 'lookup',
-            arguments: { city: 'Tokyo' },
-          },
-        ],
-        finish_reason: 'tool_call',
-      },
+      { type: 'tool_call_response', id: 'call_1', response: { forecast: 'sunny' } },
     ]);
   });
 });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
@@ -6,6 +6,7 @@
 import { SpanKind } from '@opentelemetry/api';
 import { instrumentation, ensureSpanProcessor } from './load-instrumentation';
 import { VercelAIInstrumentation } from '../../../src/instrumentation/instrumentation-vercel-ai/instrumentation';
+import { VercelAISpanProcessor } from '../../../src/instrumentation/instrumentation-vercel-ai/span-processor';
 import * as sinon from 'sinon';
 import { getTestSpans, resetMemoryExporter } from '@opentelemetry/contrib-test-utils';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
@@ -105,6 +106,21 @@ function mockMultiStepFetch(pc: ProviderTestCase): typeof globalThis.fetch {
       headers: { 'content-type': 'application/json' },
     });
   }) as typeof fetch;
+}
+
+function createVercelSpan(attributes: Record<string, unknown>): ReadableSpan {
+  return {
+    name: 'ai.test',
+    kind: SpanKind.INTERNAL,
+    instrumentationScope: { name: 'ai' },
+    attributes,
+    parentSpanContext: undefined,
+    spanContext: () => ({
+      traceId: '0'.repeat(32),
+      spanId: '1'.repeat(16),
+      traceFlags: 1,
+    }),
+  } as unknown as ReadableSpan;
 }
 
 before(() => {
@@ -231,6 +247,127 @@ describe('generateText content capture', function () {
     expect(chatSpans[0].attributes[ATTR_GEN_AI_INPUT_MESSAGES]).toBeUndefined();
     expect(chatSpans[0].attributes[ATTR_GEN_AI_OUTPUT_MESSAGES]).toBeUndefined();
   });
+
+  it('normalizes multimodal and tool content through shared helpers', async () => {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText.doGenerate',
+      'ai.model.provider': 'openai',
+      'ai.model.id': OPENAI_MODEL,
+      'ai.prompt.messages': [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'describe' },
+            {
+              type: 'file',
+              data: 'https://base64-by-contract.example',
+              mediaType: 'image/png',
+              filename: 'generated.png',
+            },
+            {
+              type: 'file',
+              data: new URL('https://example.com/report.pdf'),
+              mediaType: 'application/pdf',
+            },
+          ],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'tool-call', toolCallId: 'call_1', toolName: 'lookup', args: '{"city":"Tokyo"}' }],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'tool-result', toolCallId: 'call_1', result: { forecast: 'sunny' } }],
+        },
+      ],
+      'ai.response.text': 'The answer is blue.',
+      'ai.response.reasoning': 'Reasoning summary.',
+      'ai.response.toolCalls': JSON.stringify([
+        { toolCallId: 'call_2', toolName: 'lookup', input: { city: 'Seattle' } },
+      ]),
+      'ai.response.finishReason': 'stop',
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    const inputMessages = JSON.parse(attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
+    await validateOtelGenaiSchema(inputMessages, 'gen-ai-input-messages');
+    expect(inputMessages[0].parts).toEqual([
+      { type: 'text', content: 'describe' },
+      {
+        type: 'blob',
+        modality: 'document',
+        content: 'https://base64-by-contract.example',
+        mime_type: 'image/png',
+        filename: 'generated.png',
+      },
+      {
+        type: 'uri',
+        modality: 'document',
+        uri: 'https://example.com/report.pdf',
+        mime_type: 'application/pdf',
+      },
+    ]);
+    expect(inputMessages[1].parts[0]).toEqual({
+      type: 'tool_call',
+      id: 'call_1',
+      name: 'lookup',
+      arguments: { city: 'Tokyo' },
+    });
+    expect(inputMessages[2].parts[0]).toEqual({
+      type: 'tool_call_response',
+      id: 'call_1',
+      response: { forecast: 'sunny' },
+    });
+
+    const outputMessages = JSON.parse(attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string);
+    await validateOtelGenaiSchema(outputMessages, 'gen-ai-output-messages');
+    expect(outputMessages).toEqual([
+      {
+        role: 'assistant',
+        parts: [
+          { type: 'text', content: 'The answer is blue.' },
+          { type: 'reasoning', content: 'Reasoning summary.' },
+          {
+            type: 'tool_call',
+            id: 'call_2',
+            name: 'lookup',
+            arguments: { city: 'Seattle' },
+          },
+        ],
+        finish_reason: 'stop',
+      },
+    ]);
+  });
+
+  it('emits a tool-call-only output message with a canonical finish reason', async () => {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText.doGenerate',
+      'ai.response.toolCalls': JSON.stringify([
+        { toolCallId: 'call_only', toolName: 'lookup', input: '{"city":"Tokyo"}' },
+      ]),
+      'ai.response.finishReason': 'tool-calls',
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    const outputMessages = JSON.parse(attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string);
+    await validateOtelGenaiSchema(outputMessages, 'gen-ai-output-messages');
+    expect(outputMessages).toEqual([
+      {
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool_call',
+            id: 'call_only',
+            name: 'lookup',
+            arguments: { city: 'Tokyo' },
+          },
+        ],
+        finish_reason: 'tool_call',
+      },
+    ]);
+  });
 });
 
 describe('generateText tool calls', function () {
@@ -293,6 +430,32 @@ describe('generateText tool calls', function () {
       resetMemoryExporter();
     });
   }
+
+  it('preserves structured tool arguments and results through shared serialization', function () {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.toolCall',
+      'ai.toolCall.name': 'structured_add',
+      'ai.toolCall.args': '{"a":1,"b":2}',
+      'ai.toolCall.result': '{"content":{"sum":3},"artifact":{"id":"artifact-1"}}',
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    expect(attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]).toBe('{"a":1,"b":2}');
+    expect(attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe('{"content":{"sum":3},"artifact":{"id":"artifact-1"}}');
+  });
+
+  it('preserves an explicitly present empty telemetry value', function () {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.toolCall',
+      'ai.toolCall.name': 'empty_result',
+      'ai.toolCall.result': '',
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    expect(attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe('');
+  });
 
   for (const pc of providerCases) {
     it(`${pc.name} maps tool_calls finish reason correctly`, async () => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
@@ -250,7 +250,7 @@ describe('generateText content capture', function () {
 
   it('normalizes image and tool content with the Vercel adapter', function () {
     expect(
-      (VercelAISpanProcessor as any)._contentToParts([
+      (VercelAISpanProcessor as any)._formatMessageParts([
         { type: 'text', text: 'describe' },
         { type: 'file', data: 'AAAA', mediaType: 'image/png' },
         { type: 'tool-call', toolCallId: 'call_1', toolName: 'lookup', args: '{"city":"Tokyo"}' },


### PR DESCRIPTION
Fixes GenAI message content serialization so list-valued multimodal and reasoning content is emitted as typed OTel message parts instead of being flattened or stringified across LangChain, OpenAI Agents, and Vercel AI.

Adds a shared `contentToParts` helper that maps text, reasoning, image URI, and image blob blocks to their OTel representations, with small `_formatMessageParts` adapters for each SDK. Also aligns tool call argument/result serialization with OTel util-genai: primitives remain native span attribute values, objects and arrays are JSON-serialized, and binary values are base64-encoded so multimodal blob content survives.