### PR TITLE
Temporarily suppress Trivy CVEs until 2026-08-24

### DIFF
--- a/.github/trivy/daily-scan.trivyignore.yaml
+++ b/.github/trivy/daily-scan.trivyignore.yaml
@@ -13,24 +13,32 @@
 vulnerabilities:
   - id: CVE-2026-33036
     statement: "fast-xml-parser numeric entity expansion DoS. Low risk for ADOT JS: XML parsing only occurs on trusted AWS API responses, not user-supplied input. Fix in PR #369, will ship with next scheduled release."
-    expired_at: 2026-06-22
+    expired_at: 2026-08-24
 
   - id: CVE-2026-44665
     statement: "fast-xml-builder attribute value quote bypass. Low risk for ADOT JS: XML building only occurs for trusted AWS API request payloads, not user-supplied input. Fix available in 1.1.7."
-    expired_at: 2026-06-22
+    expired_at: 2026-08-24
 
   - id: CVE-2026-44902
     statement: "Prometheus exporter process crash via malformed HTTP request. Will be fixed in #425 and released in next scheduled release."
-    expired_at: 2026-06-22
+    expired_at: 2026-08-24
 
   - id: CVE-2026-59892
     statement: "@opentelemetry/propagator-jaeger DoS via malformed HTTP header decoding. Fix: bump to 2.9.0. https://avd.aquasec.com/nvd/cve-2026-59892"
-    expired_at: 2026-08-07
+    expired_at: 2026-08-24
 
   - id: CVE-2026-13149
     statement: "brace-expansion DoS via exponential-time complexity. Fix: bump to 2.1.2. https://avd.aquasec.com/nvd/cve-2026-13149"
-    expired_at: 2026-08-07
+    expired_at: 2026-08-24
 
   - id: CVE-2026-14257
     statement: "brace-expansion <=5.0.7 DoS via memory exhaustion in expand() (result count is bounded but per-result string length is not). Only exploitable if attacker-influenced strings reach expand() via minimatch/glob brace patterns. In ADOT JS, glob/minimatch inputs are build/config-time patterns, not user-supplied runtime input, so not exploitable in the agent runtime. Fix: bump to 5.0.8 (adds maxLength bound). https://avd.aquasec.com/nvd/cve-2026-14257"
-    expired_at: 2026-08-07
+    expired_at: 2026-08-24
+
+  - id: CVE-2026-69152
+    statement: "brace-expansion DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. Temporary suppression pending dependency update. Fix: bump to 2.1.4 or 5.0.9. https://avd.aquasec.com/nvd/cve-2026-69152"
+    expired_at: 2026-08-24
+
+  - id: CVE-2026-59877
+    statement: "protobufjs DoS via crafted .proto schema. Temporary suppression pending dependency update. Fix: bump to 7.6.5. https://avd.aquasec.com/nvd/cve-2026-59877"
+    expired_at: 2026-08-24

--- a/.github/trivy/pr-build.trivyignore.yaml
+++ b/.github/trivy/pr-build.trivyignore.yaml
@@ -11,20 +11,28 @@
 vulnerabilities:
   - id: CVE-2026-33036
     statement: "fast-xml-parser numeric entity expansion DoS. Low risk for ADOT JS: XML parsing only occurs on trusted AWS API responses, not user-supplied input. Fix in PR #369, will ship with next scheduled release. Ticket: V2145663734"
-    expired_at: 2026-06-22
+    expired_at: 2026-08-24
 
   - id: CVE-2026-44665
     statement: "fast-xml-builder attribute value quote bypass. Low risk for ADOT JS: XML building only occurs for trusted AWS API request payloads, not user-supplied input. Fix available in 1.1.7."
-    expired_at: 2026-06-22
+    expired_at: 2026-08-24
 
   - id: CVE-2026-44902
     statement: "Prometheus exporter process crash via malformed HTTP request. Will be fixed in #425 and released in next scheduled release."
-    expired_at: 2026-06-22
+    expired_at: 2026-08-24
 
   - id: CVE-2026-59892
     statement: "@opentelemetry/propagator-jaeger DoS via malformed HTTP header decoding. Fix: bump to 2.9.0. https://avd.aquasec.com/nvd/cve-2026-59892"
-    expired_at: 2026-08-07
+    expired_at: 2026-08-24
 
   - id: CVE-2026-14257
     statement: "brace-expansion <=5.0.7 DoS via memory exhaustion in expand() (result count is bounded but per-result string length is not). Only exploitable if attacker-influenced strings reach expand() via minimatch/glob brace patterns. In ADOT JS, glob/minimatch inputs are build/config-time patterns, not user-supplied runtime input, so not exploitable in the agent runtime. Fix: bump to 5.0.8 (adds maxLength bound). https://avd.aquasec.com/nvd/cve-2026-14257"
-    expired_at: 2026-08-07
+    expired_at: 2026-08-24
+
+  - id: CVE-2026-69152
+    statement: "brace-expansion DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. Temporary suppression pending dependency update. Fix: bump to 2.1.4 or 5.0.9. https://avd.aquasec.com/nvd/cve-2026-69152"
+    expired_at: 2026-08-24
+
+  - id: CVE-2026-59877
+    statement: "protobufjs DoS via crafted .proto schema. Temporary suppression pending dependency update. Fix: bump to 7.6.5. https://avd.aquasec.com/nvd/cve-2026-59877"
+    expired_at: 2026-08-24


### PR DESCRIPTION
## Description

- Extends the existing PR-build and daily-scan Trivy suppressions through 2026-08-24.
- Adds CVE-2026-69152 (`brace-expansion`) and CVE-2026-59877 (`protobufjs`), which are present in the current Trivy database.
- Keeps remediation versions and vulnerability references in each new suppression.

## Testing

- Validated both ignore files parse as YAML and contain unique CVE IDs with required fields.
- Ran Trivy v0.69.2 against `public.ecr.aws/aws-observability/adot-autoinstrumentation-node:v0.12.0`; 0 unsuppressed vulnerabilities remain.
- Ran `git diff --check`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.