### PR TITLE
Scope the cloudwatch-plugin-otel release to its own test suites

### DIFF
--- a/.github/workflows/release-cloudwatch-plugin-otel.yml
+++ b/.github/workflows/release-cloudwatch-plugin-otel.yml
@@ -20,13 +20,20 @@ jobs:
       - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
-      - name: Set up Node and run Unit Tests
+      # run_unit_tests is false because the set_up action runs the ROOT test script (lerna run
+      # test = every workspace): this release must gate on the plugin's own suites only, not on
+      # unrelated workspaces whose tests can flake the publish.
+      - name: Set up Node
         uses: ./.github/actions/set_up
         with:
           node_version: "24"
           package_name: "@aws/cloudwatch-plugin-otel"
           os: ubuntu-latest
-          run_unit_tests: true
+          run_unit_tests: false
+
+      - name: Run unit tests
+        working-directory: cloudwatch-plugin-otel
+        run: npm test
 
       # The release runner provides a Docker daemon (same as the PR build's compat-tests job), so
       # the full contract suite — all wiring modes and attribute families — gates the release.


### PR DESCRIPTION
## Description

The plugin's release workflow ran unit tests through the shared `set_up` action, whose test step executes the **root** script (`lerna run test`) — every workspace in the repo. A release of `@aws/cloudwatch-plugin-otel` was therefore gated on ~1700 tests for code it does not ship, and a timing-flaky sampler test in the autoinstrumentation workspace (`AwsXrayRemoteSampler > testUpdateSamplingRulesAndTargetsWithPollersAndShouldSampled`) failed a release run today: https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/32786369082/attempts/1

This scopes the release gates to the plugin itself:

- `set_up` now runs with `run_unit_tests: false` (node setup + dependency install only)
- a new step runs `npm test` from `cloudwatch-plugin-otel/` (the plugin's unit suite)
- the existing contract-test and packed-tarball validation steps were already plugin-scoped and are unchanged

This also addresses the review feedback on PR #520 that the reused action ignores its `package_name` input and tests every workspace.

## Testing

- YAML parses; the new step mirrors the already-working contract-test step (same working-directory pattern).
- The plugin's `npm test` runs its 94 unit tests in isolation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.