### PR TITLE
Pre-release cloudwatch-plugin-otel: update version to 0.1.0

### DIFF
--- a/cloudwatch-plugin-otel/CHANGELOG.md
+++ b/cloudwatch-plugin-otel/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History: @aws/cloudwatch-plugin-otel
 
-## Unreleased
+## v0.1.0 - 2026-08-25
 
 * Initial release: in-process span-derived RED metrics for the OpenTelemetry JS SDK ([#520](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/520))

--- a/cloudwatch-plugin-otel/package.json
+++ b/cloudwatch-plugin-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/cloudwatch-plugin-otel",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Generates span-derived RED metrics inside the OpenTelemetry JS SDK, from 100% of spans, before trace sampling.",
   "author": {
     "name": "Amazon Web Services",

--- a/cloudwatch-plugin-otel/src/version.ts
+++ b/cloudwatch-plugin-otel/src/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "0.0.1";
+export const LIB_VERSION = "0.1.0";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,7 +1217,7 @@
     },
     "cloudwatch-plugin-otel": {
       "name": "@aws/cloudwatch-plugin-otel",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/sdk-trace-base": "^2.0.0"


### PR DESCRIPTION
## Description

Prepares the first regular release of `@aws/cloudwatch-plugin-otel`:

- `package.json` version `0.0.1` → `0.1.0` (0.0.1 was the manual bootstrap publish that seeded the npm package for trusted publishing)
- CHANGELOG `Unreleased` section dated as `v0.1.0 - 2026-08-25`
- Generated `src/version.ts` (`LIB_VERSION`) and root lockfile synced

Verified: the plugin's unit suite passes with the bumped version (94 tests; `LIB_VERSION` regenerates from `package.json` via the precompile hook), and the lockfile diff is the version field only.

After merge, the release runs via the `Release CloudWatch Plugin for OpenTelemetry` workflow with input `0.1.0`, publishing over the now-configured trusted publisher with provenance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.