### PR TITLE
fix(vercel-ai): normalize ai.prompt input messages and treat declared tools as an agent signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(vercel-ai): normalize ai.prompt input messages and treat declared tools as an agent signal
+  ([#536](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/536))
 - fix(agent-observability): suppress invalid instrumentation startup logs
   ([#531](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/531))
 - test(agent-observability): validate the oldest and latest supported LangChain and OpenAI Agents releases,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -51,6 +51,7 @@ import {
 } from '../common/instrumentation-utils';
 import { LIB_VERSION } from '../../version';
 import { INSTRUMENTATION_NAME } from './instrumentation';
+import type { ModelMessage, Prompt } from 'ai';
 
 export class VercelAISpanProcessor implements SpanProcessor {
   // Span processor that translates VercelAI span attributes into OTel GenAI semantic conventions.
@@ -194,9 +195,6 @@ export class VercelAISpanProcessor implements SpanProcessor {
           signals.toolCalls++;
         } else {
           signals.llmCalls++;
-          // A request that declares tools is an agent turn even when the model chose not to call
-          // any. ai.prompt.tools is only recorded on the inner doGenerate/doStream span, so hoist
-          // it to the parent alongside the call counts.
           const tools = attrs['ai.prompt.tools'];
           if (Array.isArray(tools) && tools.length > 0) {
             signals.toolDefs++;
@@ -292,36 +290,40 @@ export class VercelAISpanProcessor implements SpanProcessor {
     try {
       const parsed = typeof value === 'string' ? JSON.parse(value) : value;
 
-      // ai.prompt.messages is already a message array, but ai.prompt carries the caller's raw
-      // args instead — { system?, prompt?, messages? } — so flatten it into the same shape before
-      // formatting. Anything we don't recognize falls through to the raw value, since the ai.*
-      // attributes are deleted in onEnd and dropping it would lose the prompt entirely.
-      let messages: any[];
+      let messages: ModelMessage[];
       if (Array.isArray(parsed)) {
-        messages = parsed;
+        messages = parsed as ModelMessage[];
       } else if (parsed && typeof parsed === 'object') {
+        const {
+          system,
+          prompt,
+          messages: promptMessages,
+        } = parsed as {
+          system?: Prompt['system'];
+          prompt?: string | ModelMessage[];
+          messages?: ModelMessage[];
+        };
         messages = [];
-        const system = parsed.system;
         for (const entry of Array.isArray(system) ? system : [system]) {
           if (entry == null) continue;
           messages.push(
-            typeof entry === 'object'
-              ? { role: entry.role ?? 'system', content: entry.content }
-              : { role: 'system', content: entry }
+            typeof entry === 'object' ? { role: 'system', content: entry.content } : { role: 'system', content: entry }
           );
         }
-        if (parsed.prompt != null) {
-          messages.push({ role: 'user', content: parsed.prompt });
+        if (Array.isArray(prompt)) {
+          messages.push(...prompt);
+        } else if (prompt != null) {
+          messages.push({ role: 'user', content: prompt });
         }
-        if (Array.isArray(parsed.messages)) {
-          messages.push(...parsed.messages);
+        if (Array.isArray(promptMessages)) {
+          messages.push(...promptMessages);
         }
         if (messages.length === 0) return value;
       } else {
         return value;
       }
 
-      const formatted = messages.map((msg: any) => {
+      const formatted = messages.map(msg => {
         return { role: msg.role, parts: VercelAISpanProcessor._formatMessageParts(msg.content) };
       });
       return serializeToJson(formatted);

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/span-processor.ts
@@ -56,8 +56,8 @@ export class VercelAISpanProcessor implements SpanProcessor {
   // Span processor that translates VercelAI span attributes into OTel GenAI semantic conventions.
 
   // Vercel AI does not record whether a request was configured as an agentic workflow in its span attributes.
-  // We detect agents by tracking child spans if it either has tool use or multiple LLM calls.
-  private _spanIdToCounts: Map<string, { llmCalls: number; toolCalls: number }> = new Map();
+  // We detect agents by tracking child spans: declared tools, tool use, or multiple LLM calls.
+  private _spanIdToCounts: Map<string, { llmCalls: number; toolCalls: number; toolDefs: number }> = new Map();
 
   private static readonly ATTRIBUTE_MAP: AttributeMapping[] = [
     {
@@ -189,11 +189,18 @@ export class VercelAISpanProcessor implements SpanProcessor {
     ) {
       const parentSpanId = span.parentSpanContext?.spanId;
       if (parentSpanId) {
-        const signals = this._spanIdToCounts.get(parentSpanId) ?? { llmCalls: 0, toolCalls: 0 };
+        const signals = this._spanIdToCounts.get(parentSpanId) ?? { llmCalls: 0, toolCalls: 0, toolDefs: 0 };
         if (operationId === 'ai.toolCall') {
           signals.toolCalls++;
         } else {
           signals.llmCalls++;
+          // A request that declares tools is an agent turn even when the model chose not to call
+          // any. ai.prompt.tools is only recorded on the inner doGenerate/doStream span, so hoist
+          // it to the parent alongside the call counts.
+          const tools = attrs['ai.prompt.tools'];
+          if (Array.isArray(tools) && tools.length > 0) {
+            signals.toolDefs++;
+          }
         }
         this._spanIdToCounts.set(parentSpanId, signals);
       }
@@ -271,20 +278,49 @@ export class VercelAISpanProcessor implements SpanProcessor {
    * connected to a Generative AI model invokes the concept of an agent."
    * See: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/
    *
-   * We detect this if the LLM used any tools or made more than one LLM call.
+   * We detect this if the LLM had tools available, used any, or made more than one LLM call.
    */
   private isAgentSpan(span: ReadableSpan): boolean {
     const spanId = span.spanContext().spanId;
     const signals = this._spanIdToCounts.get(spanId);
     this._spanIdToCounts.delete(spanId);
     if (!signals) return false;
-    return signals.toolCalls > 0 || signals.llmCalls > 1;
+    return signals.toolDefs > 0 || signals.toolCalls > 0 || signals.llmCalls > 1;
   }
 
   private static formatInputMessages(value: string): string | undefined {
     try {
-      const messages = typeof value === 'string' ? JSON.parse(value) : value;
-      if (!Array.isArray(messages)) return value;
+      const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+
+      // ai.prompt.messages is already a message array, but ai.prompt carries the caller's raw
+      // args instead — { system?, prompt?, messages? } — so flatten it into the same shape before
+      // formatting. Anything we don't recognize falls through to the raw value, since the ai.*
+      // attributes are deleted in onEnd and dropping it would lose the prompt entirely.
+      let messages: any[];
+      if (Array.isArray(parsed)) {
+        messages = parsed;
+      } else if (parsed && typeof parsed === 'object') {
+        messages = [];
+        const system = parsed.system;
+        for (const entry of Array.isArray(system) ? system : [system]) {
+          if (entry == null) continue;
+          messages.push(
+            typeof entry === 'object'
+              ? { role: entry.role ?? 'system', content: entry.content }
+              : { role: 'system', content: entry }
+          );
+        }
+        if (parsed.prompt != null) {
+          messages.push({ role: 'user', content: parsed.prompt });
+        }
+        if (Array.isArray(parsed.messages)) {
+          messages.push(...parsed.messages);
+        }
+        if (messages.length === 0) return value;
+      } else {
+        return value;
+      }
+
       const formatted = messages.map((msg: any) => {
         return { role: msg.role, parts: VercelAISpanProcessor._formatMessageParts(msg.content) };
       });

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
@@ -144,16 +144,22 @@ function mockMultiStepFetch(pc: ProviderTestCase): typeof globalThis.fetch {
   }) as typeof fetch;
 }
 
-function createVercelSpan(attributes: Record<string, unknown>): ReadableSpan {
+function createVercelSpan(
+  attributes: Record<string, unknown>,
+  ids: { spanId?: string; parentSpanId?: string } = {}
+): ReadableSpan {
+  const spanId = ids.spanId ?? '1'.repeat(16);
   return {
     name: 'ai.test',
     kind: SpanKind.INTERNAL,
     instrumentationScope: { name: 'ai' },
     attributes,
-    parentSpanContext: undefined,
+    parentSpanContext: ids.parentSpanId
+      ? { traceId: '0'.repeat(32), spanId: ids.parentSpanId, traceFlags: 1 }
+      : undefined,
     spanContext: () => ({
       traceId: '0'.repeat(32),
-      spanId: '1'.repeat(16),
+      spanId,
       traceFlags: 1,
     }),
   } as unknown as ReadableSpan;
@@ -525,6 +531,146 @@ describe('generateText agent detection', function () {
     const spans = getTestSpans();
     const agentSpans = spans.filter((s: ReadableSpan) => s.attributes[ATTR_GEN_AI_OPERATION_NAME] === 'invoke_agent');
     expect(agentSpans.length).toBe(0);
+  });
+
+  it('detects agent span when tools are declared but the model calls none', async () => {
+    const model = getModel(providerCases[0]);
+
+    const weatherTool = (tool as any)({
+      description: 'Get weather',
+      parameters: z.object({ location: z.string() }),
+      execute: async ({ location }: { location: string }) => `Sunny in ${location}`,
+    });
+
+    await generateText({
+      model,
+      prompt: 'Hello',
+      tools: { get_weather: weatherTool },
+    } as any);
+
+    const spans = getTestSpans();
+    const agentSpans = spans.filter((s: ReadableSpan) => s.attributes[ATTR_GEN_AI_OPERATION_NAME] === 'invoke_agent');
+    if (expectToolDefinitions) {
+      expect(agentSpans.length).toBeGreaterThanOrEqual(1);
+    } else {
+      expect(agentSpans.length).toBe(0);
+    }
+  });
+
+  it('hoists declared tools from the inner span to classify the parent as invoke_agent', function () {
+    const processor = new VercelAISpanProcessor();
+    const parentSpanId = 'a'.repeat(16);
+
+    const inner: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText.doGenerate',
+      'ai.prompt.tools': [JSON.stringify({ type: 'function', name: 'emit_suggestions' })],
+    };
+    processor.onEnd(createVercelSpan(inner, { spanId: 'b'.repeat(16), parentSpanId }));
+    expect(inner[ATTR_GEN_AI_OPERATION_NAME]).toBe('chat');
+
+    const outer: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText',
+      'ai.telemetry.functionId': 'horizon-loop-agent',
+    };
+    const outerSpan = createVercelSpan(outer, { spanId: parentSpanId });
+    processor.onEnd(outerSpan);
+
+    expect(outer[ATTR_GEN_AI_OPERATION_NAME]).toBe('invoke_agent');
+    expect(outerSpan.name).toBe('invoke_agent horizon-loop-agent');
+  });
+
+  it('leaves the parent as chat when the inner span declares no tools', function () {
+    const processor = new VercelAISpanProcessor();
+    const parentSpanId = 'c'.repeat(16);
+
+    processor.onEnd(
+      createVercelSpan({ 'ai.operationId': 'ai.generateText.doGenerate' }, { spanId: 'd'.repeat(16), parentSpanId })
+    );
+
+    const outer: Record<string, unknown> = { 'ai.operationId': 'ai.generateText' };
+    processor.onEnd(createVercelSpan(outer, { spanId: parentSpanId }));
+
+    expect(outer[ATTR_GEN_AI_OPERATION_NAME]).toBe('chat');
+  });
+});
+
+describe('input message normalization', function () {
+  this.timeout(15000);
+
+  beforeEach(() => {
+    resetMemoryExporter();
+  });
+
+  it('normalizes the ai.prompt object emitted on the outer span', async function () {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText',
+      'ai.prompt': JSON.stringify({
+        system: [
+          { role: 'system', content: 'You are terse.' },
+          { role: 'system', content: 'Cite sources.' },
+        ],
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'Any anomalies?' }] }],
+      }),
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    const inputMessages = JSON.parse(attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
+    await validateOtelGenaiSchema(inputMessages, 'gen-ai-input-messages');
+    expect(inputMessages).toEqual([
+      { role: 'system', parts: [{ type: 'text', content: 'You are terse.' }] },
+      { role: 'system', parts: [{ type: 'text', content: 'Cite sources.' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'Any anomalies?' }] },
+    ]);
+  });
+
+  it('normalizes a string system prompt and the prompt shorthand', function () {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText',
+      'ai.prompt': JSON.stringify({ system: 'Be brief.', prompt: 'Hello' }),
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    expect(JSON.parse(attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string)).toEqual([
+      { role: 'system', parts: [{ type: 'text', content: 'Be brief.' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+    ]);
+  });
+
+  it('leaves an already normalized message array untouched', function () {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText.doGenerate',
+      'ai.prompt.messages': JSON.stringify([{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }]),
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    expect(JSON.parse(attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string)).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+    ]);
+  });
+
+  it('keeps the raw value when the prompt shape is unrecognized', function () {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText',
+      'ai.prompt': '{"unexpected":true}',
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    expect(attributes[ATTR_GEN_AI_INPUT_MESSAGES]).toBe('{"unexpected":true}');
+  });
+
+  it('keeps the raw value when the prompt is not JSON', function () {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText',
+      'ai.prompt': 'not json{',
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    expect(attributes[ATTR_GEN_AI_INPUT_MESSAGES]).toBe('not json{');
   });
 });
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/instrumentation/instrumentation-vercel-ai/instrumentation.test.ts
@@ -638,6 +638,46 @@ describe('input message normalization', function () {
     ]);
   });
 
+  it('normalizes the array form of prompt as messages, not as user content', async function () {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText',
+      'ai.prompt': JSON.stringify({
+        prompt: [
+          { role: 'user', content: 'What is the weather?' },
+          { role: 'assistant', content: [{ type: 'text', text: 'Where?' }] },
+          { role: 'user', content: 'Tokyo' },
+        ],
+      }),
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    const inputMessages = JSON.parse(attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string);
+    await validateOtelGenaiSchema(inputMessages, 'gen-ai-input-messages');
+    expect(inputMessages).toEqual([
+      { role: 'user', parts: [{ type: 'text', content: 'What is the weather?' }] },
+      { role: 'assistant', parts: [{ type: 'text', content: 'Where?' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'Tokyo' }] },
+    ]);
+  });
+
+  it('normalizes a single SystemModelMessage system prompt', function () {
+    const attributes: Record<string, unknown> = {
+      'ai.operationId': 'ai.generateText',
+      'ai.prompt': JSON.stringify({
+        system: { role: 'system', content: 'Be brief.', providerOptions: { anthropic: {} } },
+        prompt: 'Hello',
+      }),
+    };
+
+    new VercelAISpanProcessor().onEnd(createVercelSpan(attributes));
+
+    expect(JSON.parse(attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string)).toEqual([
+      { role: 'system', parts: [{ type: 'text', content: 'Be brief.' }] },
+      { role: 'user', parts: [{ type: 'text', content: 'Hello' }] },
+    ]);
+  });
+
   it('leaves an already normalized message array untouched', function () {
     const attributes: Record<string, unknown> = {
       'ai.operationId': 'ai.generateText.doGenerate',


### PR DESCRIPTION
## Description of changes

Two fixes to the Vercel AI span processor, both affecting the outer `ai.generateText` / `ai.streamText` / `ai.generateObject` / `ai.streamObject` span.

**1. `gen_ai.input.messages` was not normalized on the outer span.** The inner `doGenerate`/`doStream` span carries `ai.prompt.messages` (a `ModelMessage` array), but the outer span carries `ai.prompt`, which all four call sites record as `JSON.stringify({ system, prompt, messages })` — the caller's raw prompt args. `formatInputMessages` early-returned anything that wasn't an array, so provider-native data landed in a semconv attribute slot and consumers expecting the semconv shape fail on it.

The `Prompt` type makes that shape closed, so every case is now flattened into the semconv message array:

Before:
```
{
  "system": [
    {
      "role": "system",
      "content": "You are terse."
    },
    {
      "role": "system",
      "content": "Report operational anomalies only."
    }
  ],
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "Any anomalies in Seattle?"
        }
      ]
    }
  ]
}
```

After:
```
[
  {
    "role": "system",
    "parts": [
      {
        "type": "text",
        "content": "You are terse."
      }
    ]
  },
  {
    "role": "system",
    "parts": [
      {
        "type": "text",
        "content": "Report operational anomalies only."
      }
    ]
  },
  {
    "role": "user",
    "parts": [
      {
        "type": "text",
        "content": "Any anomalies in Seattle?"
      }
    ]
  }
]
```

The flattening is typed against the AI SDK's own `Prompt` / `ModelMessage` types (type-only import, erased at compile time — no runtime dependency, and nothing leaks into the emitted `.d.ts`). The remaining raw-value returns are unreachable for anything the SDK emits; they're there because `onEnd` deletes every `ai.*` attribute after mapping, so returning `undefined` would leave the span with no input at all.

**2. A turn that declared tools but called none was classified as `chat`.** `isAgentSpan` only counted executed `ai.toolCall` spans and LLM calls, so an agent whose model chose not to invoke a tool got `gen_ai.operation.name = chat`. `ai.prompt.tools` is only recorded on the inner span, so it's now hoisted to the parent alongside the call counts and treated as an agent signal.

## Test plan

Added 10 tests to `instrumentation-vercel-ai/instrumentation.test.ts`: each `system` form, both `prompt` forms, the already-normalized array, both raw-fallback paths, and agent classification with tools declared-but-unused. Input shapes are validated against the `gen-ai-input-messages` schema. 5 fail on `main` and pass here; the rest are regression guards.

Full package suite passes (1796). `lint` and `tsc` clean, no new warnings in the touched files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
