### PR TITLE
fix: apply Trivy ignores to main build

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -74,6 +74,7 @@ jobs:
           node_version: "24"
           package_name: aws-distro-opentelemetry-node-autoinstrumentation
           os: ubuntu-latest
+          trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
 
       - name: Output Tarball File Name
         id: staging_tarball_output


### PR DESCRIPTION
Pass the existing PR-build Trivy ignore file to the main build image scan so temporary CVE suppressions are applied consistently.