### PR TITLE
fix(vercel-ai): skip span processor when instrumentation is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(vercel-ai): honor disabled instrumentation settings when registering the span processor
 - fix(agent-observability): suppress invalid instrumentation startup logs
   ([#531](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/531))
 - test(agent-observability): validate the oldest and latest supported LangChain and OpenAI Agents releases,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 ## Unreleased
 
 - fix(vercel-ai): honor disabled instrumentation settings when registering the span processor
+  ([#539](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/539))
 - fix(agent-observability): suppress invalid instrumentation startup logs
   ([#531](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/531))
 - test(agent-observability): validate the oldest and latest supported LangChain and OpenAI Agents releases,

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/instrumentation.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/instrumentation.ts
@@ -67,7 +67,7 @@ export class VercelAIInstrumentation extends InstrumentationBase<VercelAIInstrum
   }
 
   override setTracerProvider(provider: any): void {
-    if (!this._spanProcessorRegistered) {
+    if (this.isEnabled() && !this._spanProcessorRegistered) {
       this._diag.debug('Registering VercelAISpanProcessor');
       const delegate = provider.getDelegate?.() ?? provider;
       const processors = delegate._activeSpanProcessor?._spanProcessors;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/register.test.ts
@@ -300,6 +300,32 @@ describe('Register', function () {
       instr.disable();
       trace.disable();
     });
+
+    it('does not register VercelAISpanProcessor when Vercel AI instrumentation is disabled', () => {
+      const originalDisabledInstrumentations = process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS;
+      process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS = VERCEL_AI_SHORT_NAME;
+
+      const provider = new BasicTracerProvider();
+      const instr = new VercelAIInstrumentation();
+
+      try {
+        assert.equal(instr.isEnabled(), false, 'Vercel AI instrumentation should be disabled');
+        instr.setTracerProvider(provider);
+
+        const processors = (provider as any)._activeSpanProcessor?._spanProcessors ?? [];
+        assert.ok(
+          !processors.some((p: any) => p.constructor.name === 'VercelAISpanProcessor'),
+          'VercelAISpanProcessor should not be registered'
+        );
+      } finally {
+        instr.disable();
+        if (originalDisabledInstrumentations === undefined) {
+          delete process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS;
+        } else {
+          process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS = originalDisabledInstrumentations;
+        }
+      }
+    });
   });
 
   it('Requires without error', () => {


### PR DESCRIPTION
## Summary
- skip `VercelAISpanProcessor` registration when the Vercel AI instrumentation is disabled
- leave explicitly enabled AI SDK telemetry spans untouched in that configuration

Follow-up to #531.

## Testing
- `npm run compile --workspace @aws/aws-distro-opentelemetry-node-autoinstrumentation`
- focused `VercelAISpanProcessor` register tests
- `npm run lint --workspace @aws/aws-distro-opentelemetry-node-autoinstrumentation`