### PR TITLE
Only demote duplicate nested GenAI client spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(agent-observability): only demote duplicate nested GenAI client spans
+  ([#544](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/544))
 - fix(vercel-ai): honor disabled instrumentation settings when registering the span processor
   ([#539](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/539))
 - fix(vercel-ai): normalize ai.prompt input messages and treat declared tools as an agent signal

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -317,12 +317,15 @@ export class AwsOpentelemetryConfigurator {
     const baggageKeys: Set<string> = parseOtelBaggageKeysEnvVar();
 
     if (isAgentObservabilityEnabled()) {
+      // This processor modifies span kind in onEnd, so it must run before exporter
+      // processors to ensure they observe the updated kind.
+      spanProcessors.unshift(new GenAiNestedClientSpanProcessor());
+
       // We always send 100% spans to Bedrock AgentCore platform for agent observability because
       // AI applications typically have low throughput traffic patterns and require
       // comprehensive monitoring to catch subtle failure modes like hallucinations
       // and quality degradation that sampling could miss.
       this.exportUnsampledSpanForAgentObservability(spanProcessors, resource);
-      spanProcessors.push(new GenAiNestedClientSpanProcessor());
 
       // Add session.id baggage attribute to span attributes to support AI Agent use cases
       // enabling session ID tracking in spans.

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -74,7 +74,7 @@ import { LIB_VERSION } from './version';
 import { AWSCloudWatchEMFExporter } from './exporter/aws/metrics/aws-cloudwatch-emf-exporter';
 import { OTLPAwsLogExporter } from './exporter/otlp/aws/logs/otlp-aws-log-exporter';
 import { isAgentObservabilityEnabled, parseOtelBaggageKeysEnvVar } from './utils';
-import { GenAiNestedClientSpanProcessor } from './gen-ai-nested-client-span-processor';
+import { GenAINestedClientSpanProcessor } from './gen-ai-nested-client-span-processor';
 import { BaggageSpanProcessor } from '@opentelemetry/baggage-span-processor';
 import { AWS_ATTRIBUTE_KEYS } from './aws-attribute-keys';
 import { AwsCloudWatchOtlpBatchLogRecordProcessor } from './exporter/otlp/aws/logs/aws-cw-otlp-batch-log-record-processor';
@@ -319,7 +319,7 @@ export class AwsOpentelemetryConfigurator {
     if (isAgentObservabilityEnabled()) {
       // This processor modifies span kind in onEnd, so it must run before exporter
       // processors to ensure they observe the updated kind.
-      spanProcessors.unshift(new GenAiNestedClientSpanProcessor());
+      spanProcessors.unshift(new GenAINestedClientSpanProcessor());
 
       // We always send 100% spans to Bedrock AgentCore platform for agent observability because
       // AI applications typically have low throughput traffic patterns and require

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/gen-ai-nested-client-span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/gen-ai-nested-client-span-processor.ts
@@ -11,53 +11,55 @@ import {
   GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
 } from './instrumentation/common/semconv';
 
-const GEN_AI_INFERENCE_OPERATIONS: Set<string> = new Set([
-  GEN_AI_OPERATION_NAME_VALUE_CHAT,
-  GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
-  GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT,
-  GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS,
-]);
-
-export class GenAiNestedClientSpanProcessor implements SpanProcessor {
+export class GenAINestedClientSpanProcessor implements SpanProcessor {
   // OTel GenAI semantic conventions require outgoing LLM calls to be CLIENT spans.
   // However, the same call can be instrumented by both the agentic framework
   // and the underlying LLM client SDK, producing nested CLIENT spans for a single request.
   // This processor converts the outer span to INTERNAL only when its child has
   // the same GenAI inference operation.
 
-  private _parentSpanIdToGenAiClientChildOperations: Map<string, Set<string>> = new Map();
+  // Tracks which parent spans have a GenAI CLIENT child for each operation.
+  private _parentSpanIdAndOperationToGenAiClientChild: Map<string, boolean> = new Map();
 
   onStart(_span: Span, _parentContext: Context): void {}
 
   onEnd(span: ReadableSpan): void {
+    const genAiInferenceOperations = [
+      GEN_AI_OPERATION_NAME_VALUE_CHAT,
+      GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
+      GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT,
+      GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS,
+    ];
+
     // Clean up before early returns so child state cannot leak for non-GenAI parents.
     const spanId = span.spanContext().spanId;
-    const childOperations = this._parentSpanIdToGenAiClientChildOperations.get(spanId);
-    this._parentSpanIdToGenAiClientChildOperations.delete(spanId);
+    const childOperations = new Set(
+      genAiInferenceOperations.filter(
+        operation => spanId && this._parentSpanIdAndOperationToGenAiClientChild.delete(`${spanId}:${operation}`)
+      )
+    );
 
     if (span.kind !== SpanKind.CLIENT) {
       return;
     }
 
-    const operationName = (span.attributes || {})[ATTR_GEN_AI_OPERATION_NAME] as string | undefined;
-    if (!operationName || !GEN_AI_INFERENCE_OPERATIONS.has(operationName)) {
+    const operation = (span.attributes || {})[ATTR_GEN_AI_OPERATION_NAME] as string | undefined;
+    if (!operation || !genAiInferenceOperations.includes(operation)) {
       return;
     }
 
     const parentSpanId = span.parentSpanContext?.spanId;
     if (parentSpanId) {
-      const operations = this._parentSpanIdToGenAiClientChildOperations.get(parentSpanId) ?? new Set<string>();
-      operations.add(operationName);
-      this._parentSpanIdToGenAiClientChildOperations.set(parentSpanId, operations);
+      this._parentSpanIdAndOperationToGenAiClientChild.set(`${parentSpanId}:${operation}`, true);
     }
 
-    if (childOperations?.has(operationName)) {
+    if (childOperations.has(operation)) {
       (span as any).kind = SpanKind.INTERNAL;
     }
   }
 
   shutdown(): Promise<void> {
-    this._parentSpanIdToGenAiClientChildOperations.clear();
+    this._parentSpanIdAndOperationToGenAiClientChild.clear();
     return Promise.resolve();
   }
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/gen-ai-nested-client-span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/gen-ai-nested-client-span-processor.ts
@@ -11,41 +11,53 @@ import {
   GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
 } from './instrumentation/common/semconv';
 
+const GEN_AI_INFERENCE_OPERATIONS: Set<string> = new Set([
+  GEN_AI_OPERATION_NAME_VALUE_CHAT,
+  GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
+  GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT,
+  GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS,
+]);
+
 export class GenAiNestedClientSpanProcessor implements SpanProcessor {
   // OTel GenAI semantic conventions require outgoing LLM calls to be CLIENT spans.
   // However, the same call can be instrumented by both the agentic framework
   // and the underlying LLM client SDK, producing nested CLIENT spans for a single request.
-  // This processor converts the outer span to INTERNAL so only the innermost
-  // SDK span remains CLIENT, avoiding the nested CLIENT anti-pattern.
+  // This processor converts the outer span to INTERNAL only when its child has
+  // the same GenAI inference operation.
 
-  private _hasGenAiClientChild: Map<string, boolean> = new Map();
+  private _parentSpanIdToGenAiClientChildOperations: Map<string, Set<string>> = new Map();
 
   onStart(_span: Span, _parentContext: Context): void {}
 
   onEnd(span: ReadableSpan): void {
+    // Clean up before early returns so child state cannot leak for non-GenAI parents.
+    const spanId = span.spanContext().spanId;
+    const childOperations = this._parentSpanIdToGenAiClientChildOperations.get(spanId);
+    this._parentSpanIdToGenAiClientChildOperations.delete(spanId);
+
     if (span.kind !== SpanKind.CLIENT) {
+      return;
+    }
+
+    const operationName = (span.attributes || {})[ATTR_GEN_AI_OPERATION_NAME] as string | undefined;
+    if (!operationName || !GEN_AI_INFERENCE_OPERATIONS.has(operationName)) {
       return;
     }
 
     const parentSpanId = span.parentSpanContext?.spanId;
     if (parentSpanId) {
-      this._hasGenAiClientChild.set(parentSpanId, true);
+      const operations = this._parentSpanIdToGenAiClientChildOperations.get(parentSpanId) ?? new Set<string>();
+      operations.add(operationName);
+      this._parentSpanIdToGenAiClientChildOperations.set(parentSpanId, operations);
     }
 
-    const operationName = (span.attributes || {})[ATTR_GEN_AI_OPERATION_NAME] as string | undefined;
-    const isLlmSpan =
-      operationName === GEN_AI_OPERATION_NAME_VALUE_CHAT ||
-      operationName === GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION ||
-      operationName === GEN_AI_OPERATION_NAME_VALUE_GENERATE_CONTENT ||
-      operationName === GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS;
-
-    if (isLlmSpan && span.spanContext() && this._hasGenAiClientChild.delete(span.spanContext().spanId)) {
+    if (childOperations?.has(operationName)) {
       (span as any).kind = SpanKind.INTERNAL;
     }
   }
 
   shutdown(): Promise<void> {
-    this._hasGenAiClientChild.clear();
+    this._parentSpanIdToGenAiClientChildOperations.clear();
     return Promise.resolve();
   }
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -65,6 +65,14 @@ import { TRACE_PARENT_HEADER } from '@opentelemetry/core';
 import { ConsoleEMFExporter } from '../src/exporter/aws/metrics/console-emf-exporter';
 import { GenAiNestedClientSpanProcessor } from '../src/gen-ai-nested-client-span-processor';
 
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
 // Tests AwsOpenTelemetryConfigurator after running Environment Variable setup in register.ts
 describe('AwsOpenTelemetryConfiguratorTest', () => {
   let awsOtelConfigurator: AwsOpentelemetryConfigurator;
@@ -536,6 +544,33 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
 
     // Clean up
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
+  });
+
+  it('registers the GenAI nested client processor before exporter processors', async () => {
+    const previousAgentObservability = process.env.AGENT_OBSERVABILITY_ENABLED;
+    const previousTracesExporter = process.env.OTEL_TRACES_EXPORTER;
+    const previousTracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    const previousBaseEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    let processors: SpanProcessor[] = [];
+
+    try {
+      process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
+      process.env.OTEL_TRACES_EXPORTER = 'otlp';
+      delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+      delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+
+      const config = new AwsOpentelemetryConfigurator([]).configure();
+      processors = config.spanProcessors ?? [];
+
+      expect(processors[0]).toBeInstanceOf(GenAiNestedClientSpanProcessor);
+      expect(processors[1]).toBeInstanceOf(BatchSpanProcessor);
+    } finally {
+      await Promise.all(processors.map(processor => processor.shutdown()));
+      restoreEnv('AGENT_OBSERVABILITY_ENABLED', previousAgentObservability);
+      restoreEnv('OTEL_TRACES_EXPORTER', previousTracesExporter);
+      restoreEnv('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', previousTracesEndpoint);
+      restoreEnv('OTEL_EXPORTER_OTLP_ENDPOINT', previousBaseEndpoint);
+    }
   });
 
   it('BaggageSpanProcessorSessionIdFilteringTest', () => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -63,7 +63,7 @@ import { OTLPAwsSpanExporter } from '../src/exporter/otlp/aws/traces/otlp-aws-sp
 import { AwsCloudWatchOtlpBatchLogRecordProcessor } from '../src/exporter/otlp/aws/logs/aws-cw-otlp-batch-log-record-processor';
 import { TRACE_PARENT_HEADER } from '@opentelemetry/core';
 import { ConsoleEMFExporter } from '../src/exporter/aws/metrics/console-emf-exporter';
-import { GenAiNestedClientSpanProcessor } from '../src/gen-ai-nested-client-span-processor';
+import { GenAINestedClientSpanProcessor } from '../src/gen-ai-nested-client-span-processor';
 
 function restoreEnv(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -517,7 +517,7 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     expect(spanProcessors.length).toEqual(4);
 
     // Verify processors are added in the expected order
-    expect(spanProcessors[0]).toBeInstanceOf(GenAiNestedClientSpanProcessor);
+    expect(spanProcessors[0]).toBeInstanceOf(GenAINestedClientSpanProcessor);
     expect(spanProcessors[1]).toBeInstanceOf(BaggageSpanProcessor);
     expect(spanProcessors[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
     expect(spanProcessors[3]).toBeInstanceOf(AwsSpanMetricsProcessor);
@@ -562,7 +562,7 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
       const config = new AwsOpentelemetryConfigurator([]).configure();
       processors = config.spanProcessors ?? [];
 
-      expect(processors[0]).toBeInstanceOf(GenAiNestedClientSpanProcessor);
+      expect(processors[0]).toBeInstanceOf(GenAINestedClientSpanProcessor);
       expect(processors[1]).toBeInstanceOf(BatchSpanProcessor);
     } finally {
       await Promise.all(processors.map(processor => processor.shutdown()));

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/gen-ai-nested-client-span-processor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/gen-ai-nested-client-span-processor.test.ts
@@ -17,12 +17,14 @@ import {
 describe('TestGenAiNestedClientSpanProcessor', () => {
   let exporter: InMemorySpanExporter;
   let provider: NodeTracerProvider;
+  let processor: GenAiNestedClientSpanProcessor;
   let tracer: ReturnType<NodeTracerProvider['getTracer']>;
 
   beforeEach(() => {
     exporter = new InMemorySpanExporter();
+    processor = new GenAiNestedClientSpanProcessor();
     provider = new NodeTracerProvider({
-      spanProcessors: [new GenAiNestedClientSpanProcessor(), new SimpleSpanProcessor(exporter)],
+      spanProcessors: [processor, new SimpleSpanProcessor(exporter)],
     });
     tracer = provider.getTracer('test');
   });
@@ -56,7 +58,7 @@ describe('TestGenAiNestedClientSpanProcessor', () => {
     expect(parentSpan.kind).toBe(SpanKind.INTERNAL);
   });
 
-  it('should convert parent when HTTP child span exists', () => {
+  it('should keep parent CLIENT when HTTP child span exists', () => {
     const parent = makeLlmSpan();
     const ctx = trace.setSpan(context.active(), parent);
     const child = tracer.startSpan('POST', { kind: SpanKind.CLIENT }, ctx);
@@ -65,7 +67,7 @@ describe('TestGenAiNestedClientSpanProcessor', () => {
 
     const spans = exporter.getFinishedSpans();
     const parentSpan = spans.find(s => s.name === 'chat model')!;
-    expect(parentSpan.kind).toBe(SpanKind.INTERNAL);
+    expect(parentSpan.kind).toBe(SpanKind.CLIENT);
   });
 
   it('should keep CLIENT when no child exists', () => {
@@ -113,6 +115,19 @@ describe('TestGenAiNestedClientSpanProcessor', () => {
     expect(spans[1].kind).toBe(SpanKind.INTERNAL);
   });
 
+  it('should keep parent CLIENT when nested GenAI child has a different operation', () => {
+    const parent = makeLlmSpan();
+    const ctx = trace.setSpan(context.active(), parent);
+    const child = makeLlmSpan('embeddings model', GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS, SpanKind.CLIENT, ctx);
+    child.end();
+    parent.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].kind).toBe(SpanKind.CLIENT);
+    expect(spans[1].kind).toBe(SpanKind.CLIENT);
+    expect((processor as any)._parentSpanIdToGenAiClientChildOperations.size).toBe(0);
+  });
+
   it('should not convert non-LLM operation', () => {
     const span = tracer.startSpan('invoke_agent MyAgent', { kind: SpanKind.CLIENT });
     span.setAttribute(ATTR_GEN_AI_OPERATION_NAME, GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT);
@@ -120,6 +135,20 @@ describe('TestGenAiNestedClientSpanProcessor', () => {
 
     const spans = exporter.getFinishedSpans();
     expect(spans[0].kind).toBe(SpanKind.CLIENT);
+  });
+
+  it('should keep a non-LLM parent CLIENT when it has a nested GenAI child', () => {
+    const parent = tracer.startSpan('invoke_agent MyAgent', { kind: SpanKind.CLIENT });
+    parent.setAttribute(ATTR_GEN_AI_OPERATION_NAME, GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT);
+    const ctx = trace.setSpan(context.active(), parent);
+    const child = makeLlmSpan('chat model', GEN_AI_OPERATION_NAME_VALUE_CHAT, SpanKind.CLIENT, ctx);
+    child.end();
+    parent.end();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].kind).toBe(SpanKind.CLIENT);
+    expect(spans[1].kind).toBe(SpanKind.CLIENT);
+    expect((processor as any)._parentSpanIdToGenAiClientChildOperations.size).toBe(0);
   });
 
   it('should not modify INTERNAL span', () => {
@@ -149,10 +178,13 @@ describe('TestGenAiNestedClientSpanProcessor', () => {
 
   it('should clear state on shutdown', async () => {
     const processor = new GenAiNestedClientSpanProcessor();
-    (processor as any)._hasGenAiClientChild.set('123', true);
-    expect((processor as any)._hasGenAiClientChild.size).toBe(1);
+    (processor as any)._parentSpanIdToGenAiClientChildOperations.set(
+      '123',
+      new Set([GEN_AI_OPERATION_NAME_VALUE_CHAT])
+    );
+    expect((processor as any)._parentSpanIdToGenAiClientChildOperations.size).toBe(1);
     await processor.shutdown();
-    expect((processor as any)._hasGenAiClientChild.size).toBe(0);
+    expect((processor as any)._parentSpanIdToGenAiClientChildOperations.size).toBe(0);
   });
 
   it('should return resolved promise from forceFlush', async () => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/gen-ai-nested-client-span-processor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/gen-ai-nested-client-span-processor.test.ts
@@ -4,7 +4,7 @@
 import { context, SpanKind, trace } from '@opentelemetry/api';
 import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
 import { expect } from 'expect';
-import { GenAiNestedClientSpanProcessor } from '../src/gen-ai-nested-client-span-processor';
+import { GenAINestedClientSpanProcessor } from '../src/gen-ai-nested-client-span-processor';
 import {
   ATTR_GEN_AI_OPERATION_NAME,
   GEN_AI_OPERATION_NAME_VALUE_CHAT,
@@ -14,15 +14,15 @@ import {
   GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION,
 } from '../src/instrumentation/common/semconv';
 
-describe('TestGenAiNestedClientSpanProcessor', () => {
+describe('TestGenAINestedClientSpanProcessor', () => {
   let exporter: InMemorySpanExporter;
   let provider: NodeTracerProvider;
-  let processor: GenAiNestedClientSpanProcessor;
+  let processor: GenAINestedClientSpanProcessor;
   let tracer: ReturnType<NodeTracerProvider['getTracer']>;
 
   beforeEach(() => {
     exporter = new InMemorySpanExporter();
-    processor = new GenAiNestedClientSpanProcessor();
+    processor = new GenAINestedClientSpanProcessor();
     provider = new NodeTracerProvider({
       spanProcessors: [processor, new SimpleSpanProcessor(exporter)],
     });
@@ -125,7 +125,7 @@ describe('TestGenAiNestedClientSpanProcessor', () => {
     const spans = exporter.getFinishedSpans();
     expect(spans[0].kind).toBe(SpanKind.CLIENT);
     expect(spans[1].kind).toBe(SpanKind.CLIENT);
-    expect((processor as any)._parentSpanIdToGenAiClientChildOperations.size).toBe(0);
+    expect((processor as any)._parentSpanIdAndOperationToGenAiClientChild.size).toBe(0);
   });
 
   it('should not convert non-LLM operation', () => {
@@ -148,7 +148,7 @@ describe('TestGenAiNestedClientSpanProcessor', () => {
     const spans = exporter.getFinishedSpans();
     expect(spans[0].kind).toBe(SpanKind.CLIENT);
     expect(spans[1].kind).toBe(SpanKind.CLIENT);
-    expect((processor as any)._parentSpanIdToGenAiClientChildOperations.size).toBe(0);
+    expect((processor as any)._parentSpanIdAndOperationToGenAiClientChild.size).toBe(0);
   });
 
   it('should not modify INTERNAL span', () => {
@@ -177,18 +177,15 @@ describe('TestGenAiNestedClientSpanProcessor', () => {
   });
 
   it('should clear state on shutdown', async () => {
-    const processor = new GenAiNestedClientSpanProcessor();
-    (processor as any)._parentSpanIdToGenAiClientChildOperations.set(
-      '123',
-      new Set([GEN_AI_OPERATION_NAME_VALUE_CHAT])
-    );
-    expect((processor as any)._parentSpanIdToGenAiClientChildOperations.size).toBe(1);
+    const processor = new GenAINestedClientSpanProcessor();
+    (processor as any)._parentSpanIdAndOperationToGenAiClientChild.set(`123:${GEN_AI_OPERATION_NAME_VALUE_CHAT}`, true);
+    expect((processor as any)._parentSpanIdAndOperationToGenAiClientChild.size).toBe(1);
     await processor.shutdown();
-    expect((processor as any)._parentSpanIdToGenAiClientChildOperations.size).toBe(0);
+    expect((processor as any)._parentSpanIdAndOperationToGenAiClientChild.size).toBe(0);
   });
 
   it('should return resolved promise from forceFlush', async () => {
-    const processor = new GenAiNestedClientSpanProcessor();
+    const processor = new GenAINestedClientSpanProcessor();
     await processor.forceFlush();
   });
 });


### PR DESCRIPTION
## Summary

JS equivalent of aws-observability/aws-otel-python-instrumentation#872.

- demote an outer GenAI `CLIENT` span only when it has a nested `CLIENT` span with the same supported GenAI inference operation
- keep outer spans as `CLIENT` for HTTP children, different GenAI operations, and non-GenAI relationships
- register the mutating processor before exporter processors so exporters observe the final span kind

## Behavioral differences

- `CHAT -> CHAT`: outer span becomes `INTERNAL`
- `CHAT -> POST`: outer span remains `CLIENT`
- `CHAT -> EMBEDDINGS`: outer span remains `CLIENT`
- standalone GenAI spans remain `CLIENT`
- matching `GENERATE_CONTENT`, `TEXT_COMPLETION`, and `EMBEDDINGS` spans are deduplicated the same way

## Validation

- `npm run compile`
- targeted ESLint (0 errors)
- focused processor/configurator tests (69 passing)
- full `npm test` (1,801 passing)