### PR TITLE
docs: add Generative AI instrumentation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ Meanwhile, check out the [getting started documentation for manual instrumentati
 
 For the complete list of supported frameworks, please refer to the [OpenTelemetry for JavaScript documentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node#supported-instrumentations).
 
+## Generative AI
+
+Instrumentation is also available for the supported agent frameworks and SDKs
+listed below. These libraries complement the auto-instrumentation already
+included with the distribution, providing comprehensive, end-to-end visibility
+into your agent applications, from incoming requests and framework orchestration
+to model calls, tool invocations, and downstream dependencies.
+
+- [LangChain](aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/README.md) (`@langchain/core >=1.0.0 <2.0.0`)
+- [OpenAI Agents SDK](aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/README.md) (`@openai/agents-core >=0.1.0`)
+- [Vercel AI SDK](aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/README.md) (`ai >=3.3.0 <7.0.0`)
+
+> [!NOTE]
+> Instrumentation is skipped when a conflicting third-party instrumentation is
+> detected for the same framework. Set
+> `AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true` to force the ADOT instrumentation to
+> load.
+
 ## Dynamic Instrumentation
 
 Dynamic Instrumentation lets you capture runtime "snapshots" (local variables and trace context, plus the call stack when `CaptureStackTrace` is enabled in the configuration) from a running application on demand — without redeploying or restarting it. The SDK periodically polls instrumentation configurations from the AWS control plane (proxied through the CloudWatch Agent), applies them at runtime using the V8 Inspector in an isolated worker thread, and emits captured snapshots as OTLP logs.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ to model calls, tool invocations, and downstream dependencies.
 - [Vercel AI SDK](aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/README.md) (`ai >=3.3.0 <7.0.0`)
 
 > [!NOTE]
-> Instrumentation is skipped when a conflicting third-party instrumentation is
+> When agent observability is enabled (`AGENT_OBSERVABILITY_ENABLED=true`),
+> instrumentation is skipped when a conflicting third-party instrumentation is
 > detected for the same framework. Set
 > `AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true` to force the ADOT instrumentation to
 > load.

--- a/README.md
+++ b/README.md
@@ -38,9 +38,14 @@ to model calls, tool invocations, and downstream dependencies.
 > [!NOTE]
 > When agent observability is enabled (`AGENT_OBSERVABILITY_ENABLED=true`),
 > instrumentation is skipped when a conflicting third-party instrumentation is
-> detected for the same framework. Set
-> `AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true` to force the ADOT instrumentation to
-> load.
+> detected for the same framework. You may add `aws_langchain`,
+> `aws_openai_agents`, and `aws_vercel_ai` to
+> `OTEL_NODE_DISABLED_INSTRUMENTATIONS` to disable all of the above
+> instrumentations if you are using another instrumentation source and automatic
+> detection does not work. If another third-party instrumentation is installed,
+> you may set `AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true` to force the above
+> instrumentations to load. We recommend that you do not use this setting because
+> both instrumentations may run and produce duplicate or inconsistent telemetry.
 
 ## Dynamic Instrumentation
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/README.md
@@ -27,9 +27,14 @@ to model calls, tool invocations, and downstream dependencies.
 > [!NOTE]
 > When agent observability is enabled (`AGENT_OBSERVABILITY_ENABLED=true`),
 > instrumentation is skipped when a conflicting third-party instrumentation is
-> detected for the same framework. Set
-> `AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true` to force the ADOT instrumentation to
-> load.
+> detected for the same framework. You may add `aws_langchain`,
+> `aws_openai_agents`, and `aws_vercel_ai` to
+> `OTEL_NODE_DISABLED_INSTRUMENTATIONS` to disable all of the above
+> instrumentations if you are using another instrumentation source and automatic
+> detection does not work. If another third-party instrumentation is installed,
+> you may set `AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true` to force the above
+> instrumentations to load. We recommend that you do not use this setting because
+> both instrumentations may run and produce duplicate or inconsistent telemetry.
 
 ## Sample Environment Variables for Application Signals
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/README.md
@@ -12,6 +12,24 @@ Run your application with ADOT NodeJS with:
 node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' your-application.js
 ```
 
+## Agent Observability
+
+Instrumentation is also available for the supported agent frameworks and SDKs
+listed below. These libraries complement the auto-instrumentation already
+included with the distribution, providing comprehensive, end-to-end visibility
+into your agent applications, from incoming requests and framework orchestration
+to model calls, tool invocations, and downstream dependencies.
+
+- [LangChain](src/instrumentation/instrumentation-langchain/README.md) (`@langchain/core >=1.0.0 <2.0.0`)
+- [OpenAI Agents SDK](src/instrumentation/instrumentation-openai-agents/README.md) (`@openai/agents-core >=0.1.0`)
+- [Vercel AI SDK](src/instrumentation/instrumentation-vercel-ai/README.md) (`ai >=3.3.0 <7.0.0`)
+
+> [!NOTE]
+> Instrumentation is skipped when a conflicting third-party instrumentation is
+> detected for the same framework. Set
+> `AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true` to force the ADOT instrumentation to
+> load.
+
 ## Sample Environment Variables for Application Signals
 
 ```shell

--- a/aws-distro-opentelemetry-node-autoinstrumentation/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/README.md
@@ -12,7 +12,7 @@ Run your application with ADOT NodeJS with:
 node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' your-application.js
 ```
 
-## Agent Observability
+## Generative AI
 
 Instrumentation is also available for the supported agent frameworks and SDKs
 listed below. These libraries complement the auto-instrumentation already

--- a/aws-distro-opentelemetry-node-autoinstrumentation/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/README.md
@@ -25,7 +25,8 @@ to model calls, tool invocations, and downstream dependencies.
 - [Vercel AI SDK](src/instrumentation/instrumentation-vercel-ai/README.md) (`ai >=3.3.0 <7.0.0`)
 
 > [!NOTE]
-> Instrumentation is skipped when a conflicting third-party instrumentation is
+> When agent observability is enabled (`AGENT_OBSERVABILITY_ENABLED=true`),
+> instrumentation is skipped when a conflicting third-party instrumentation is
 > detected for the same framework. Set
 > `AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true` to force the ADOT instrumentation to
 > load.

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/README.md
@@ -1,0 +1,54 @@
+# AWS Distro for OpenTelemetry LangChain instrumentation
+
+This instrumentation traces applications built with LangChain.js and emits
+telemetry that follows OpenTelemetry's Generative AI semantic conventions.
+
+## Features
+
+- Creates spans for chains, agents, model calls, and tools.
+- Records model, token usage, message, tool, and operation attributes when they
+  are available from LangChain callbacks.
+- Supports CommonJS and ECMAScript modules.
+
+## Installation
+
+Install the ADOT Node.js auto-instrumentation package and a supported LangChain
+core version:
+
+```shell
+npm install @aws/aws-distro-opentelemetry-node-autoinstrumentation "@langchain/core@^1"
+```
+
+## Usage
+
+The instrumentation is registered with ADOT Node.js auto-instrumentation and is
+loaded when LangChain is installed:
+
+```shell
+node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' app.js
+```
+
+No application tracing code or LangChain callback registration is required.
+
+## Disable the instrumentation
+
+Add `aws_langchain` to `OTEL_NODE_DISABLED_INSTRUMENTATIONS` before starting the
+application. Include any other disabled instrumentations in the same
+comma-separated value:
+
+```shell
+export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,aws_langchain
+node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' app.js
+```
+
+If `OTEL_NODE_ENABLED_INSTRUMENTATIONS` is set, omitting `aws_langchain` from its
+comma-separated allowlist also disables this instrumentation.
+
+## Supported versions
+
+- `@langchain/core`: `>=1.0.0 <2.0.0`
+
+## References
+
+- [OpenTelemetry generative AI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [LangChain.js documentation](https://docs.langchain.com/oss/javascript/langchain/overview)

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-langchain/README.md
@@ -1,4 +1,4 @@
-# AWS Distro for OpenTelemetry LangChain instrumentation
+# AWS Distro for OpenTelemetry LangChain Instrumentation
 
 This instrumentation traces applications built with LangChain.js and emits
 telemetry that follows OpenTelemetry's Generative AI semantic conventions.

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/README.md
@@ -1,0 +1,55 @@
+# AWS Distro for OpenTelemetry OpenAI Agents instrumentation
+
+This instrumentation traces applications built with the OpenAI Agents SDK for
+JavaScript and emits telemetry that follows OpenTelemetry's Generative AI
+semantic conventions.
+
+## Features
+
+- Creates spans for agents, model generations, tools, guardrails, and handoffs.
+- Records model, token usage, message, tool, and operation attributes when they
+  are available from the Agents SDK.
+- Supports CommonJS and ECMAScript modules.
+
+## Installation
+
+Install the ADOT Node.js auto-instrumentation package and the OpenAI Agents SDK:
+
+```shell
+npm install @aws/aws-distro-opentelemetry-node-autoinstrumentation @openai/agents
+```
+
+## Usage
+
+The instrumentation is registered with ADOT Node.js auto-instrumentation and is
+loaded when the OpenAI Agents SDK is installed:
+
+```shell
+node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' app.js
+```
+
+No application tracing code or Agents SDK trace processor registration is
+required.
+
+## Disable the instrumentation
+
+Add `aws_openai_agents` to `OTEL_NODE_DISABLED_INSTRUMENTATIONS` before starting
+the application. Include any other disabled instrumentations in the same
+comma-separated value:
+
+```shell
+export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,aws_openai_agents
+node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' app.js
+```
+
+If `OTEL_NODE_ENABLED_INSTRUMENTATIONS` is set, omitting `aws_openai_agents` from
+its comma-separated allowlist also disables this instrumentation.
+
+## Supported versions
+
+- `@openai/agents-core`: `>=0.1.0`
+
+## References
+
+- [OpenTelemetry generative AI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [OpenAI Agents SDK for JavaScript](https://openai.github.io/openai-agents-js/)

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-openai-agents/README.md
@@ -1,4 +1,4 @@
-# AWS Distro for OpenTelemetry OpenAI Agents instrumentation
+# AWS Distro for OpenTelemetry OpenAI Agents Instrumentation
 
 This instrumentation traces applications built with the OpenAI Agents SDK for
 JavaScript and emits telemetry that follows OpenTelemetry's Generative AI

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/README.md
@@ -1,4 +1,4 @@
-# AWS Distro for OpenTelemetry Vercel AI SDK instrumentation
+# AWS Distro for OpenTelemetry Vercel AI SDK Instrumentation
 
 This instrumentation traces applications built with the Vercel AI SDK and emits
 telemetry that follows OpenTelemetry's Generative AI semantic conventions.

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/README.md
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/instrumentation/instrumentation-vercel-ai/README.md
@@ -1,0 +1,55 @@
+# AWS Distro for OpenTelemetry Vercel AI SDK instrumentation
+
+This instrumentation traces applications built with the Vercel AI SDK and emits
+telemetry that follows OpenTelemetry's Generative AI semantic conventions.
+
+## Features
+
+- Enables telemetry for `generateText`, `streamText`, `generateObject`, and
+  `streamObject` unless a call explicitly disables it.
+- Translates Vercel AI SDK spans to OpenTelemetry generative AI attributes.
+- Records prompt and response content when content capture is enabled.
+- Supports CommonJS and ECMAScript modules.
+
+## Installation
+
+Install the ADOT Node.js auto-instrumentation package and a supported Vercel AI
+SDK version:
+
+```shell
+npm install @aws/aws-distro-opentelemetry-node-autoinstrumentation "ai@>=3.3.0 <7"
+```
+
+## Usage
+
+The instrumentation is registered with ADOT Node.js auto-instrumentation and is
+loaded when the Vercel AI SDK is installed:
+
+```shell
+node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' app.js
+```
+
+No application tracing code is required.
+
+## Disable the instrumentation
+
+Add `aws_vercel_ai` to `OTEL_NODE_DISABLED_INSTRUMENTATIONS` before starting the
+application. Include any other disabled instrumentations in the same
+comma-separated value:
+
+```shell
+export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,aws_vercel_ai
+node --require '@aws/aws-distro-opentelemetry-node-autoinstrumentation/register' app.js
+```
+
+If `OTEL_NODE_ENABLED_INSTRUMENTATIONS` is set, omitting `aws_vercel_ai` from its
+comma-separated allowlist also disables this instrumentation.
+
+## Supported versions
+
+- `ai`: `>=3.3.0 <7.0.0`
+
+## References
+
+- [OpenTelemetry generative AI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [Vercel AI SDK telemetry documentation](https://ai-sdk.dev/docs/ai-sdk-core/telemetry)


### PR DESCRIPTION
## Summary
- document official Generative AI instrumentation support as of version `0.13.0`
- add README guides for LangChain, OpenAI Agents, and Vercel AI SDK instrumentation
- align the repository and Node auto-instrumentation configuration sections with ADOT Python, using JavaScript-specific defaults and controls
- document agent-observability defaults, `AWS_REDACT_SPAN_ATTRIBUTES`, instrumentation disable settings, and third-party conflict handling

## Validation
- validated supported versions, environment-variable defaults, disable keys, and conflict controls against the implementation
- ran the repository-pinned Markdown linter on all changed READMEs
- rendered both overview READMEs with GitHub’s Markdown API and verified note and warning callouts

Documentation-only change; no changelog entry.