### PR TITLE
add concurrency block according to suggested files by github admin team

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,12 @@ on:
   schedule:
     - cron: '42 4 * * 1'
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+  
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -11,6 +11,12 @@ on:
       - main
       - "release/v*"
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+  
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
Github admin team suggested adding this block to reduce jobs that get queued. Will help with reducing queue times on github actions.

These 2 files were specifically named.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

