### PR TITLE
feat: redact span, span event, and span link attributes via ADOT_REDACT_SPAN_ATTRIBUTES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: redact span, span event, and span link attributes via ADOT_REDACT_SPAN_ATTRIBUTES
+  ([#550](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/550))
 - fix(vercel-ai): map missing AI SDK telemetry to OTel GenAI attributes and output messages
   ([#543](https://github.com/aws-observability/aws-otel-js-instrumentation/pull/543))
 - fix(agent-observability): only demote duplicate nested GenAI client spans

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/attribute-redacting-span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/attribute-redacting-span-processor.ts
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Attributes } from '@opentelemetry/api';
+import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+
+export const ENV_ADOT_REDACT_SPAN_ATTRIBUTES = 'ADOT_REDACT_SPAN_ATTRIBUTES';
+export const REDACTED_VALUE = 'REDACTED';
+
+/**
+ * Redacts configured attributes on completed spans and their events.
+ *
+ * Attribute names can be supplied to the constructor or through the
+ * ADOT_REDACT_SPAN_ATTRIBUTES environment variable as a comma-separated list.
+ * Each entry can be an exact attribute name or contain * wildcards. Matching
+ * attribute values are replaced with REDACTED in place while attribute names
+ * and non-matching values remain unchanged.
+ *
+ * Redact several exact attributes, every attribute beginning with
+ * http.request., and matching GenAI content attributes:
+ *
+ * ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*,gen_ai.*.content
+ *
+ * Redact every span and span event attribute:
+ *
+ * ADOT_REDACT_SPAN_ATTRIBUTES=*
+ */
+export class AttributeRedactingSpanProcessor implements SpanProcessor {
+  public readonly attributesToRedact: string[];
+  private readonly compiledPatterns: RegExp[];
+
+  public constructor(attributesToRedact?: string[]) {
+    this.attributesToRedact =
+      attributesToRedact && attributesToRedact.length > 0
+        ? [...attributesToRedact]
+        : (process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES] ?? '')
+            .split(',')
+            .map(attribute => attribute.trim())
+            .filter(attribute => attribute.length > 0);
+    this.compiledPatterns = this.attributesToRedact.map(attribute => {
+      const pattern = attribute.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+      return new RegExp(`^${pattern}$`);
+    });
+  }
+
+  public onStart(): void {}
+
+  public onEnd(span: ReadableSpan): void {
+    if (this.attributesToRedact.length === 0) {
+      return;
+    }
+
+    this.redactAttributes(span.attributes);
+    span.events.forEach(event => this.redactAttributes(event.attributes));
+  }
+
+  private redactAttributes(attributes?: Attributes): void {
+    if (!attributes) {
+      return;
+    }
+
+    Object.keys(attributes).forEach(attributeName => {
+      if (this.shouldRedact(attributeName)) {
+        attributes[attributeName] = REDACTED_VALUE;
+      }
+    });
+  }
+
+  private shouldRedact(attributeName: string): boolean {
+    return this.compiledPatterns.some(pattern => pattern.test(attributeName));
+  }
+
+  public shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/attribute-redacting-span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/attribute-redacting-span-processor.ts
@@ -5,59 +5,39 @@ import { Attributes } from '@opentelemetry/api';
 import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 export const ENV_ADOT_REDACT_SPAN_ATTRIBUTES = 'ADOT_REDACT_SPAN_ATTRIBUTES';
-export const ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES = 'ADOT_REDACT_SPAN_EVENT_ATTRIBUTES';
 export const REDACTED_VALUE = 'REDACTED';
 
 /**
- * Redacts separately configured attributes on completed spans and span events.
+ * Redacts configured attributes on completed spans, their events, and their links.
  *
- * Span and span event attribute names can be supplied to the constructor or
- * through the ADOT_REDACT_SPAN_ATTRIBUTES and
- * ADOT_REDACT_SPAN_EVENT_ATTRIBUTES environment variables as comma-separated
- * lists. Each entry can be an exact attribute name or contain * wildcards.
- * Matching attribute values are replaced with REDACTED in place while
- * attribute names and non-matching values remain unchanged.
+ * Attribute names can be supplied to the constructor or through the
+ * ADOT_REDACT_SPAN_ATTRIBUTES environment variable as a comma-separated list.
+ * Each entry can be an exact attribute name or contain * wildcards. Matching
+ * attribute values are replaced with REDACTED in place while attribute names
+ * and non-matching values remain unchanged.
  *
- * Redact several exact span attributes and every span attribute beginning with
- * http.request.:
+ * Redact several exact attributes, every attribute beginning with
+ * http.request., and matching GenAI content attributes:
  *
- * ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*
+ * ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*,gen_ai.*.content
  *
- * Redact matching GenAI content attributes from span events:
- *
- * ADOT_REDACT_SPAN_EVENT_ATTRIBUTES=gen_ai.*.content
- *
- * Redact every span attribute and every span event attribute:
+ * Redact every span, span event, and span link attribute:
  *
  * ADOT_REDACT_SPAN_ATTRIBUTES=*
- * ADOT_REDACT_SPAN_EVENT_ATTRIBUTES=*
  */
 export class AttributeRedactingSpanProcessor implements SpanProcessor {
-  public readonly spanAttributesToRedact: string[];
-  public readonly spanEventAttributesToRedact: string[];
-  private readonly compiledSpanAttributePatterns: RegExp[];
-  private readonly compiledSpanEventAttributePatterns: RegExp[];
+  public readonly attributesToRedact: string[];
+  private readonly compiledPatterns: RegExp[];
 
-  public constructor(spanAttributesToRedact?: string[], spanEventAttributesToRedact?: string[]) {
-    this.spanAttributesToRedact =
-      spanAttributesToRedact && spanAttributesToRedact.length > 0
-        ? [...spanAttributesToRedact]
+  public constructor(attributesToRedact?: string[]) {
+    this.attributesToRedact =
+      attributesToRedact && attributesToRedact.length > 0
+        ? [...attributesToRedact]
         : (process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES] ?? '')
             .split(',')
             .map(attribute => attribute.trim())
             .filter(attribute => attribute.length > 0);
-    this.spanEventAttributesToRedact =
-      spanEventAttributesToRedact && spanEventAttributesToRedact.length > 0
-        ? [...spanEventAttributesToRedact]
-        : (process.env[ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES] ?? '')
-            .split(',')
-            .map(attribute => attribute.trim())
-            .filter(attribute => attribute.length > 0);
-    this.compiledSpanAttributePatterns = this.spanAttributesToRedact.map(attribute => {
-      const pattern = attribute.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
-      return new RegExp(`^${pattern}$`);
-    });
-    this.compiledSpanEventAttributePatterns = this.spanEventAttributesToRedact.map(attribute => {
+    this.compiledPatterns = this.attributesToRedact.map(attribute => {
       const pattern = attribute.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
       return new RegExp(`^${pattern}$`);
     });
@@ -66,33 +46,29 @@ export class AttributeRedactingSpanProcessor implements SpanProcessor {
   public onStart(): void {}
 
   public onEnd(span: ReadableSpan): void {
-    if (this.spanAttributesToRedact.length === 0 && this.spanEventAttributesToRedact.length === 0) {
+    if (this.attributesToRedact.length === 0) {
       return;
     }
 
-    if (this.spanAttributesToRedact.length > 0) {
-      this.redactAttributes(span.attributes, this.compiledSpanAttributePatterns);
-    }
-
-    if (this.spanEventAttributesToRedact.length > 0) {
-      span.events.forEach(event => this.redactAttributes(event.attributes, this.compiledSpanEventAttributePatterns));
-    }
+    this.redactAttributes(span.attributes);
+    span.events.forEach(event => this.redactAttributes(event.attributes));
+    span.links.forEach(link => this.redactAttributes(link.attributes));
   }
 
-  private redactAttributes(attributes: Attributes | undefined, compiledPatterns: RegExp[]): void {
+  private redactAttributes(attributes?: Attributes): void {
     if (!attributes) {
       return;
     }
 
     Object.keys(attributes).forEach(attributeName => {
-      if (this.shouldRedact(attributeName, compiledPatterns)) {
+      if (this.shouldRedact(attributeName)) {
         attributes[attributeName] = REDACTED_VALUE;
       }
     });
   }
 
-  private shouldRedact(attributeName: string, compiledPatterns: RegExp[]): boolean {
-    return compiledPatterns.some(pattern => pattern.test(attributeName));
+  private shouldRedact(attributeName: string): boolean {
+    return this.compiledPatterns.some(pattern => pattern.test(attributeName));
   }
 
   public shutdown(): Promise<void> {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/attribute-redacting-span-processor.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/attribute-redacting-span-processor.ts
@@ -5,39 +5,59 @@ import { Attributes } from '@opentelemetry/api';
 import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 export const ENV_ADOT_REDACT_SPAN_ATTRIBUTES = 'ADOT_REDACT_SPAN_ATTRIBUTES';
+export const ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES = 'ADOT_REDACT_SPAN_EVENT_ATTRIBUTES';
 export const REDACTED_VALUE = 'REDACTED';
 
 /**
- * Redacts configured attributes on completed spans and their events.
+ * Redacts separately configured attributes on completed spans and span events.
  *
- * Attribute names can be supplied to the constructor or through the
- * ADOT_REDACT_SPAN_ATTRIBUTES environment variable as a comma-separated list.
- * Each entry can be an exact attribute name or contain * wildcards. Matching
- * attribute values are replaced with REDACTED in place while attribute names
- * and non-matching values remain unchanged.
+ * Span and span event attribute names can be supplied to the constructor or
+ * through the ADOT_REDACT_SPAN_ATTRIBUTES and
+ * ADOT_REDACT_SPAN_EVENT_ATTRIBUTES environment variables as comma-separated
+ * lists. Each entry can be an exact attribute name or contain * wildcards.
+ * Matching attribute values are replaced with REDACTED in place while
+ * attribute names and non-matching values remain unchanged.
  *
- * Redact several exact attributes, every attribute beginning with
- * http.request., and matching GenAI content attributes:
+ * Redact several exact span attributes and every span attribute beginning with
+ * http.request.:
  *
- * ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*,gen_ai.*.content
+ * ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*
  *
- * Redact every span and span event attribute:
+ * Redact matching GenAI content attributes from span events:
+ *
+ * ADOT_REDACT_SPAN_EVENT_ATTRIBUTES=gen_ai.*.content
+ *
+ * Redact every span attribute and every span event attribute:
  *
  * ADOT_REDACT_SPAN_ATTRIBUTES=*
+ * ADOT_REDACT_SPAN_EVENT_ATTRIBUTES=*
  */
 export class AttributeRedactingSpanProcessor implements SpanProcessor {
-  public readonly attributesToRedact: string[];
-  private readonly compiledPatterns: RegExp[];
+  public readonly spanAttributesToRedact: string[];
+  public readonly spanEventAttributesToRedact: string[];
+  private readonly compiledSpanAttributePatterns: RegExp[];
+  private readonly compiledSpanEventAttributePatterns: RegExp[];
 
-  public constructor(attributesToRedact?: string[]) {
-    this.attributesToRedact =
-      attributesToRedact && attributesToRedact.length > 0
-        ? [...attributesToRedact]
+  public constructor(spanAttributesToRedact?: string[], spanEventAttributesToRedact?: string[]) {
+    this.spanAttributesToRedact =
+      spanAttributesToRedact && spanAttributesToRedact.length > 0
+        ? [...spanAttributesToRedact]
         : (process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES] ?? '')
             .split(',')
             .map(attribute => attribute.trim())
             .filter(attribute => attribute.length > 0);
-    this.compiledPatterns = this.attributesToRedact.map(attribute => {
+    this.spanEventAttributesToRedact =
+      spanEventAttributesToRedact && spanEventAttributesToRedact.length > 0
+        ? [...spanEventAttributesToRedact]
+        : (process.env[ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES] ?? '')
+            .split(',')
+            .map(attribute => attribute.trim())
+            .filter(attribute => attribute.length > 0);
+    this.compiledSpanAttributePatterns = this.spanAttributesToRedact.map(attribute => {
+      const pattern = attribute.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+      return new RegExp(`^${pattern}$`);
+    });
+    this.compiledSpanEventAttributePatterns = this.spanEventAttributesToRedact.map(attribute => {
       const pattern = attribute.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
       return new RegExp(`^${pattern}$`);
     });
@@ -46,28 +66,33 @@ export class AttributeRedactingSpanProcessor implements SpanProcessor {
   public onStart(): void {}
 
   public onEnd(span: ReadableSpan): void {
-    if (this.attributesToRedact.length === 0) {
+    if (this.spanAttributesToRedact.length === 0 && this.spanEventAttributesToRedact.length === 0) {
       return;
     }
 
-    this.redactAttributes(span.attributes);
-    span.events.forEach(event => this.redactAttributes(event.attributes));
+    if (this.spanAttributesToRedact.length > 0) {
+      this.redactAttributes(span.attributes, this.compiledSpanAttributePatterns);
+    }
+
+    if (this.spanEventAttributesToRedact.length > 0) {
+      span.events.forEach(event => this.redactAttributes(event.attributes, this.compiledSpanEventAttributePatterns));
+    }
   }
 
-  private redactAttributes(attributes?: Attributes): void {
+  private redactAttributes(attributes: Attributes | undefined, compiledPatterns: RegExp[]): void {
     if (!attributes) {
       return;
     }
 
     Object.keys(attributes).forEach(attributeName => {
-      if (this.shouldRedact(attributeName)) {
+      if (this.shouldRedact(attributeName, compiledPatterns)) {
         attributes[attributeName] = REDACTED_VALUE;
       }
     });
   }
 
-  private shouldRedact(attributeName: string): boolean {
-    return this.compiledPatterns.some(pattern => pattern.test(attributeName));
+  private shouldRedact(attributeName: string, compiledPatterns: RegExp[]): boolean {
+    return compiledPatterns.some(pattern => pattern.test(attributeName));
   }
 
   public shutdown(): Promise<void> {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -63,6 +63,7 @@ import {
 import { SEMRESATTRS_TELEMETRY_AUTO_VERSION } from '@opentelemetry/semantic-conventions';
 import { AlwaysRecordSampler } from './always-record-sampler';
 import { AttributePropagatingSpanProcessorBuilder } from './attribute-propagating-span-processor-builder';
+import { AttributeRedactingSpanProcessor } from './attribute-redacting-span-processor';
 import { AwsBatchUnsampledSpanProcessor } from './aws-batch-unsampled-span-processor';
 import { AwsMetricAttributesSpanExporterBuilder } from './aws-metric-attributes-span-exporter-builder';
 import { AwsSpanMetricsProcessorBuilder } from './aws-span-metrics-processor-builder';
@@ -209,6 +210,11 @@ export class AwsOpentelemetryConfigurator {
     // default SpanProcessors with Span Exporters wrapped inside AwsMetricAttributesSpanExporter
     const awsSpanProcessorProvider: AwsSpanProcessorProvider = new AwsSpanProcessorProvider(this.resource);
     this.spanProcessors = awsSpanProcessorProvider.getSpanProcessors();
+
+    // This processor modifies attributes in onEnd, so it must run before exporter
+    // processors to ensure they observe the redacted values.
+    this.spanProcessors.unshift(new AttributeRedactingSpanProcessor());
+
     this.logRecordProcessors = AwsLoggerProcessorProvider.getlogRecordProcessors();
     AwsOpentelemetryConfigurator.customizeSpanProcessors(this.spanProcessors, this.resource);
 

--- a/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/src/aws-opentelemetry-configurator.ts
@@ -210,11 +210,6 @@ export class AwsOpentelemetryConfigurator {
     // default SpanProcessors with Span Exporters wrapped inside AwsMetricAttributesSpanExporter
     const awsSpanProcessorProvider: AwsSpanProcessorProvider = new AwsSpanProcessorProvider(this.resource);
     this.spanProcessors = awsSpanProcessorProvider.getSpanProcessors();
-
-    // This processor modifies attributes in onEnd, so it must run before exporter
-    // processors to ensure they observe the redacted values.
-    this.spanProcessors.unshift(new AttributeRedactingSpanProcessor());
-
     this.logRecordProcessors = AwsLoggerProcessorProvider.getlogRecordProcessors();
     AwsOpentelemetryConfigurator.customizeSpanProcessors(this.spanProcessors, this.resource);
 
@@ -321,6 +316,10 @@ export class AwsOpentelemetryConfigurator {
 
   static customizeSpanProcessors(spanProcessors: SpanProcessor[], resource: Resource): void {
     const baggageKeys: Set<string> = parseOtelBaggageKeysEnvVar();
+
+    // This processor modifies attributes in onEnd, so it must run before exporter
+    // processors to ensure they observe the redacted values.
+    spanProcessors.unshift(new AttributeRedactingSpanProcessor());
 
     if (isAgentObservabilityEnabled()) {
       // This processor modifies span kind in onEnd, so it must run before exporter

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/attribute-redacting-span-processor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/attribute-redacting-span-processor.test.ts
@@ -1,0 +1,303 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Attributes } from '@opentelemetry/api';
+import { BatchSpanProcessor, InMemorySpanExporter, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import expect from 'expect';
+import {
+  AttributeRedactingSpanProcessor,
+  ENV_ADOT_REDACT_SPAN_ATTRIBUTES,
+  REDACTED_VALUE,
+} from '../src/attribute-redacting-span-processor';
+
+interface RedactionTestData {
+  name: string;
+  environmentValue: string;
+  spanAttributes: Attributes;
+  eventAttributes: Attributes;
+  expectedSpanAttributes: Attributes;
+  expectedEventAttributes: Attributes;
+}
+
+describe('AttributeRedactingSpanProcessorTest', () => {
+  it('should redact all attributes that match configured patterns', async () => {
+    const testCases: RedactionTestData[] = [
+      {
+        name: 'configured attribute names',
+        environmentValue: ' user.email, request.body, db.statement, gen_ai.prompt, user.email ',
+        spanAttributes: {
+          'user.email': 'user@example.com',
+          'request.body': '{"password":"secret"}',
+          'db.statement': 'SELECT * FROM users',
+          'gen_ai.prompt': 'private prompt',
+          'http.request.method': 'POST',
+          'server.address': 'example.com',
+        },
+        eventAttributes: {
+          'user.email': 'event-user@example.com',
+          'db.statement': "UPDATE users SET password = 'secret'",
+          'gen_ai.prompt': 'private event prompt',
+          'event.safe': 'keep me',
+        },
+        expectedSpanAttributes: {
+          'user.email': REDACTED_VALUE,
+          'request.body': REDACTED_VALUE,
+          'db.statement': REDACTED_VALUE,
+          'gen_ai.prompt': REDACTED_VALUE,
+          'http.request.method': 'POST',
+          'server.address': 'example.com',
+        },
+        expectedEventAttributes: {
+          'user.email': REDACTED_VALUE,
+          'db.statement': REDACTED_VALUE,
+          'gen_ai.prompt': REDACTED_VALUE,
+          'event.safe': 'keep me',
+        },
+      },
+      {
+        name: 'wildcard only',
+        environmentValue: '*',
+        spanAttributes: { first: 'secret', second: 42, third: true },
+        eventAttributes: { 'event.first': 'secret', 'event.second': 42 },
+        expectedSpanAttributes: {
+          first: REDACTED_VALUE,
+          second: REDACTED_VALUE,
+          third: REDACTED_VALUE,
+        },
+        expectedEventAttributes: {
+          'event.first': REDACTED_VALUE,
+          'event.second': REDACTED_VALUE,
+        },
+      },
+      {
+        name: 'prefix wildcard',
+        environmentValue: 'http.*',
+        spanAttributes: {
+          'http.request.method': 'GET',
+          'http.response.status_code': 200,
+          'server.address': 'example.com',
+        },
+        eventAttributes: {
+          'http.request.header.authorization': 'secret',
+          'event.safe': 'keep me',
+        },
+        expectedSpanAttributes: {
+          'http.request.method': REDACTED_VALUE,
+          'http.response.status_code': REDACTED_VALUE,
+          'server.address': 'example.com',
+        },
+        expectedEventAttributes: {
+          'http.request.header.authorization': REDACTED_VALUE,
+          'event.safe': 'keep me',
+        },
+      },
+      {
+        name: 'suffix wildcard',
+        environmentValue: '*.body',
+        spanAttributes: {
+          'request.body': 'secret',
+          'response.body': 'secret',
+          'body.size': 42,
+        },
+        eventAttributes: {
+          'message.body': 'secret',
+          'message.body.size': 42,
+        },
+        expectedSpanAttributes: {
+          'request.body': REDACTED_VALUE,
+          'response.body': REDACTED_VALUE,
+          'body.size': 42,
+        },
+        expectedEventAttributes: {
+          'message.body': REDACTED_VALUE,
+          'message.body.size': 42,
+        },
+      },
+      {
+        name: 'multiple wildcard segments',
+        environmentValue: 'gen_ai.*.content',
+        spanAttributes: {
+          'gen_ai.input.content': 'secret input',
+          'gen_ai.output.content': 'secret output',
+          'gen_ai.request.model': 'model',
+        },
+        eventAttributes: {
+          'gen_ai.tool.content': 'secret event',
+          'gen_ai.tool.name': 'lookup',
+        },
+        expectedSpanAttributes: {
+          'gen_ai.input.content': REDACTED_VALUE,
+          'gen_ai.output.content': REDACTED_VALUE,
+          'gen_ai.request.model': 'model',
+        },
+        expectedEventAttributes: {
+          'gen_ai.tool.content': REDACTED_VALUE,
+          'gen_ai.tool.name': 'lookup',
+        },
+      },
+      {
+        name: 'wildcard mixed with explicit names',
+        environmentValue: 'user.email,http.*',
+        spanAttributes: {
+          'user.email': 'user@example.com',
+          'http.route': '/users',
+          safe: 'value',
+        },
+        eventAttributes: {
+          'user.email': 'event-user@example.com',
+          'http.response.body': 'secret',
+          'event.safe': 'keep me',
+        },
+        expectedSpanAttributes: {
+          'user.email': REDACTED_VALUE,
+          'http.route': REDACTED_VALUE,
+          safe: 'value',
+        },
+        expectedEventAttributes: {
+          'user.email': REDACTED_VALUE,
+          'http.response.body': REDACTED_VALUE,
+          'event.safe': 'keep me',
+        },
+      },
+    ];
+
+    for (let index = 0; index < testCases.length; index += 1) {
+      await assertRedaction(testCases[index]);
+    }
+  });
+
+  it('should not redact attributes for invalid configured patterns', async () => {
+    const testCases: RedactionTestData[] = [
+      {
+        name: 'empty configuration',
+        environmentValue: '',
+        spanAttributes: { 'user.email': 'user@example.com' },
+        eventAttributes: { 'user.email': 'event-user@example.com' },
+        expectedSpanAttributes: { 'user.email': 'user@example.com' },
+        expectedEventAttributes: { 'user.email': 'event-user@example.com' },
+      },
+      {
+        name: 'empty comma-separated entries',
+        environmentValue: ' , , ',
+        spanAttributes: { 'request.body': 'secret' },
+        eventAttributes: { 'request.body': 'event secret' },
+        expectedSpanAttributes: { 'request.body': 'secret' },
+        expectedEventAttributes: { 'request.body': 'event secret' },
+      },
+      {
+        name: 'whitespace-only configuration',
+        environmentValue: ' \t ',
+        spanAttributes: { 'db.statement': 'SELECT * FROM users' },
+        eventAttributes: { 'db.statement': 'DELETE FROM users' },
+        expectedSpanAttributes: { 'db.statement': 'SELECT * FROM users' },
+        expectedEventAttributes: { 'db.statement': 'DELETE FROM users' },
+      },
+      {
+        name: 'unsupported regular expression',
+        environmentValue: 'http\\.request\\..+',
+        spanAttributes: { 'http.request.method': 'POST' },
+        eventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanAttributes: { 'http.request.method': 'POST' },
+        expectedEventAttributes: { 'http.request.body': 'secret' },
+      },
+      {
+        name: 'unsupported regular expression anchors',
+        environmentValue: '^user.email$',
+        spanAttributes: { 'user.email': 'user@example.com' },
+        eventAttributes: { 'user.email': 'event-user@example.com' },
+        expectedSpanAttributes: { 'user.email': 'user@example.com' },
+        expectedEventAttributes: { 'user.email': 'event-user@example.com' },
+      },
+      {
+        name: 'unsupported regular expression character class',
+        environmentValue: 'http.request.[a-z]+',
+        spanAttributes: { 'http.request.method': 'POST' },
+        eventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanAttributes: { 'http.request.method': 'POST' },
+        expectedEventAttributes: { 'http.request.body': 'secret' },
+      },
+      {
+        name: 'unsupported regular expression alternation',
+        environmentValue: 'user.email|request.body',
+        spanAttributes: {
+          'user.email': 'user@example.com',
+          'request.body': 'secret',
+        },
+        eventAttributes: {
+          'user.email': 'event-user@example.com',
+          'request.body': 'event secret',
+        },
+        expectedSpanAttributes: {
+          'user.email': 'user@example.com',
+          'request.body': 'secret',
+        },
+        expectedEventAttributes: {
+          'user.email': 'event-user@example.com',
+          'request.body': 'event secret',
+        },
+      },
+      {
+        name: 'unsupported question mark wildcard',
+        environmentValue: 'http.request.?',
+        spanAttributes: { 'http.request.method': 'POST' },
+        eventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanAttributes: { 'http.request.method': 'POST' },
+        expectedEventAttributes: { 'http.request.body': 'secret' },
+      },
+      {
+        name: 'malformed bracket pattern',
+        environmentValue: 'http.request.[',
+        spanAttributes: { 'http.request.method': 'POST' },
+        eventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanAttributes: { 'http.request.method': 'POST' },
+        expectedEventAttributes: { 'http.request.body': 'secret' },
+      },
+      {
+        name: 'attribute name containing comma',
+        environmentValue: 'custom,attribute',
+        spanAttributes: { 'custom,attribute': 'secret' },
+        eventAttributes: { 'custom,attribute': 'event secret' },
+        expectedSpanAttributes: { 'custom,attribute': 'secret' },
+        expectedEventAttributes: { 'custom,attribute': 'event secret' },
+      },
+    ];
+
+    for (let index = 0; index < testCases.length; index += 1) {
+      await assertRedaction(testCases[index]);
+    }
+  });
+});
+
+async function assertRedaction(testData: RedactionTestData): Promise<void> {
+  const previousEnvironmentValue = process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES];
+  const exporter = new InMemorySpanExporter();
+  let provider: NodeTracerProvider | undefined;
+
+  try {
+    process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES] = testData.environmentValue;
+    provider = new NodeTracerProvider({
+      spanProcessors: [new AttributeRedactingSpanProcessor(), new BatchSpanProcessor(exporter)],
+    });
+    const tracer = provider.getTracer('test');
+    const span = tracer.startSpan('test', {
+      attributes: testData.spanAttributes,
+    });
+    span.addEvent('test.event', testData.eventAttributes);
+    span.end();
+
+    await provider.forceFlush();
+    const finishedSpans = exporter.getFinishedSpans();
+    expect(finishedSpans).toHaveLength(1);
+    expect(finishedSpans[0].attributes).toEqual(testData.expectedSpanAttributes);
+    expect(finishedSpans[0].events).toHaveLength(1);
+    expect(finishedSpans[0].events[0].name).toBe('test.event');
+    expect(finishedSpans[0].events[0].attributes).toEqual(testData.expectedEventAttributes);
+  } finally {
+    await provider?.shutdown();
+    if (previousEnvironmentValue === undefined) {
+      delete process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES];
+    } else {
+      process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES] = previousEnvironmentValue;
+    }
+  }
+}

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/attribute-redacting-span-processor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/attribute-redacting-span-processor.test.ts
@@ -6,13 +6,14 @@ import { BatchSpanProcessor, InMemorySpanExporter, NodeTracerProvider } from '@o
 import expect from 'expect';
 import {
   AttributeRedactingSpanProcessor,
+  ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES,
   ENV_ADOT_REDACT_SPAN_ATTRIBUTES,
   REDACTED_VALUE,
 } from '../src/attribute-redacting-span-processor';
 
 interface RedactionTestData {
   name: string;
-  environmentValue: string;
+  environmentVariables: Record<string, string>;
   spanAttributes: Attributes;
   eventAttributes: Attributes;
   expectedSpanAttributes: Attributes;
@@ -23,13 +24,17 @@ describe('AttributeRedactingSpanProcessorTest', () => {
   it('should redact all attributes that match configured patterns', async () => {
     const testCases: RedactionTestData[] = [
       {
-        name: 'configured attribute names',
-        environmentValue: ' user.email, request.body, db.statement, gen_ai.prompt, user.email ',
+        name: 'independent configured attribute names',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: ' user.email, request.body, db.statement, gen_ai.prompt, user.email ',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: ' db.statement, event.secret ',
+        },
         spanAttributes: {
           'user.email': 'user@example.com',
           'request.body': '{"password":"secret"}',
           'db.statement': 'SELECT * FROM users',
           'gen_ai.prompt': 'private prompt',
+          'event.secret': 'span value',
           'http.request.method': 'POST',
           'server.address': 'example.com',
         },
@@ -37,6 +42,7 @@ describe('AttributeRedactingSpanProcessorTest', () => {
           'user.email': 'event-user@example.com',
           'db.statement': "UPDATE users SET password = 'secret'",
           'gen_ai.prompt': 'private event prompt',
+          'event.secret': 'event value',
           'event.safe': 'keep me',
         },
         expectedSpanAttributes: {
@@ -44,19 +50,24 @@ describe('AttributeRedactingSpanProcessorTest', () => {
           'request.body': REDACTED_VALUE,
           'db.statement': REDACTED_VALUE,
           'gen_ai.prompt': REDACTED_VALUE,
+          'event.secret': 'span value',
           'http.request.method': 'POST',
           'server.address': 'example.com',
         },
         expectedEventAttributes: {
-          'user.email': REDACTED_VALUE,
+          'user.email': 'event-user@example.com',
           'db.statement': REDACTED_VALUE,
-          'gen_ai.prompt': REDACTED_VALUE,
+          'gen_ai.prompt': 'private event prompt',
+          'event.secret': REDACTED_VALUE,
           'event.safe': 'keep me',
         },
       },
       {
         name: 'wildcard only',
-        environmentValue: '*',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: '*',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: '*',
+        },
         spanAttributes: { first: 'secret', second: 42, third: true },
         eventAttributes: { 'event.first': 'secret', 'event.second': 42 },
         expectedSpanAttributes: {
@@ -71,7 +82,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'prefix wildcard',
-        environmentValue: 'http.*',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http.*',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http.*',
+        },
         spanAttributes: {
           'http.request.method': 'GET',
           'http.response.status_code': 200,
@@ -93,7 +107,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'suffix wildcard',
-        environmentValue: '*.body',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: '*.body',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: '*.body',
+        },
         spanAttributes: {
           'request.body': 'secret',
           'response.body': 'secret',
@@ -115,7 +132,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'multiple wildcard segments',
-        environmentValue: 'gen_ai.*.content',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'gen_ai.*.content',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'gen_ai.*.content',
+        },
         spanAttributes: {
           'gen_ai.input.content': 'secret input',
           'gen_ai.output.content': 'secret output',
@@ -137,7 +157,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'wildcard mixed with explicit names',
-        environmentValue: 'user.email,http.*',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'user.email,http.*',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'user.email,http.*',
+        },
         spanAttributes: {
           'user.email': 'user@example.com',
           'http.route': '/users',
@@ -170,7 +193,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
     const testCases: RedactionTestData[] = [
       {
         name: 'empty configuration',
-        environmentValue: '',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: '',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: '',
+        },
         spanAttributes: { 'user.email': 'user@example.com' },
         eventAttributes: { 'user.email': 'event-user@example.com' },
         expectedSpanAttributes: { 'user.email': 'user@example.com' },
@@ -178,7 +204,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'empty comma-separated entries',
-        environmentValue: ' , , ',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: ' , , ',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: ' , , ',
+        },
         spanAttributes: { 'request.body': 'secret' },
         eventAttributes: { 'request.body': 'event secret' },
         expectedSpanAttributes: { 'request.body': 'secret' },
@@ -186,7 +215,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'whitespace-only configuration',
-        environmentValue: ' \t ',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: ' \t ',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: ' \t ',
+        },
         spanAttributes: { 'db.statement': 'SELECT * FROM users' },
         eventAttributes: { 'db.statement': 'DELETE FROM users' },
         expectedSpanAttributes: { 'db.statement': 'SELECT * FROM users' },
@@ -194,7 +226,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'unsupported regular expression',
-        environmentValue: 'http\\.request\\..+',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http\\.request\\..+',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http\\.request\\..+',
+        },
         spanAttributes: { 'http.request.method': 'POST' },
         eventAttributes: { 'http.request.body': 'secret' },
         expectedSpanAttributes: { 'http.request.method': 'POST' },
@@ -202,7 +237,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'unsupported regular expression anchors',
-        environmentValue: '^user.email$',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: '^user.email$',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: '^user.email$',
+        },
         spanAttributes: { 'user.email': 'user@example.com' },
         eventAttributes: { 'user.email': 'event-user@example.com' },
         expectedSpanAttributes: { 'user.email': 'user@example.com' },
@@ -210,7 +248,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'unsupported regular expression character class',
-        environmentValue: 'http.request.[a-z]+',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http.request.[a-z]+',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http.request.[a-z]+',
+        },
         spanAttributes: { 'http.request.method': 'POST' },
         eventAttributes: { 'http.request.body': 'secret' },
         expectedSpanAttributes: { 'http.request.method': 'POST' },
@@ -218,7 +259,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'unsupported regular expression alternation',
-        environmentValue: 'user.email|request.body',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'user.email|request.body',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'user.email|request.body',
+        },
         spanAttributes: {
           'user.email': 'user@example.com',
           'request.body': 'secret',
@@ -238,7 +282,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'unsupported question mark wildcard',
-        environmentValue: 'http.request.?',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http.request.?',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http.request.?',
+        },
         spanAttributes: { 'http.request.method': 'POST' },
         eventAttributes: { 'http.request.body': 'secret' },
         expectedSpanAttributes: { 'http.request.method': 'POST' },
@@ -246,7 +293,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'malformed bracket pattern',
-        environmentValue: 'http.request.[',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http.request.[',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http.request.[',
+        },
         spanAttributes: { 'http.request.method': 'POST' },
         eventAttributes: { 'http.request.body': 'secret' },
         expectedSpanAttributes: { 'http.request.method': 'POST' },
@@ -254,7 +304,10 @@ describe('AttributeRedactingSpanProcessorTest', () => {
       },
       {
         name: 'attribute name containing comma',
-        environmentValue: 'custom,attribute',
+        environmentVariables: {
+          [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'custom,attribute',
+          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'custom,attribute',
+        },
         spanAttributes: { 'custom,attribute': 'secret' },
         eventAttributes: { 'custom,attribute': 'event secret' },
         expectedSpanAttributes: { 'custom,attribute': 'secret' },
@@ -269,12 +322,15 @@ describe('AttributeRedactingSpanProcessorTest', () => {
 });
 
 async function assertRedaction(testData: RedactionTestData): Promise<void> {
-  const previousEnvironmentValue = process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES];
+  const previousEnvironmentVariables: NodeJS.ProcessEnv = {};
+  Object.keys(testData.environmentVariables).forEach(environmentVariable => {
+    previousEnvironmentVariables[environmentVariable] = process.env[environmentVariable];
+  });
   const exporter = new InMemorySpanExporter();
   let provider: NodeTracerProvider | undefined;
 
   try {
-    process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES] = testData.environmentValue;
+    Object.assign(process.env, testData.environmentVariables);
     provider = new NodeTracerProvider({
       spanProcessors: [new AttributeRedactingSpanProcessor(), new BatchSpanProcessor(exporter)],
     });
@@ -294,10 +350,12 @@ async function assertRedaction(testData: RedactionTestData): Promise<void> {
     expect(finishedSpans[0].events[0].attributes).toEqual(testData.expectedEventAttributes);
   } finally {
     await provider?.shutdown();
-    if (previousEnvironmentValue === undefined) {
-      delete process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES];
-    } else {
-      process.env[ENV_ADOT_REDACT_SPAN_ATTRIBUTES] = previousEnvironmentValue;
-    }
+    Object.entries(previousEnvironmentVariables).forEach(([environmentVariable, previousValue]) => {
+      if (previousValue === undefined) {
+        delete process.env[environmentVariable];
+      } else {
+        process.env[environmentVariable] = previousValue;
+      }
+    });
   }
 }

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/attribute-redacting-span-processor.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/attribute-redacting-span-processor.test.ts
@@ -1,12 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Attributes } from '@opentelemetry/api';
+import { Attributes, TraceFlags } from '@opentelemetry/api';
 import { BatchSpanProcessor, InMemorySpanExporter, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import expect from 'expect';
 import {
   AttributeRedactingSpanProcessor,
-  ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES,
   ENV_ADOT_REDACT_SPAN_ATTRIBUTES,
   REDACTED_VALUE,
 } from '../src/attribute-redacting-span-processor';
@@ -15,171 +14,219 @@ interface RedactionTestData {
   name: string;
   environmentVariables: Record<string, string>;
   spanAttributes: Attributes;
-  eventAttributes: Attributes;
+  spanEventAttributes: Attributes;
+  spanLinkAttributes: Attributes;
   expectedSpanAttributes: Attributes;
-  expectedEventAttributes: Attributes;
+  expectedSpanEventAttributes: Attributes;
+  expectedSpanLinkAttributes: Attributes;
 }
 
 describe('AttributeRedactingSpanProcessorTest', () => {
   it('should redact all attributes that match configured patterns', async () => {
     const testCases: RedactionTestData[] = [
       {
-        name: 'independent configured attribute names',
+        name: 'configured attribute names',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: ' user.email, request.body, db.statement, gen_ai.prompt, user.email ',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: ' db.statement, event.secret ',
         },
         spanAttributes: {
           'user.email': 'user@example.com',
           'request.body': '{"password":"secret"}',
           'db.statement': 'SELECT * FROM users',
           'gen_ai.prompt': 'private prompt',
-          'event.secret': 'span value',
           'http.request.method': 'POST',
           'server.address': 'example.com',
         },
-        eventAttributes: {
+        spanEventAttributes: {
           'user.email': 'event-user@example.com',
           'db.statement': "UPDATE users SET password = 'secret'",
           'gen_ai.prompt': 'private event prompt',
-          'event.secret': 'event value',
           'event.safe': 'keep me',
+        },
+        spanLinkAttributes: {
+          'user.email': 'link-user@example.com',
+          'request.body': '{"link_password":"secret"}',
+          'db.statement': 'SELECT * FROM linked_users',
+          'gen_ai.prompt': 'private link prompt',
+          'http.request.method': 'POST',
+          'server.address': 'linked.example.com',
         },
         expectedSpanAttributes: {
           'user.email': REDACTED_VALUE,
           'request.body': REDACTED_VALUE,
           'db.statement': REDACTED_VALUE,
           'gen_ai.prompt': REDACTED_VALUE,
-          'event.secret': 'span value',
           'http.request.method': 'POST',
           'server.address': 'example.com',
         },
-        expectedEventAttributes: {
-          'user.email': 'event-user@example.com',
+        expectedSpanEventAttributes: {
+          'user.email': REDACTED_VALUE,
           'db.statement': REDACTED_VALUE,
-          'gen_ai.prompt': 'private event prompt',
-          'event.secret': REDACTED_VALUE,
+          'gen_ai.prompt': REDACTED_VALUE,
           'event.safe': 'keep me',
+        },
+        expectedSpanLinkAttributes: {
+          'user.email': REDACTED_VALUE,
+          'request.body': REDACTED_VALUE,
+          'db.statement': REDACTED_VALUE,
+          'gen_ai.prompt': REDACTED_VALUE,
+          'http.request.method': 'POST',
+          'server.address': 'linked.example.com',
         },
       },
       {
         name: 'wildcard only',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: '*',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: '*',
         },
         spanAttributes: { first: 'secret', second: 42, third: true },
-        eventAttributes: { 'event.first': 'secret', 'event.second': 42 },
+        spanEventAttributes: { 'event.first': 'secret', 'event.second': 42 },
+        spanLinkAttributes: { 'link.first': 'secret', 'link.second': 42, 'link.third': true },
         expectedSpanAttributes: {
           first: REDACTED_VALUE,
           second: REDACTED_VALUE,
           third: REDACTED_VALUE,
         },
-        expectedEventAttributes: {
+        expectedSpanEventAttributes: {
           'event.first': REDACTED_VALUE,
           'event.second': REDACTED_VALUE,
+        },
+        expectedSpanLinkAttributes: {
+          'link.first': REDACTED_VALUE,
+          'link.second': REDACTED_VALUE,
+          'link.third': REDACTED_VALUE,
         },
       },
       {
         name: 'prefix wildcard',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http.*',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http.*',
         },
         spanAttributes: {
           'http.request.method': 'GET',
           'http.response.status_code': 200,
           'server.address': 'example.com',
         },
-        eventAttributes: {
+        spanEventAttributes: {
           'http.request.header.authorization': 'secret',
           'event.safe': 'keep me',
+        },
+        spanLinkAttributes: {
+          'http.link.header.authorization': 'secret',
+          'link.safe': 'keep me',
         },
         expectedSpanAttributes: {
           'http.request.method': REDACTED_VALUE,
           'http.response.status_code': REDACTED_VALUE,
           'server.address': 'example.com',
         },
-        expectedEventAttributes: {
+        expectedSpanEventAttributes: {
           'http.request.header.authorization': REDACTED_VALUE,
           'event.safe': 'keep me',
+        },
+        expectedSpanLinkAttributes: {
+          'http.link.header.authorization': REDACTED_VALUE,
+          'link.safe': 'keep me',
         },
       },
       {
         name: 'suffix wildcard',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: '*.body',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: '*.body',
         },
         spanAttributes: {
           'request.body': 'secret',
           'response.body': 'secret',
           'body.size': 42,
         },
-        eventAttributes: {
+        spanEventAttributes: {
           'message.body': 'secret',
           'message.body.size': 42,
+        },
+        spanLinkAttributes: {
+          'link.body': 'secret',
+          'link.body.size': 42,
         },
         expectedSpanAttributes: {
           'request.body': REDACTED_VALUE,
           'response.body': REDACTED_VALUE,
           'body.size': 42,
         },
-        expectedEventAttributes: {
+        expectedSpanEventAttributes: {
           'message.body': REDACTED_VALUE,
           'message.body.size': 42,
+        },
+        expectedSpanLinkAttributes: {
+          'link.body': REDACTED_VALUE,
+          'link.body.size': 42,
         },
       },
       {
         name: 'multiple wildcard segments',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'gen_ai.*.content',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'gen_ai.*.content',
         },
         spanAttributes: {
           'gen_ai.input.content': 'secret input',
           'gen_ai.output.content': 'secret output',
           'gen_ai.request.model': 'model',
         },
-        eventAttributes: {
+        spanEventAttributes: {
           'gen_ai.tool.content': 'secret event',
           'gen_ai.tool.name': 'lookup',
+        },
+        spanLinkAttributes: {
+          'gen_ai.link.content': 'secret link',
+          'gen_ai.link.name': 'lookup',
         },
         expectedSpanAttributes: {
           'gen_ai.input.content': REDACTED_VALUE,
           'gen_ai.output.content': REDACTED_VALUE,
           'gen_ai.request.model': 'model',
         },
-        expectedEventAttributes: {
+        expectedSpanEventAttributes: {
           'gen_ai.tool.content': REDACTED_VALUE,
           'gen_ai.tool.name': 'lookup',
+        },
+        expectedSpanLinkAttributes: {
+          'gen_ai.link.content': REDACTED_VALUE,
+          'gen_ai.link.name': 'lookup',
         },
       },
       {
         name: 'wildcard mixed with explicit names',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'user.email,http.*',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'user.email,http.*',
         },
         spanAttributes: {
           'user.email': 'user@example.com',
           'http.route': '/users',
           safe: 'value',
         },
-        eventAttributes: {
+        spanEventAttributes: {
           'user.email': 'event-user@example.com',
           'http.response.body': 'secret',
           'event.safe': 'keep me',
+        },
+        spanLinkAttributes: {
+          'user.email': 'link-user@example.com',
+          'http.link': 'secret',
+          'link.safe': 'keep me',
         },
         expectedSpanAttributes: {
           'user.email': REDACTED_VALUE,
           'http.route': REDACTED_VALUE,
           safe: 'value',
         },
-        expectedEventAttributes: {
+        expectedSpanEventAttributes: {
           'user.email': REDACTED_VALUE,
           'http.response.body': REDACTED_VALUE,
           'event.safe': 'keep me',
+        },
+        expectedSpanLinkAttributes: {
+          'user.email': REDACTED_VALUE,
+          'http.link': REDACTED_VALUE,
+          'link.safe': 'keep me',
         },
       },
     ];
@@ -195,123 +242,139 @@ describe('AttributeRedactingSpanProcessorTest', () => {
         name: 'empty configuration',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: '',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: '',
         },
         spanAttributes: { 'user.email': 'user@example.com' },
-        eventAttributes: { 'user.email': 'event-user@example.com' },
+        spanEventAttributes: { 'user.email': 'event-user@example.com' },
+        spanLinkAttributes: { 'user.email': 'link-user@example.com' },
         expectedSpanAttributes: { 'user.email': 'user@example.com' },
-        expectedEventAttributes: { 'user.email': 'event-user@example.com' },
+        expectedSpanEventAttributes: { 'user.email': 'event-user@example.com' },
+        expectedSpanLinkAttributes: { 'user.email': 'link-user@example.com' },
       },
       {
         name: 'empty comma-separated entries',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: ' , , ',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: ' , , ',
         },
         spanAttributes: { 'request.body': 'secret' },
-        eventAttributes: { 'request.body': 'event secret' },
+        spanEventAttributes: { 'request.body': 'event secret' },
+        spanLinkAttributes: { 'request.body': 'link secret' },
         expectedSpanAttributes: { 'request.body': 'secret' },
-        expectedEventAttributes: { 'request.body': 'event secret' },
+        expectedSpanEventAttributes: { 'request.body': 'event secret' },
+        expectedSpanLinkAttributes: { 'request.body': 'link secret' },
       },
       {
         name: 'whitespace-only configuration',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: ' \t ',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: ' \t ',
         },
         spanAttributes: { 'db.statement': 'SELECT * FROM users' },
-        eventAttributes: { 'db.statement': 'DELETE FROM users' },
+        spanEventAttributes: { 'db.statement': 'DELETE FROM users' },
+        spanLinkAttributes: { 'db.statement': 'SELECT * FROM linked_users' },
         expectedSpanAttributes: { 'db.statement': 'SELECT * FROM users' },
-        expectedEventAttributes: { 'db.statement': 'DELETE FROM users' },
+        expectedSpanEventAttributes: { 'db.statement': 'DELETE FROM users' },
+        expectedSpanLinkAttributes: { 'db.statement': 'SELECT * FROM linked_users' },
       },
       {
         name: 'unsupported regular expression',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http\\.request\\..+',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http\\.request\\..+',
         },
         spanAttributes: { 'http.request.method': 'POST' },
-        eventAttributes: { 'http.request.body': 'secret' },
+        spanEventAttributes: { 'http.request.body': 'secret' },
+        spanLinkAttributes: { 'http.request.header': 'secret' },
         expectedSpanAttributes: { 'http.request.method': 'POST' },
-        expectedEventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanEventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanLinkAttributes: { 'http.request.header': 'secret' },
       },
       {
         name: 'unsupported regular expression anchors',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: '^user.email$',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: '^user.email$',
         },
         spanAttributes: { 'user.email': 'user@example.com' },
-        eventAttributes: { 'user.email': 'event-user@example.com' },
+        spanEventAttributes: { 'user.email': 'event-user@example.com' },
+        spanLinkAttributes: { 'user.email': 'link-user@example.com' },
         expectedSpanAttributes: { 'user.email': 'user@example.com' },
-        expectedEventAttributes: { 'user.email': 'event-user@example.com' },
+        expectedSpanEventAttributes: { 'user.email': 'event-user@example.com' },
+        expectedSpanLinkAttributes: { 'user.email': 'link-user@example.com' },
       },
       {
         name: 'unsupported regular expression character class',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http.request.[a-z]+',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http.request.[a-z]+',
         },
         spanAttributes: { 'http.request.method': 'POST' },
-        eventAttributes: { 'http.request.body': 'secret' },
+        spanEventAttributes: { 'http.request.body': 'secret' },
+        spanLinkAttributes: { 'http.request.header': 'secret' },
         expectedSpanAttributes: { 'http.request.method': 'POST' },
-        expectedEventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanEventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanLinkAttributes: { 'http.request.header': 'secret' },
       },
       {
         name: 'unsupported regular expression alternation',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'user.email|request.body',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'user.email|request.body',
         },
         spanAttributes: {
           'user.email': 'user@example.com',
           'request.body': 'secret',
         },
-        eventAttributes: {
+        spanEventAttributes: {
           'user.email': 'event-user@example.com',
           'request.body': 'event secret',
+        },
+        spanLinkAttributes: {
+          'user.email': 'link-user@example.com',
+          'request.body': 'link secret',
         },
         expectedSpanAttributes: {
           'user.email': 'user@example.com',
           'request.body': 'secret',
         },
-        expectedEventAttributes: {
+        expectedSpanEventAttributes: {
           'user.email': 'event-user@example.com',
           'request.body': 'event secret',
+        },
+        expectedSpanLinkAttributes: {
+          'user.email': 'link-user@example.com',
+          'request.body': 'link secret',
         },
       },
       {
         name: 'unsupported question mark wildcard',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http.request.?',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http.request.?',
         },
         spanAttributes: { 'http.request.method': 'POST' },
-        eventAttributes: { 'http.request.body': 'secret' },
+        spanEventAttributes: { 'http.request.body': 'secret' },
+        spanLinkAttributes: { 'http.request.header': 'secret' },
         expectedSpanAttributes: { 'http.request.method': 'POST' },
-        expectedEventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanEventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanLinkAttributes: { 'http.request.header': 'secret' },
       },
       {
         name: 'malformed bracket pattern',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'http.request.[',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'http.request.[',
         },
         spanAttributes: { 'http.request.method': 'POST' },
-        eventAttributes: { 'http.request.body': 'secret' },
+        spanEventAttributes: { 'http.request.body': 'secret' },
+        spanLinkAttributes: { 'http.request.header': 'secret' },
         expectedSpanAttributes: { 'http.request.method': 'POST' },
-        expectedEventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanEventAttributes: { 'http.request.body': 'secret' },
+        expectedSpanLinkAttributes: { 'http.request.header': 'secret' },
       },
       {
         name: 'attribute name containing comma',
         environmentVariables: {
           [ENV_ADOT_REDACT_SPAN_ATTRIBUTES]: 'custom,attribute',
-          [ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES]: 'custom,attribute',
         },
         spanAttributes: { 'custom,attribute': 'secret' },
-        eventAttributes: { 'custom,attribute': 'event secret' },
+        spanEventAttributes: { 'custom,attribute': 'event secret' },
+        spanLinkAttributes: { 'custom,attribute': 'link secret' },
         expectedSpanAttributes: { 'custom,attribute': 'secret' },
-        expectedEventAttributes: { 'custom,attribute': 'event secret' },
+        expectedSpanEventAttributes: { 'custom,attribute': 'event secret' },
+        expectedSpanLinkAttributes: { 'custom,attribute': 'link secret' },
       },
     ];
 
@@ -337,17 +400,30 @@ async function assertRedaction(testData: RedactionTestData): Promise<void> {
     const tracer = provider.getTracer('test');
     const span = tracer.startSpan('test', {
       attributes: testData.spanAttributes,
+      links: [
+        {
+          context: {
+            traceId: '00000000000000000000000000000001',
+            spanId: '0000000000000001',
+            traceFlags: TraceFlags.SAMPLED,
+            isRemote: true,
+          },
+          attributes: testData.spanLinkAttributes,
+        },
+      ],
     });
-    span.addEvent('test.event', testData.eventAttributes);
+    span.addEvent('test.event', testData.spanEventAttributes);
     span.end();
 
     await provider.forceFlush();
     const finishedSpans = exporter.getFinishedSpans();
     expect(finishedSpans).toHaveLength(1);
     expect(finishedSpans[0].attributes).toEqual(testData.expectedSpanAttributes);
+    expect(finishedSpans[0].links).toHaveLength(1);
+    expect(finishedSpans[0].links[0].attributes).toEqual(testData.expectedSpanLinkAttributes);
     expect(finishedSpans[0].events).toHaveLength(1);
     expect(finishedSpans[0].events[0].name).toBe('test.event');
-    expect(finishedSpans[0].events[0].attributes).toEqual(testData.expectedEventAttributes);
+    expect(finishedSpans[0].events[0].attributes).toEqual(testData.expectedSpanEventAttributes);
   } finally {
     await provider?.shutdown();
     Object.entries(previousEnvironmentVariables).forEach(([environmentVariable, previousValue]) => {

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -30,6 +30,7 @@ import * as sinon from 'sinon';
 import * as opentelemetry from '@opentelemetry/sdk-node';
 import { AlwaysRecordSampler } from '../src/always-record-sampler';
 import { AttributePropagatingSpanProcessor } from '../src/attribute-propagating-span-processor';
+import { AttributeRedactingSpanProcessor } from '../src/attribute-redacting-span-processor';
 import { AwsBatchUnsampledSpanProcessor } from '../src/aws-batch-unsampled-span-processor';
 import { AwsMetricAttributesSpanExporter } from '../src/aws-metric-attributes-span-exporter';
 import {
@@ -546,7 +547,7 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
   });
 
-  it('registers the GenAI nested client processor before exporter processors', async () => {
+  it('registers the GenAI and attribute redacting processors before exporter processors', async () => {
     const previousAgentObservability = process.env.AGENT_OBSERVABILITY_ENABLED;
     const previousTracesExporter = process.env.OTEL_TRACES_EXPORTER;
     const previousTracesEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
@@ -563,7 +564,8 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
       processors = config.spanProcessors ?? [];
 
       expect(processors[0]).toBeInstanceOf(GenAINestedClientSpanProcessor);
-      expect(processors[1]).toBeInstanceOf(BatchSpanProcessor);
+      expect(processors[1]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+      expect(processors[2]).toBeInstanceOf(BatchSpanProcessor);
     } finally {
       await Promise.all(processors.map(processor => processor.shutdown()));
       restoreEnv('AGENT_OBSERVABILITY_ENABLED', previousAgentObservability);
@@ -834,11 +836,12 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     process.env.AWS_XRAY_DAEMON_ADDRESS = 'www.test.com:2222';
 
     const config = new AwsOpentelemetryConfigurator([]).configure();
-    expect((config.spanProcessors as any)[0]).toBeInstanceOf(BatchSpanProcessor);
-    expect((config.spanProcessors as any)[0]._exporter).toBeInstanceOf(OTLPUdpSpanExporter);
-    expect((config.spanProcessors as any)[0]._exporter._endpoint).toBe('www.test.com:2222');
-    expect((config.spanProcessors as any)[1]).toBeInstanceOf(BaggageSpanProcessor);
-    expect(config.spanProcessors?.length).toEqual(2);
+    expect((config.spanProcessors as any)[0]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+    expect((config.spanProcessors as any)[1]).toBeInstanceOf(BatchSpanProcessor);
+    expect((config.spanProcessors as any)[1]._exporter).toBeInstanceOf(OTLPUdpSpanExporter);
+    expect((config.spanProcessors as any)[1]._exporter._endpoint).toBe('www.test.com:2222');
+    expect((config.spanProcessors as any)[2]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(config.spanProcessors?.length).toEqual(3);
 
     delete process.env.AWS_LAMBDA_FUNCTION_NAME;
     delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;
@@ -937,27 +940,30 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     // Default scenario where no trace exporter is specified
     process.env.OTEL_TRACES_EXPORTER = 'none';
     config = new AwsOpentelemetryConfigurator([]).configure();
-    expect((config.spanProcessors as any)[0]).toBeInstanceOf(BaggageSpanProcessor);
-    expect((config.spanProcessors as any)[1]).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    expect((config.spanProcessors as any)[2]).toBeInstanceOf(AwsSpanMetricsProcessor);
-    expect(config.spanProcessors?.length).toEqual(3);
-
-    // Scenario where otlp trace exporter is specified, adds one more exporter compared to default case
-    process.env.OTEL_TRACES_EXPORTER = 'otlp';
-    config = new AwsOpentelemetryConfigurator([]).configure();
-    expect((config.spanProcessors as any)[0]._exporter.delegate).toBeInstanceOf(OTLPProtoTraceExporter);
+    expect((config.spanProcessors as any)[0]).toBeInstanceOf(AttributeRedactingSpanProcessor);
     expect((config.spanProcessors as any)[1]).toBeInstanceOf(BaggageSpanProcessor);
     expect((config.spanProcessors as any)[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
     expect((config.spanProcessors as any)[3]).toBeInstanceOf(AwsSpanMetricsProcessor);
     expect(config.spanProcessors?.length).toEqual(4);
 
+    // Scenario where otlp trace exporter is specified, adds one more exporter compared to default case
+    process.env.OTEL_TRACES_EXPORTER = 'otlp';
+    config = new AwsOpentelemetryConfigurator([]).configure();
+    expect((config.spanProcessors as any)[0]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+    expect((config.spanProcessors as any)[1]._exporter.delegate).toBeInstanceOf(OTLPProtoTraceExporter);
+    expect((config.spanProcessors as any)[2]).toBeInstanceOf(BaggageSpanProcessor);
+    expect((config.spanProcessors as any)[3]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect((config.spanProcessors as any)[4]).toBeInstanceOf(AwsSpanMetricsProcessor);
+    expect(config.spanProcessors?.length).toEqual(5);
+
     // Specify invalid exporter, same result as default scenario where no trace exporter is specified
     process.env.OTEL_TRACES_EXPORTER = 'invalid_exporter_name';
     config = new AwsOpentelemetryConfigurator([]).configure();
-    expect((config.spanProcessors as any)[0]).toBeInstanceOf(BaggageSpanProcessor);
-    expect((config.spanProcessors as any)[1]).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    expect((config.spanProcessors as any)[2]).toBeInstanceOf(AwsSpanMetricsProcessor);
-    expect(config.spanProcessors?.length).toEqual(3);
+    expect((config.spanProcessors as any)[0]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+    expect((config.spanProcessors as any)[1]).toBeInstanceOf(BaggageSpanProcessor);
+    expect((config.spanProcessors as any)[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect((config.spanProcessors as any)[3]).toBeInstanceOf(AwsSpanMetricsProcessor);
+    expect(config.spanProcessors?.length).toEqual(4);
 
     // Cleanup
     delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;

--- a/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
+++ b/aws-distro-opentelemetry-node-autoinstrumentation/test/aws-opentelemetry-configurator.test.ts
@@ -475,16 +475,19 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     // Test application signals only
     let spanProcessors: SpanProcessor[] = [];
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, emptyResource());
-    expect(spanProcessors.length).toEqual(1);
-    expect(spanProcessors[0]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(spanProcessors.length).toEqual(2);
+    expect(spanProcessors[0]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+    expect(spanProcessors[1]).toBeInstanceOf(BaggageSpanProcessor);
 
     process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED = 'True';
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, emptyResource());
-    expect(spanProcessors.length).toEqual(4);
-    expect(spanProcessors[0]).toBeInstanceOf(BaggageSpanProcessor);
-    expect(spanProcessors[1]).toBeInstanceOf(BaggageSpanProcessor);
-    expect(spanProcessors[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    expect(spanProcessors[3]).toBeInstanceOf(AwsSpanMetricsProcessor);
+    expect(spanProcessors.length).toEqual(6);
+    expect(spanProcessors[0]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+    expect(spanProcessors[1]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+    expect(spanProcessors[2]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(spanProcessors[3]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(spanProcessors[4]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect(spanProcessors[5]).toBeInstanceOf(AwsSpanMetricsProcessor);
     delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;
 
     try {
@@ -515,13 +518,14 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     process.env.AGENT_OBSERVABILITY_ENABLED = 'true';
     process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED = 'True';
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, emptyResource());
-    expect(spanProcessors.length).toEqual(4);
+    expect(spanProcessors.length).toEqual(5);
 
     // Verify processors are added in the expected order
     expect(spanProcessors[0]).toBeInstanceOf(GenAINestedClientSpanProcessor);
-    expect(spanProcessors[1]).toBeInstanceOf(BaggageSpanProcessor);
-    expect(spanProcessors[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    expect(spanProcessors[3]).toBeInstanceOf(AwsSpanMetricsProcessor);
+    expect(spanProcessors[1]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+    expect(spanProcessors[2]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(spanProcessors[3]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect(spanProcessors[4]).toBeInstanceOf(AwsSpanMetricsProcessor);
 
     // shut down exporters for test cleanup
     spanProcessors.forEach(spanProcessor => {
@@ -534,13 +538,13 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
   it('CustomizeSpanProcessorsWithAgentObservabilityTest', () => {
     const spanProcessorsToTest: SpanProcessor[] = [];
 
-    // Test that only BaggageSpanProcessor is added when agent observability is disabled
+    // Test that redaction and baggage processors are added when agent observability is disabled
     delete process.env.AGENT_OBSERVABILITY_ENABLED;
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessorsToTest, emptyResource());
-    expect(spanProcessorsToTest.length).toEqual(1);
+    expect(spanProcessorsToTest.length).toEqual(2);
 
-    // Verify the added processor is BaggageSpanProcessor
-    const addedProcessor = spanProcessorsToTest[0];
+    expect(spanProcessorsToTest[0]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+    const addedProcessor = spanProcessorsToTest[1];
     expect(addedProcessor).toBeInstanceOf(BaggageSpanProcessor);
 
     // Clean up
@@ -854,10 +858,11 @@ describe('AwsOpenTelemetryConfiguratorTest', () => {
     process.env.AWS_LAMBDA_FUNCTION_NAME = 'TestFunction';
     const spanProcessors: SpanProcessor[] = [];
     AwsOpentelemetryConfigurator.customizeSpanProcessors(spanProcessors, emptyResource());
-    expect(spanProcessors.length).toEqual(3);
-    expect(spanProcessors[0]).toBeInstanceOf(BaggageSpanProcessor);
-    expect(spanProcessors[1]).toBeInstanceOf(AttributePropagatingSpanProcessor);
-    expect(spanProcessors[2]).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
+    expect(spanProcessors.length).toEqual(4);
+    expect(spanProcessors[0]).toBeInstanceOf(AttributeRedactingSpanProcessor);
+    expect(spanProcessors[1]).toBeInstanceOf(BaggageSpanProcessor);
+    expect(spanProcessors[2]).toBeInstanceOf(AttributePropagatingSpanProcessor);
+    expect(spanProcessors[3]).toBeInstanceOf(AwsBatchUnsampledSpanProcessor);
     delete process.env.OTEL_AWS_APPLICATION_SIGNALS_ENABLED;
     delete process.env.AWS_LAMBDA_FUNCTION_NAME;
   });


### PR DESCRIPTION
## Summary

- add an AttributeRedactingSpanProcessor for configured span, span event, and span link attributes
- support exact attribute names and * wildcard patterns through ADOT_REDACT_SPAN_ATTRIBUTES
- register the processor before exporter processors so exporters observe redacted values
- provide the Node.js counterpart to https://github.com/aws-observability/aws-otel-python-instrumentation/pull/886

## Testing

- 2 focused attribute redaction tests passed
- 5 configurator ordering tests passed
- Prettier and ESLint passed
- changed files passed TypeScript compilation