### PR TITLE
chore: extend PR Trivy CVE suppressions through 2026-10-01

### DIFF
--- a/.github/trivy/pr-build.trivyignore.yaml
+++ b/.github/trivy/pr-build.trivyignore.yaml
@@ -11,28 +11,28 @@
 vulnerabilities:
   - id: CVE-2026-33036
     statement: "fast-xml-parser numeric entity expansion DoS. Low risk for ADOT JS: XML parsing only occurs on trusted AWS API responses, not user-supplied input. Fix in PR #369, will ship with next scheduled release. Ticket: V2145663734"
-    expired_at: 2026-09-06
+    expired_at: 2026-10-01
 
   - id: CVE-2026-44665
     statement: "fast-xml-builder attribute value quote bypass. Low risk for ADOT JS: XML building only occurs for trusted AWS API request payloads, not user-supplied input. Fix available in 1.1.7."
-    expired_at: 2026-09-06
+    expired_at: 2026-10-01
 
   - id: CVE-2026-44902
     statement: "Prometheus exporter process crash via malformed HTTP request. Will be fixed in #425 and released in next scheduled release."
-    expired_at: 2026-09-06
+    expired_at: 2026-10-01
 
   - id: CVE-2026-59892
     statement: "@opentelemetry/propagator-jaeger DoS via malformed HTTP header decoding. Fix: bump to 2.9.0. https://avd.aquasec.com/nvd/cve-2026-59892"
-    expired_at: 2026-09-06
+    expired_at: 2026-10-01
 
   - id: CVE-2026-14257
     statement: "brace-expansion <=5.0.7 DoS via memory exhaustion in expand() (result count is bounded but per-result string length is not). Only exploitable if attacker-influenced strings reach expand() via minimatch/glob brace patterns. In ADOT JS, glob/minimatch inputs are build/config-time patterns, not user-supplied runtime input, so not exploitable in the agent runtime. Fix: bump to 5.0.8 (adds maxLength bound). https://avd.aquasec.com/nvd/cve-2026-14257"
-    expired_at: 2026-09-06
+    expired_at: 2026-10-01
 
   - id: CVE-2026-69152
     statement: "brace-expansion DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. Temporary suppression pending dependency update. Fix: bump to 2.1.4 or 5.0.9. https://avd.aquasec.com/nvd/cve-2026-69152"
-    expired_at: 2026-09-06
+    expired_at: 2026-10-01
 
   - id: CVE-2026-59877
     statement: "protobufjs DoS via crafted .proto schema. Temporary suppression pending dependency update. Fix: bump to 7.6.5. https://avd.aquasec.com/nvd/cve-2026-59877"
-    expired_at: 2026-09-06
+    expired_at: 2026-10-01


### PR DESCRIPTION
## Summary

- extend existing PR build Trivy CVE suppressions through October 1, 2026, the first business day of October
- leave the suppressed CVE set and rationale unchanged
- do not change daily scan suppressions

## Validation

- parsed the Trivy ignore file as YAML and verified all seven expiry dates
- ran `git diff --check`